### PR TITLE
Cleanup CoBlocks options from database on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 }
 
-$options = array(
+$coblocks_options = array(
 	'coblocks_settings_api',
 	'coblocks_plugin_feedback_activation_date',
 	'coblocks_date_installed',
@@ -19,8 +19,8 @@ $options = array(
 	'coblocks_plugin_feedback_no_bug',
 );
 
-foreach ( $options as $option ) {
+foreach ( $coblocks_options as $coblocks_option ) {
 
-	delete_option( $option );
+	delete_option( $coblocks_option );
 
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,4 +24,3 @@ foreach ( $coblocks_options as $coblocks_option ) {
 	delete_option( $coblocks_option );
 
 }
-

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * CoBlocks Uninstall
+ *
+ * @package CoBlocks
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+
+	die;
+
+}
+
+$options = array(
+	'coblocks_settings_api',
+	'coblocks_plugin_feedback_activation_date',
+	'coblocks_date_installed',
+	'coblocks_google_maps_api_key',
+	'coblocks_plugin_feedback_no_bug',
+);
+
+foreach ( $options as $option ) {
+
+	delete_option( $option );
+
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,3 +24,4 @@ foreach ( $coblocks_options as $coblocks_option ) {
 	delete_option( $coblocks_option );
 
 }
+


### PR DESCRIPTION
Based on https://github.com/godaddy-wordpress/coblocks/blob/add-coblocks-uninstall/uninstall.php
- I excluded a check for `ABSPATH` since accessing uninstall.php directly would cause `WP_UNINSTALL_PLUGIN` to be undefined. No need to check for both.
- I did not check if this was a multi-site install, since we are not storing any options using `update_site_option`.