### PR TITLE
Improve Author block stability through transforms testing

### DIFF
--- a/src/blocks/author/block.json
+++ b/src/blocks/author/block.json
@@ -10,6 +10,7 @@
 		},
 		"name": {
 			"type": "string",
+			"source": "html",
 			"selector": ".wp-block-coblocks-author__name"
 		},
 		"imgId": {

--- a/src/blocks/author/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/author/test/__snapshots__/save.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`coblocks/author should render with content 1`] = `
-"<!-- wp:coblocks/author {\\"name\\":\\"Author Name\\"} -->
+"<!-- wp:coblocks/author -->
 <div class=\\"wp-block-coblocks-author\\"><div class=\\"wp-block-coblocks-author__content\\"><span class=\\"wp-block-coblocks-author__name\\">Author Name</span><p class=\\"wp-block-coblocks-author__biography\\">Author biography</p></div></div>
 <!-- /wp:coblocks/author -->"
 `;

--- a/src/blocks/author/test/transforms.spec.js
+++ b/src/blocks/author/test/transforms.spec.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import { registerCoreBlocks } from '@wordpress/block-library';
 import { registerBlockType, rawHandler } from '@wordpress/blocks';
-
-registerCoreBlocks();
 
 /**
  * Internal dependencies.

--- a/src/blocks/author/test/transforms.spec.js
+++ b/src/blocks/author/test/transforms.spec.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, rawHandler } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+describe( 'coblocks/author transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform raw html to block', () => {
+		const attrName = 'John Doe';
+		const attrBio = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+		const attrImgUrl = 'https://s.w.org/images/core/5.3/Biologia_Centrali-Americana_-_Cantorchilus_semibadius_1902.jpg';
+		const HTML = `<!-- wp:coblocks/author {"name":"${ attrName }"} --><div class="wp-block-coblocks-author"><figure class="wp-block-coblocks-author__avatar"><img class="wp-block-coblocks-author__avatar-img" src="${ attrImgUrl }" alt="${ attrName }"/></figure><div class="wp-block-coblocks-author__content"><span class="wp-block-coblocks-author__name">${ attrName }</span><p class="wp-block-coblocks-author__biography">${ attrBio }</p><!-- wp:button {"placeholder":"Author link…"} --><div class="wp-block-button"><a class="wp-block-button__link" href="google.com">Visit my page</a></div><!-- /wp:button --></div></div><!-- /wp:coblocks/author -->`;
+
+		const block = rawHandler( { HTML } );
+
+		expect( block[ 0 ].isValid ).toBe( true );
+		expect( block[ 0 ].name ).toBe( name );
+		expect( block[ 0 ].attributes.name ).toBe( attrName );
+		expect( block[ 0 ].attributes.biography[ 0 ] ).toBe( attrBio );
+		expect( block[ 0 ].attributes.imgUrl ).toBe( attrImgUrl );
+	} );
+
+	it( 'should transform when ":author" prefix is seen', () => {
+		const prefix = ':author';
+		const block = helpers.performPrefixTransformation( name, prefix, prefix );
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+} );

--- a/src/blocks/author/test/transforms.spec.js
+++ b/src/blocks/author/test/transforms.spec.js
@@ -19,7 +19,17 @@ describe( 'coblocks/author transforms', () => {
 		const attrName = 'John Doe';
 		const attrBio = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 		const attrImgUrl = 'https://s.w.org/images/core/5.3/Biologia_Centrali-Americana_-_Cantorchilus_semibadius_1902.jpg';
-		const HTML = `<!-- wp:coblocks/author {"name":"${ attrName }"} --><div class="wp-block-coblocks-author"><figure class="wp-block-coblocks-author__avatar"><img class="wp-block-coblocks-author__avatar-img" src="${ attrImgUrl }" alt="${ attrName }"/></figure><div class="wp-block-coblocks-author__content"><span class="wp-block-coblocks-author__name">${ attrName }</span><p class="wp-block-coblocks-author__biography">${ attrBio }</p><!-- wp:button {"placeholder":"Author link…"} --><div class="wp-block-button"><a class="wp-block-button__link" href="google.com">Visit my page</a></div><!-- /wp:button --></div></div><!-- /wp:coblocks/author -->`;
+
+		const HTML =
+			`<div class="wp-block-coblocks-author">
+				<figure class="wp-block-coblocks-author__avatar">
+					<img class="wp-block-coblocks-author__avatar-img" src="${ attrImgUrl }" />
+				</figure
+				<div class="wp-block-coblocks-author__content">
+					<span class="wp-block-coblocks-author__name">${ attrName }</span>
+					<p class="wp-block-coblocks-author__biography">${ attrBio }</p>
+				</div>
+			</div>`;
 
 		const block = rawHandler( { HTML } );
 

--- a/src/blocks/author/transforms.js
+++ b/src/blocks/author/transforms.js
@@ -6,17 +6,17 @@ import metadata from './block.json';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
 		{
 			type: 'raw',
-			selector: 'div.wp-block-coblocks-author',
-			schema: {
-				div: {
-					classes: [ 'wp-block-coblocks-author' ],
-				},
+			selector: '.wp-block-coblocks-author',
+			transform( node ) {
+				return createBlock( metadata.name, {
+					...getBlockAttributes( metadata.name, node.outerHTML ),
+				} );
 			},
 		},
 		{


### PR DESCRIPTION
New Transforms tests for Author block.

Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/author/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/author/test/transforms.spec.js
  coblocks/author transforms
    ✓ should transform raw html to block (38ms)
    ✓ should transform when ":author" prefix is seen

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        3.538s, estimated 4s
```