### PR TITLE
Fix undefined Google Maps var

### DIFF
--- a/src/js/coblocks-google-maps.js
+++ b/src/js/coblocks-google-maps.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/*global google baAtts*/
+/*global google coblocksGoogleMaps*/
 
 const coblocksMap = {
 	init: function() {


### PR DESCRIPTION
Resolves #784 

Renames `baAtts` to `coblocksGoogleMaps ` to resolve a regression introduced in https://github.com/godaddy/coblocks/pull/561 (https://github.com/godaddy/coblocks/commit/85074606e42d03cb8cee04bb6cea8d0db234571c#diff-2aba29c7658cd16b1e138a45bc686114R75)

Hoping to get this into the 1.12.1 release 🤞 