### PR TITLE
Improve Buttons block stability through transforms testing

### DIFF
--- a/src/blocks/buttons/test/transforms.spec.js
+++ b/src/blocks/buttons/test/transforms.spec.js
@@ -19,7 +19,7 @@ describe( 'coblocks/buttons transforms', () => {
 	} );
 
 	// Should allow transform when prefixed with 1-4 colons.
-	for ( let i = 1; i < 5; i++ ) {
+	for ( let i = 1; i <= 4; i++ ) {
 		const prefix = Array( i + 1 ).join( ':' ) + 'buttons';
 		it( `should transform when ${ prefix } prefix is seen`, () => {
 			const block = helpers.performPrefixTransformation( name, prefix, prefix );

--- a/src/blocks/buttons/test/transforms.spec.js
+++ b/src/blocks/buttons/test/transforms.spec.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+describe( 'coblocks/buttons transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	// Should allow transform when prefixed with 1-4 colons.
+	for ( let i = 1; i < 5; i++ ) {
+		const prefix = Array( i + 1 ).join( ':' ) + 'buttons';
+		it( `should transform when ${ prefix } prefix is seen`, () => {
+			const block = helpers.performPrefixTransformation( name, prefix, prefix );
+
+			expect( block.isValid ).toBe( true );
+			expect( block.name ).toBe( name );
+		} );
+	}
+} );

--- a/src/blocks/buttons/test/transforms.spec.js
+++ b/src/blocks/buttons/test/transforms.spec.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import { registerCoreBlocks } from '@wordpress/block-library';
 import { registerBlockType } from '@wordpress/blocks';
-
-registerCoreBlocks();
 
 /**
  * Internal dependencies.


### PR DESCRIPTION
New Transforms tests for Buttons block.

Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/buttons/test/transforms.spec.js
```

```javascript
 PASS  src/blocks/buttons/test/transforms.spec.js
  coblocks/buttons transforms
    ✓ should transform when :buttons prefix is seen (1ms)
    ✓ should transform when ::buttons prefix is seen
    ✓ should transform when :::buttons prefix is seen
    ✓ should transform when ::::buttons prefix is seen

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        2.99s, estimated 3s

```

