### PR TITLE
Tweak Icon Block so the resizable handles display properly 

### DIFF
--- a/src/blocks/icon/components/edit.js
+++ b/src/blocks/icon/components/edit.js
@@ -74,6 +74,7 @@ class Edit extends Component {
 			width,
 			borderRadius,
 			padding,
+			hasContentAlign,
 		} = attributes;
 
 		const classes = classnames( 'wp-block-coblocks-icon__inner', {
@@ -126,6 +127,14 @@ class Edit extends Component {
 				showRightHandle = true;
 			}
 		}
+
+		// If the parent block has set this block to not display alignment controls.
+		// then we set them to true and hide them via CSS.
+		if ( hasContentAlign === false ) {
+			showRightHandle = true;
+			showLeftHandle = true;
+		}
+
 		return [
 			<Fragment>
 				{ isSelected && (

--- a/src/blocks/icon/styles/editor.scss
+++ b/src/blocks/icon/styles/editor.scss
@@ -130,6 +130,25 @@
 	}
 }
 
+//Add styling for resizableBox handles when a parent div is positioning the icon.
+.has-center-content .wp-block-coblocks-icon__inner.is-selected {
+	.components-resizable-box__handle-left,
+	.components-resizable-box__handle-right {
+		display: block !important;
+	}
+}
+
+.has-right-content .wp-block-coblocks-icon__inner.is-selected {
+
+	.components-resizable-box__handle-left {
+		display: block !important;
+	}
+
+	.components-resizable-box__handle-right {
+		display: none !important;
+	}
+}
+
 // Editor style preview.
 .editor-block-preview,
 .editor-block-styles__item-preview {


### PR DESCRIPTION
When contentAlign is not in use, but controlled from a parent block.