### PR TITLE
Improve Click-to-Tweet block stability through transforms testing

### DIFF
--- a/src/blocks/click-to-tweet/test/transforms.spec.js
+++ b/src/blocks/click-to-tweet/test/transforms.spec.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+describe( 'coblocks/click-to-tweet transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform from core/paragraph block', () => {
+		const coreParagraph = createBlock( 'core/paragraph', { content: 'paragraph content' } );
+		const transformed = switchToBlockType( coreParagraph, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.content ).toBe( 'paragraph content' );
+	} );
+
+	it( 'should transform from core/pullquote block', () => {
+		const corePullquote = createBlock( 'core/pullquote', { value: 'pullquote content', citation: 'citation content' } );
+		const transformed = switchToBlockType( corePullquote, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.content ).toBe( 'pullquote content' + 'citation content' );
+	} );
+
+	it( 'should transform from core/quote block', () => {
+		const coreQuote = createBlock( 'core/quote', { value: 'quote content', citation: 'citation content' } );
+		const transformed = switchToBlockType( coreQuote, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.content ).toBe( 'quote content' + 'citation content' );
+	} );
+
+	it( 'should transform to core/paragraph block', () => {
+		const block = createBlock( name, { content: 'paragraph content' } );
+		const transformed = switchToBlockType( block, 'core/paragraph' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.content ).toBe( 'paragraph content' );
+	} );
+
+	it( 'should transform to core/pullquote block', () => {
+		const block = createBlock( name, { content: 'pullquote content' } );
+		const transformed = switchToBlockType( block, 'core/pullquote' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.value ).toBe( '<p>pullquote content</p>' );
+	} );
+
+	it( 'should transform to core/quote block', () => {
+		const block = createBlock( name, { content: 'quote content' } );
+		const transformed = switchToBlockType( block, 'core/quote' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.value ).toBe( '<p>quote content</p>' );
+	} );
+} );

--- a/src/blocks/click-to-tweet/transforms.js
+++ b/src/blocks/click-to-tweet/transforms.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { split, create, toHTMLString } from '@wordpress/rich-text';
+import { create, toHTMLString } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -14,19 +14,28 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content } ) => createBlock( metadata.name, {
-				content: content,
-			} ),
+			transform: ( { content } ) => {
+				const textContent = create( { html: content } );
+				// 280 character limit per tweet
+				textContent.text = textContent.text.slice( 0, 280 );
+				return [
+					createBlock( metadata.name, {
+						content: toHTMLString( { value: textContent } ),
+					} ),
+				];
+			},
+
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value } ) => {
-				const pieces = split( create( { html: value, multilineTag: 'p' } ), '\u2028' );
-
+			transform: ( { value, citation } ) => {
+				const textContent = [ create( { html: value } ), create( { html: citation } ) ];
+				// 280 character limit per tweet
+				textContent[ 0 ].text = textContent[ 0 ].text.slice( 0, 280 - textContent[ 1 ].text.length );
 				return [
 					createBlock( metadata.name, {
-						content: toHTMLString( { value: pieces[ 0 ] } ),
+						content: toHTMLString( { value: textContent[ 0 ] } ) + toHTMLString( { value: textContent[ 1 ] } ),
 					} ),
 				];
 			},
@@ -34,12 +43,13 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/quote' ],
-			transform: ( { value } ) => {
-				const pieces = split( create( { html: value, multilineTag: 'p' } ), '\u2028' );
-
+			transform: ( { value, citation } ) => {
+				const textContent = [ create( { html: value } ), create( { html: citation } ) ];
+				// 280 character limit per tweet
+				textContent[ 0 ].text = textContent[ 0 ].text.slice( 0, 280 - textContent[ 1 ].text.length );
 				return [
 					createBlock( metadata.name, {
-						content: toHTMLString( { value: pieces[ 0 ] } ),
+						content: toHTMLString( { value: textContent[ 0 ] } ) + toHTMLString( { value: textContent[ 1 ] } ),
 					} ),
 				];
 			},
@@ -50,7 +60,7 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
 			transform: ( { content } ) => createBlock( 'core/paragraph', {
-				content: content,
+				content,
 			} ),
 		},
 		{


### PR DESCRIPTION
- New Transforms tests for Click-to-Tweet block. 
- Fix existing transforms function for Click-to-Tweet block.
Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/click-to-tweet/test/transforms.spec.js
```
```javascript
 PASS  src/blocks/click-to-tweet/test/transforms.spec.js
  coblocks/click-to-tweet transforms
    ✓ should transform from core/paragraph block (7ms)
    ✓ should transform from core/pullquote block (1ms)
    ✓ should transform from core/quote block (1ms)
    ✓ should transform to core/paragraph block
    ✓ should transform to core/pullquote block (1ms)
    ✓ should transform to core/quote block

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        3.026s, estimated 4s
```