### PR TITLE
Add CONTRIBUTORS.md to celebrate our contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,27 @@
+# Contributors
+
+CoBlocks is built by many contributors and volunteers. Thanks to all of them for their work!
+
+This list is manually curated to include valuable contributions by volunteers that do not include code, such as user testing, providing feedback, or mockups. Please edit this list to include new contributors as they come in. There is no particular order to this list. If you or someone else was omitted from this list, we assure you that was not intentional. Please let us know and we'll add you.
+
+| GitHub Username | WordPress.org Username |
+| --------------- | ---------------------- |
+| @richtabor      | @richtabor             |
+| @phpbits        | @phpbits               |
+| @anthonyledesma | @paranoia1906          |
+| @jrtashjian     | @jrtashjian            |
+| @evanherman     | @eherman24             |
+| @fjarrett       | @fjarrett              |
+| @jonathanbardo  | @jonathanbardo         |
+| @zrgisa         |                        |
+| @kwight         | @kwight                |
+| @westonruter    | @westonruter           |
+| @nicolad        | @vadimnicolai          |
+| @ramiy          | @ramiy                 |
+| @seb86          | @sebd86                |
+| @jesstech       |                        |
+| @grabovacnem    |                        |
+| @mahdiyazdani   | @mahdiyazdani          |
+| @broken8        | @adomenico             |
+| @andreilupu     | @euthelup              |
+| @alexdenning    | @alexdenning           |


### PR DESCRIPTION
In the spirit of supporting contributors and raising awareness of CoBlocks community contributions (#1126), I've created a CONTRIBUTORS.md file (based off of what Gutenberg uses - [link](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTORS.md)).

Currently it's based off of our [Contributors Graph](https://github.com/godaddy-wordpress/coblocks/graphs/contributors), though I'd like to include contributors who may not have committed code - but languages, mockups, meaningful feedback, etc as well.