### PR TITLE
Improve Gist block stability through transforms testing

### DIFF
--- a/src/blocks/gist/test/transforms.spec.js
+++ b/src/blocks/gist/test/transforms.spec.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import { registerCoreBlocks } from '@wordpress/block-library';
 import { registerBlockType, rawHandler } from '@wordpress/blocks';
-
-registerCoreBlocks();
 
 /**
  * Internal dependencies.

--- a/src/blocks/gist/test/transforms.spec.js
+++ b/src/blocks/gist/test/transforms.spec.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, rawHandler } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+
+import { name, settings } from '../index';
+
+describe( 'coblocks/gist transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform raw html to block', () => {
+		const file = '#file-gistblocktest-text';
+		const HTML = 'https://gist.github.com/AnthonyLedesma/7d0352e8bc50a8a009c2b930f23d110d' + file;
+
+		const block = rawHandler( { HTML } );
+
+		expect( block[ 0 ].isValid ).toBe( true );
+		expect( block[ 0 ].attributes.url ).toBe( HTML );
+		expect( block[ 0 ].attributes.file ).toBe( file.replace( '-', '.' ) );
+		expect( block[ 0 ].name ).toBe( name );
+	} );
+
+	it( 'should transform when ":gist" prefix is seen', () => {
+		const prefix = ':gist';
+		const block = helpers.performPrefixTransformation( name, prefix, prefix );
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+} );


### PR DESCRIPTION
New Transforms tests for Gist block.

Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/gist/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/gist/test/transforms.spec.js
  coblocks/gist transforms
    ✓ should transform raw html to block (14ms)
    ✓ should transform when ":gist" prefix is seen

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        3.147s, estimated 5s
```