### PR TITLE
[tiny] Remove unnecessary backgroundColor style #513

### DIFF
--- a/src/extensions/typography/apply-style.js
+++ b/src/extensions/typography/apply-style.js
@@ -25,10 +25,6 @@ function applyStyle( attributes, name ) {
 		style.color = attributes.customTextColor || null;
 	}
 
-	if ( typeof attributes.customBackgroundColor !== 'undefined' ) {
-		style.backgroundColor = attributes.customBackgroundColor || null;
-	}
-
 	if ( name == 'coblocks/column' && typeof attributes.width !== 'undefined' ) {
 		style.width = attributes.width + '%';
 	}


### PR DESCRIPTION
Resolves #513 by removing the unnecessary `customBackgroundColor` attribute being applied to the core Button block wrapper.