### PR TITLE
Improve Alert block stability through transforms testing

### DIFF
--- a/src/blocks/alert/block.json
+++ b/src/blocks/alert/block.json
@@ -4,6 +4,7 @@
 	"attributes": {
 		"title": {
 			"type": "string",
+			"source": "html",
 			"selector": ".wp-block-coblocks-alert__title"
 		},
 		"value": {

--- a/src/blocks/alert/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/alert/test/__snapshots__/save.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`coblocks/alert should render with content 1`] = `
-"<!-- wp:coblocks/alert {\\"title\\":\\"Alert title\\"} -->
+"<!-- wp:coblocks/alert -->
 <div class=\\"wp-block-coblocks-alert\\"><p class=\\"wp-block-coblocks-alert__title\\">Alert title</p><p class=\\"wp-block-coblocks-alert__text\\">Alert description</p></div>
 <!-- /wp:coblocks/alert -->"
 `;

--- a/src/blocks/alert/test/transforms.spec.js
+++ b/src/blocks/alert/test/transforms.spec.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, createBlock, switchToBlockType, rawHandler } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+describe( 'coblocks/alert transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform from core/paragraph block', () => {
+		const coreParagraph = createBlock( 'core/paragraph', { content: 'paragraph content' } );
+		const transformed = switchToBlockType( coreParagraph, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.value ).toBe( 'paragraph content' );
+	} );
+
+	it( 'should transform to core/paragraph block', () => {
+		const block = createBlock( name, { value: 'paragraph content' } );
+		const transformed = switchToBlockType( block, 'core/paragraph' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.content ).toBe( 'paragraph content' );
+	} );
+
+	it( 'should transform to core/paragraph block without content', () => {
+		const block = createBlock( name, { } );
+		const transformed = switchToBlockType( block, 'core/paragraph' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.content ).toBe( '' );
+	} );
+
+	it( 'should transform raw html to block', () => {
+		const content = 'Lorem <strong>ipsum</strong> dolor sit amet.';
+		const HTML = `<div class="wp-block-coblocks-alert"><p class="wp-block-coblocks-alert__title">${ content }</p><p class="wp-block-coblocks-alert__text">${ content }</p></div>`;
+
+		const block = rawHandler( { HTML } );
+
+		expect( block[ 0 ].isValid ).toBe( true );
+		expect( block[ 0 ].name ).toBe( name );
+		expect( block[ 0 ].attributes.value ).toBe( content );
+	} );
+} );

--- a/src/blocks/alert/test/transforms.spec.js
+++ b/src/blocks/alert/test/transforms.spec.js
@@ -42,9 +42,15 @@ describe( 'coblocks/alert transforms', () => {
 	} );
 
 	it( 'should transform raw html to block', () => {
-		const value = 'hello';
-		const title = value;
-		const HTML = `<!-- wp:coblocks/alert {"title":"${ title }"} --><div class="wp-block-coblocks-alert"><p class="wp-block-coblocks-alert__title">${ title }</p><p class="wp-block-coblocks-alert__text">${ value }</p></div><!-- /wp:coblocks/alert -->`;
+		const title = 'title';
+		const value = 'value';
+
+		const HTML =
+			`<div class="wp-block-coblocks-alert">
+				<p class="wp-block-coblocks-alert__title">${ title }</p>
+				<p class="wp-block-coblocks-alert__text">${ value }</p>
+			</div>`;
+
 		const block = rawHandler( { HTML } );
 
 		expect( block[ 0 ].isValid ).toBe( true );

--- a/src/blocks/alert/test/transforms.spec.js
+++ b/src/blocks/alert/test/transforms.spec.js
@@ -42,13 +42,14 @@ describe( 'coblocks/alert transforms', () => {
 	} );
 
 	it( 'should transform raw html to block', () => {
-		const content = 'Lorem <strong>ipsum</strong> dolor sit amet.';
-		const HTML = `<div class="wp-block-coblocks-alert"><p class="wp-block-coblocks-alert__title">${ content }</p><p class="wp-block-coblocks-alert__text">${ content }</p></div>`;
-
+		const value = 'hello';
+		const title = value;
+		const HTML = `<!-- wp:coblocks/alert {"title":"${ title }"} --><div class="wp-block-coblocks-alert"><p class="wp-block-coblocks-alert__title">${ title }</p><p class="wp-block-coblocks-alert__text">${ value }</p></div><!-- /wp:coblocks/alert -->`;
 		const block = rawHandler( { HTML } );
 
 		expect( block[ 0 ].isValid ).toBe( true );
 		expect( block[ 0 ].name ).toBe( name );
-		expect( block[ 0 ].attributes.value ).toBe( content );
+		expect( block[ 0 ].attributes.value ).toBe( value );
+		expect( block[ 0 ].attributes.title ).toBe( title );
 	} );
 } );

--- a/src/blocks/alert/transforms.js
+++ b/src/blocks/alert/transforms.js
@@ -6,7 +6,7 @@ import metadata from './block.json';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -19,11 +19,11 @@ const transforms = {
 		},
 		{
 			type: 'raw',
-			selector: 'div.wp-block-coblocks-alert',
-			schema: {
-				div: {
-					classes: [ 'wp-block-coblocks-alert' ],
-				},
+			selector: '.wp-block-coblocks-alert',
+			transform( node ) {
+				return createBlock( metadata.name, {
+					...getBlockAttributes( metadata.name, node.outerHTML ),
+				} );
 			},
 		},
 	],


### PR DESCRIPTION
New Transforms tests for Alert block.
Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/alert/test/transforms.spec.js 
```

```javascript
PASS  src/blocks/alert/test/transforms.spec.js
  coblocks/alert transforms
    ✓ should transform from core/paragraph block (3ms)
    ✓ should transform to core/paragraph block
    ✓ should transform to core/paragraph block without content (1ms)
    ✓ should transform raw html to block (23ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        3.188s
```