### PR TITLE
Fix bug with editing captions with no content

### DIFF
--- a/src/components/block-gallery/styles/editor/_gallery-item.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item.scss
@@ -20,6 +20,7 @@
 			right: 0;
 			top: 0;
 			z-index: 1;
+			pointer-events: none;
 		}
 	}
 


### PR DESCRIPTION
This PR adds `pointer-events: none;`  to the absolute positioned 'after' content element on gallery items. This positioned layer was preventing click events from being registered on the underlying figure so captions could not be un-selected, and captions with no content could not be selected.

PR contains minor css change only and has been manually tested.

Before:

![caption-before](https://user-images.githubusercontent.com/3629020/70397999-d1b7ba80-1a7b-11ea-916f-2945ab3bf9f2.gif)

After:

![caption-after](https://user-images.githubusercontent.com/3629020/70398005-df6d4000-1a7b-11ea-91de-8ee572ea7bf0.gif)

Fixes #1143
Fixes https://github.com/Automattic/wp-calypso/issues/37090