### PR TITLE
Improve Dynamic Separator block stability through transforms testing

### DIFF
--- a/src/blocks/dynamic-separator/test/transforms.spec.js
+++ b/src/blocks/dynamic-separator/test/transforms.spec.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+describe( 'coblocks/dynamic-separator transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform from core/spacer block', () => {
+		const coreSpacer = createBlock( 'core/spacer', { height: 200 } );
+		const transformed = switchToBlockType( coreSpacer, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.height ).toBe( 200 );
+	} );
+
+	it( 'should transform from core/separator block', () => {
+		const coreSeparator = createBlock( 'core/separator' );
+
+		const transformed = switchToBlockType( coreSeparator, name );
+		expect( transformed[ 0 ].isValid ).toBe( true );
+	} );
+
+	it( 'should transform to core/spacer block', () => {
+		const block = createBlock( name, { height: 200 } );
+		const transformed = switchToBlockType( block, 'core/spacer' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.height ).toBe( 200 );
+	} );
+
+	it( 'should transform to core/separator block', () => {
+		const block = createBlock( name );
+		const transformed = switchToBlockType( block, 'core/separator' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
New Transforms tests for Dynamic Separator block.
Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/dynamic-separator/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/dynamic-separator/test/transforms.spec.js
  coblocks/dynamic-separator transforms
    ✓ should transform from core/spacer block (2ms)
    ✓ should transform from core/separator block (1ms)
    ✓ should transform to core/spacer block
    ✓ should transform to core/separator block (1ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        4.675s
````