### PR TITLE
Add percentage based background-size to supplement existing options

### DIFF
--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -10,7 +10,7 @@ import './styles/style.scss';
 import './styles/editor.scss';
 import icons from './components/icons';
 import Edit from './components/edit';
-import { BackgroundAttributes, BackgroundClasses, BackgroundVideo } from '../../components/background';
+import { BackgroundStyles, BackgroundAttributes, BackgroundClasses, BackgroundVideo } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import CSSGridAttributes from '../../components/grid-control/attributes';
 import ResponsiveBaseControlAttributes from '../../components/responsive-base-control/attributes';
@@ -135,16 +135,11 @@ const settings = {
 				layout,
 				fullscreen,
 				maxWidth,
-				backgroundImg,
-				backgroundType,
 				paddingSize,
 				backgroundColor,
-				customBackgroundColor,
 				customTextColor,
 				textColor,
 				contentAlign,
-				focalPoint,
-				hasParallax,
 				videoMuted,
 				videoLoop,
 				height,
@@ -178,10 +173,8 @@ const settings = {
 			} );
 
 			const innerStyles = {
-				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-				backgroundImage: backgroundImg && backgroundType == 'image' ? `url(${ backgroundImg })` : undefined,
+				...BackgroundStyles( attributes ),
 				color: textColor ? textColor.color : undefined,
-				backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
 				minHeight: fullscreen ? undefined : height,
 			};
 

--- a/src/blocks/row/components/edit.js
+++ b/src/blocks/row/components/edit.js
@@ -13,7 +13,7 @@ import Controls from './controls';
 import applyWithColors from './colors';
 import rowIcons from './icons';
 import { title } from '../';
-import { BackgroundClasses, BackgroundDropZone, BackgroundVideo } from '../../../components/background';
+import { BackgroundStyles, BackgroundClasses, BackgroundDropZone, BackgroundVideo } from '../../../components/background';
 
 /**
  * WordPress dependencies
@@ -159,9 +159,6 @@ class Edit extends Component {
 			marginSize,
 			paddingSize,
 			isStackedOnMobile,
-			focalPoint,
-			hasParallax,
-			backgroundType,
 		} = attributes;
 
 		const dropZone = (
@@ -290,9 +287,8 @@ class Edit extends Component {
 		);
 
 		const innerStyles = {
+			...BackgroundStyles( attributes ),
 			backgroundColor: backgroundColor.color,
-			backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
-			backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
 			color: textColor.color,
 			paddingTop: paddingSize === 'advanced' && paddingTop ? paddingTop + paddingUnit : undefined,
 			paddingRight: paddingSize === 'advanced' && paddingRight ? paddingRight + paddingUnit : undefined,

--- a/src/blocks/row/components/save.js
+++ b/src/blocks/row/components/save.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { BackgroundClasses, BackgroundVideo } from '../../../components/background';
+import { BackgroundStyles, BackgroundClasses, BackgroundVideo } from '../../../components/background';
 
 const { getColorClassName, InnerBlocks } = wp.editor;
 
@@ -7,9 +7,7 @@ function Save( { attributes } ) {
 	const {
 		coblocks,
 		backgroundColor,
-		backgroundImg,
 		columns,
-		customBackgroundColor,
 		customTextColor,
 		gutter,
 		id,
@@ -18,13 +16,9 @@ function Save( { attributes } ) {
 		marginSize,
 		paddingSize,
 		textColor,
-		focalPoint,
-		hasParallax,
-		backgroundType,
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
-	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
 	const classes = classnames( {
 		[ `coblocks-row--${ id }` ]: id,
@@ -45,9 +39,7 @@ function Save( { attributes } ) {
 		} );
 
 	const innerStyles = {
-		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-		backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
-		backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
+		...BackgroundStyles( attributes ),
 		color: textClass ? undefined : customTextColor,
 	};
 

--- a/src/components/background/attributes.js
+++ b/src/components/background/attributes.js
@@ -21,6 +21,10 @@ const BackgroundAttributes = {
 	backgroundSize: {
 		type: 'string',
 	},
+	backgroundSizePercent: {
+		type: 'number',
+		default: 100,
+	},
 	backgroundOverlay: {
 		type: 'number',
 		default: 0,

--- a/src/components/background/controls.js
+++ b/src/components/background/controls.js
@@ -68,6 +68,7 @@ function BackgroundControls( props, options ) {
 										backgroundRepeat: 'no-repeat',
 										backgroundPosition: '',
 										backgroundSize: 'cover',
+										backgroundSizePercent: '',
 										hasParallax: false,
 										openPopover: ! openPopover,
 									} );

--- a/src/components/background/panel.js
+++ b/src/components/background/panel.js
@@ -109,6 +109,7 @@ class BackgroundPanel extends Component {
 			{ value: 'auto', label: __( 'Auto' ) },
 			{ value: 'cover', label: __( 'Cover' ) },
 			{ value: 'contain', label: __( 'Contain' ) },
+			{ value: 'percent', label: __( 'Custom' ) },
 		];
 
 		const overlayStyleOptions = [
@@ -200,6 +201,16 @@ class BackgroundPanel extends Component {
 								value={ backgroundSize ? backgroundSize : backgroundSizeDefault }
 								options={ backgroundSizeOptions }
 								onChange={ ( nextbackgroundSize ) => setAttributes( { backgroundSize: nextbackgroundSize } ) }
+							/>
+						) }
+						{ backgroundSize == 'percent' && backgroundType == 'image' && (
+							<RangeControl
+								label={ __( 'Custom Size' ) }
+								value={ backgroundSizePercent }
+								onChange={ ( nextBackgroundSizePercent ) => setAttributes( { backgroundSizePercent: nextBackgroundSizePercent } ) }
+								min={ 0 }
+								max={ 100 }
+								step={ 1 }
 							/>
 						) }
 						{ backgroundType == 'video' && (

--- a/src/components/background/panel.js
+++ b/src/components/background/panel.js
@@ -78,6 +78,7 @@ class BackgroundPanel extends Component {
 			backgroundRadius,
 			backgroundRepeat,
 			backgroundSize,
+			backgroundSizePercent,
 			backgroundType = 'image',
 			focalPoint,
 			hasParallax,

--- a/src/components/background/styles.js
+++ b/src/components/background/styles.js
@@ -6,14 +6,15 @@ const { getColorClassName } = wp.editor;
 /**
  * Background Classes
  */
-function BackgroundStyles( attributes ) {
+function BackgroundStyles( { backgroundImg, backgroundType, backgroundColor, customBackgroundColor, focalPoint, hasParallax, backgroundSize, backgroundSizePercent } ) {
 
-	const backgroundClass = getColorClassName( 'background-color', attributes.backgroundColor );
+	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
 	const styles = {
-		backgroundImage: attributes.backgroundImg && attributes.backgroundType == 'image' ? `url(${ attributes.backgroundImg })` : undefined,
-		backgroundColor: backgroundClass ? undefined : attributes.customBackgroundColor,
-		backgroundPosition:  attributes.focalPoint && !  attributes.hasParallax ? `${  attributes.focalPoint.x * 100 }% ${  attributes.focalPoint.y * 100 }%` : undefined,
+		backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
+		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+		backgroundPosition: backgroundImg && focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
+		backgroundSize: backgroundImg && ['auto', 'cover', 'contain'].indexOf(backgroundSize) === -1 && ( backgroundSizePercent || backgroundSizePercent === 0 ) ? `${ backgroundSizePercent }%` : undefined,
 	};
 
 	return styles;


### PR DESCRIPTION
Currently, block backgrounds support either `auto`, `contain`, or `cover` background sizes.  I have a template which needs to explicitly set a percentage-based value, so I've added an inspector panel control and utilized an inline style when not specifying any of the keywords.

Looking for feedback on this one, as I'm not too familiar with the way WordPress diffs block markup.  I updated `Row`'s 'save' and 'edit' components to match the way other components spread BackgroundStyles as it looked to me like an oversight, but I suspect that doing this may break existing blocks.