### PR TITLE
Localize instructions string for MediaPlaceholder

### DIFF
--- a/src/blocks/media-card/media-container.js
+++ b/src/blocks/media-card/media-container.js
@@ -99,6 +99,7 @@ class MediaContainer extends Component {
 						icon={ <BlockIcon icon={ icons.mediaContainer } /> }
 						labels={ {
 							title: __( 'Media area', 'coblocks' ),
+							instructions: __( 'Upload a media file or pick one from your media library', 'coblocks' ),
 						} }
 						className={ figureClass }
 						onSelect={ onSelectMedia }


### PR DESCRIPTION
The instructions string for the Media Placeholder is not being localized in non-EN markets. Adding string to our implementation which we can localize as needed.