### PR TITLE
Serve full size images with Post Carousel block

### DIFF
--- a/src/blocks/post-carousel/index.php
+++ b/src/blocks/post-carousel/index.php
@@ -241,7 +241,7 @@ function coblocks_get_post_carousel_info( $posts ) {
 
 		$formatted_post = null;
 
-		$formatted_post['thumbnailURL'] = get_the_post_thumbnail_url( $post );
+		$formatted_post['thumbnailURL'] = get_the_post_thumbnail_url( $post, 'full' );
 		$formatted_post['date']         = esc_attr( get_the_date( 'c', $post ) );
 		$formatted_post['dateReadable'] = esc_html( get_the_date( '', $post ) );
 		$formatted_post['title']        = get_the_title( $post );


### PR DESCRIPTION
The editor provides full-size images to preview the block but published pages use the thumbnail-sized imaged. This change will bring in full-size images to be used on published pages. The default behavior of `get_the_post_thumbnail_url()` is to retrieve the thumbnail size image for the provided post ID. Here we can pass the string 'full' to retrieve full-size images. 

**Inspired with WordPress.org support request**
https://wordpress.org/support/topic/featured-images-in-post-carousel-low-res/