### PR TITLE
Improve Features block stability through transforms testing

### DIFF
--- a/src/blocks/features/test/transforms.spec.js
+++ b/src/blocks/features/test/transforms.spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+describe( 'coblocks/features transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform when :feature prefix is seen', () => {
+		const block = helpers.performPrefixTransformation( name, ':feature', ':feature' );
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+		expect( block.attributes.columns ).toBe( 1 ); // should be single column.
+	} );
+
+	// Should allow transform when prefixed with 1-3 colons.
+	for ( let i = 1; i <= 3; i++ ) {
+		const prefix = Array( i + 1 ).join( ':' ) + 'features';
+		it( `should transform when ${ prefix } prefix is seen`, () => {
+			const block = helpers.performPrefixTransformation( name, prefix, prefix );
+			expect( block.isValid ).toBe( true );
+			expect( block.name ).toBe( name );
+			expect( block.attributes.columns ).toBe( Math.max( i, 2 ) ); // should be 2 minimum columns or 3 max.
+		} );
+	}
+} );

--- a/src/blocks/features/test/transforms.spec.js
+++ b/src/blocks/features/test/transforms.spec.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import { registerCoreBlocks } from '@wordpress/block-library';
 import { registerBlockType } from '@wordpress/blocks';
-
-registerCoreBlocks();
 
 /**
  * Internal dependencies.


### PR DESCRIPTION
New Transforms tests for Features block.
Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/features/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/features/test/transforms.spec.js
  coblocks/features transforms
    ✓ should transform when :feature prefix is seen (2ms)
    ✓ should transform when :features prefix is seen (1ms)
    ✓ should transform when ::features prefix is seen
    ✓ should transform when :::features prefix is seen (1ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        4.44s
```