### PR TITLE
Remove minimum height limitation on the Carousel block

### DIFF
--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -273,7 +273,7 @@ class GalleryCarouselEdit extends Component {
 						'is-selected': isSelected,
 						'has-responsive-height': responsiveHeight,
 					} ) }
-					minHeight="200"
+					minHeight="0"
 					enable={ {
 						bottom: true,
 						bottomLeft: false,

--- a/src/blocks/gallery-carousel/inspector.js
+++ b/src/blocks/gallery-carousel/inspector.js
@@ -13,8 +13,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls, InspectorAdvancedControls } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl, BaseControl } from '@wordpress/components';
 
-const carouselMin = 0;
-
 /**
  * Inspector controls
  */
@@ -119,16 +117,16 @@ class Inspector extends Component {
 										const inputValue = unprocessedValue !== '' ?
 											parseInt( event.target.value, 10 ) :
 											undefined;
-										if ( ( inputValue < carouselMin ) && inputValue !== undefined ) {
+										if ( ( inputValue < 0 ) && inputValue !== undefined ) {
 											this.setTemporayInput( inputValue );
-											this.setHeightTo( carouselMin );
+											this.setHeightTo( 0 );
 											return;
 										}
 										this.setTemporayInput( null );
 										this.setHeightTo( inputValue );
 									} }
 									value={ temporaryInput || height }
-									min={ carouselMin }
+									min={ 0 }
 									step="10"
 								/>
 							</BaseControl>

--- a/src/blocks/gallery-carousel/inspector.js
+++ b/src/blocks/gallery-carousel/inspector.js
@@ -13,7 +13,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls, InspectorAdvancedControls } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl, BaseControl } from '@wordpress/components';
 
-const carouselMin = 200;
+const carouselMin = 0;
 
 /**
  * Inspector controls


### PR DESCRIPTION
The Carousel block currently has a minimum height restriction to 200px. This PR will lower the minimum height to 0px which would accommodate images with a height smaller than 200px. 

**Inspired with WordPress.org support request**
https://wordpress.org/support/topic/carousel-block-200px-height-limitation/