### PR TITLE
Add keyboard shortcuts for navigating images in a lightbox

### DIFF
--- a/src/components/block-gallery/styles/style/_lightbox.scss
+++ b/src/components/block-gallery/styles/style/_lightbox.scss
@@ -152,7 +152,7 @@
 	}
 }
 
-.has-lightbox {
+.has-lightbox > :not(.carousel-nav) {
 	figure:hover {
 		cursor: zoom-in;
 	}

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -80,10 +80,16 @@
 					case 27 : // Esc key
 						close.trigger( 'click' );
 						break;
-					case 37 : // Arrow left
+					case 37 : // Arrow left or 'A' key.
 						arrowLeftContainer.trigger( 'click' );
 						break;
-					case 39 : // Arrow left
+					case 65 : // 'A' key.
+						arrowLeftContainer.trigger( 'click' );
+						break;
+					case 39 : // Arrow right.
+						arrowRightContainer.trigger( 'click' );
+						break;
+					case 68 : // 'D' key.
 						arrowRightContainer.trigger( 'click' );
 						break;
 				}

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -22,7 +22,7 @@
 		const arrowRight = $( '<div/>', { class: 'arrow-right' } );
 		const arrowLeft = $( '<div/>', { class: 'arrow-left' } );
 
-		const images = $( `.has-lightbox.lightbox-${ lightboxIndex } figure img` );
+		const images = $( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure img` );
 		let index;
 
 		modalHeading.append( counter, close );

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -71,5 +71,23 @@
 			image.attr( 'src', imagePreloader[ `img-${ index }` ].src );
 			counter.html( ( index + 1 ) + ' / ' + images.length );
 		}
+
+		$( window ).keydown( function( event ) {
+			const lightboxDisplayValue = wrapper.css( 'display' );
+			const lightboxIsOpen = ( typeof lightboxDisplayValue !== typeof undefined && lightboxDisplayValue !== 'none' );
+			if ( lightboxIsOpen ) {
+				switch ( event.which ) {
+					case 27 : // Esc key
+						close.trigger( 'click' );
+						break;
+					case 37 : // Arrow left
+						arrowLeftContainer.trigger( 'click' );
+						break;
+					case 39 : // Arrow left
+						arrowRightContainer.trigger( 'click' );
+						break;
+				}
+			}
+		} );
 	}
 }( jQuery ) );


### PR DESCRIPTION
Closes #1155
Tested and compatible with Chrome, FireFox, Edge, Safari, and Opera.

Exit lightbox with `Esc` key. 
Scroll left in Lightbox with `Left arrow` or `A` key. 
Scroll right in Lightbox with `Right arrow` or `D` key.

