### PR TITLE
Improve Masonry Gallery block stability through transforms testing

### DIFF
--- a/.dev/tests/jest/helpers.js
+++ b/.dev/tests/jest/helpers.js
@@ -13,11 +13,31 @@ import '../../../src/extensions/colors';
 import '../../../src/extensions/image-crop';
 import '../../../src/extensions/typography';
 
+// Imports used for registerGalleryBlocks().
+import { name as stackedName, settings as stackedSettings } from '../../../src/blocks/gallery-stacked';
+import { name as collageName, settings as collageSettings } from '../../../src/blocks/gallery-collage/';
+import { name as carouselName, settings as carouselSettings } from '../../../src/blocks/gallery-carousel';
+import { name as offsetName, settings as offsetSettings } from '../../../src/blocks/gallery-offset';
+import { name as masonryName, settings as masonrySettings } from '../../../src/blocks/gallery-masonry';
+
 /**
  * WordPress dependencies
  */
 import { sprintf } from '@wordpress/i18n';
 import { registerBlockType, unregisterBlockType, createBlock, getBlockTransforms, serialize, parse } from '@wordpress/blocks';
+
+/**
+ * Register all gallery blocks to be used for transforms testing.
+ *
+ * @returns null;
+ */
+export const registerGalleryBlocks = () => {
+	registerBlockType( stackedName, { category: 'common', ...stackedSettings } ); // Register stacked block
+	registerBlockType( collageName, { category: 'common', ...collageSettings } ); // Register collage block
+	registerBlockType( carouselName, { category: 'common', ...carouselSettings } ); // Register carousel block
+	registerBlockType( offsetName, { category: 'common', ...offsetSettings } ); // Register offset block
+	registerBlockType( masonryName, { category: 'common', ...masonrySettings } ); // Register masonry block
+};
 
 /**
  * A simplified version of the prefix trigger located in the RichText component.

--- a/src/blocks/gallery-masonry/test/transforms.spec.js
+++ b/src/blocks/gallery-masonry/test/transforms.spec.js
@@ -33,8 +33,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
-			// console.log( transformed );
-
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -42,13 +40,11 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	it( 'should transform from coblocks/gallery-collage block', () => {
 		const galleryCollage = createBlock( 'coblocks/gallery-collage', attributes );
-		// console.log( galleryCollage );
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
-			// console.log( transformed );
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}

--- a/src/blocks/gallery-masonry/test/transforms.spec.js
+++ b/src/blocks/gallery-masonry/test/transforms.spec.js
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name } from '../index';
+
+describe( 'coblocks/gallery-masonry transforms', () => {
+	// Shared attributes
+	const attributes = {
+		gutter: 5,
+		images: [
+			{ id: 0, index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
+			{ id: 1, index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
+		] };
+
+	beforeAll( () => {
+		// Register all gallery blocks.
+		helpers.registerGalleryBlocks();
+	} );
+
+	it( 'should transform from coblocks/gallery-stacked block', () => {
+		const galleryStacked = createBlock( 'coblocks/gallery-stacked',	attributes );
+		const transformed = switchToBlockType( galleryStacked, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			// console.log( transformed );
+
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from coblocks/gallery-collage block', () => {
+		const galleryCollage = createBlock( 'coblocks/gallery-collage', attributes );
+		// console.log( galleryCollage );
+		const transformed = switchToBlockType( galleryCollage, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			// console.log( transformed );
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from coblocks/gallery-offset block', () => {
+		const galleryOffset = createBlock( 'coblocks/gallery-offset', attributes );
+		const transformed = switchToBlockType( galleryOffset, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from coblocks/gallery-carousel block', () => {
+		const galleryCarousel = createBlock( 'coblocks/gallery-carousel', attributes );
+		const transformed = switchToBlockType( galleryCarousel, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from core/gallery block', () => {
+		const coreGallery = createBlock( 'core/gallery', { images: attributes.images } );
+		const transformed = switchToBlockType( coreGallery, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from core/image block', () => {
+		const coreImage = createBlock( 'core/image', { id: attributes.images[ 0 ].index, url: attributes.images[ 0 ].url } );
+		const transformed = switchToBlockType( coreImage, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.images.length ).toBeGreaterThan( 0 );
+
+		expect( transformed[ 0 ].attributes.images[ 0 ].index ).toBe( coreImage.attributes.id );
+		expect( transformed[ 0 ].attributes.images[ 0 ].url ).toBe( coreImage.attributes.url );
+	} );
+
+	it( 'should transform to coblocks/gallery-stacked block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-collage block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-offset block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-carousel block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to core/gallery block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'core/gallery' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		for ( let i = 0; i < attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform when ":masonry" prefix is seen', () => {
+		const prefix = ':masonry';
+		const block = helpers.performPrefixTransformation( name, prefix, prefix );
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+} );

--- a/src/blocks/gallery-masonry/transforms.js
+++ b/src/blocks/gallery-masonry/transforms.js
@@ -18,76 +18,27 @@ const transforms = {
 	from: [
 		{
 			type: 'block',
-			blocks: [ 'coblocks/gallery-stacked' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'coblocks/gallery-carousel' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'coblocks/gallery-offset' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'blockgallery/stacked' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'blockgallery/masonry' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'blockgallery/carousel' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/gallery' ],
-			transform: ( attributes ) => (
-				createBlock( metadata.name, {
-					...GalleryTransforms( attributes ),
-				} )
-			),
+			blocks: [
+				'coblocks/gallery-carousel',
+				'coblocks/gallery-collage',
+				'coblocks/gallery-stacked',
+				'coblocks/gallery-offset',
+				'blockgallery/carousel',
+				'blockgallery/masonry',
+				'blockgallery/stacked',
+				'core/gallery',
+			],
+			transform: ( attributes ) => createBlock( metadata.name, GalleryTransforms( attributes ) ),
 		},
 		{
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
-				const validImages = filter( attributes, ( { id, url } ) => id && url );
+				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( { id, url, alt, caption } ) ),
+						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
 					} );
 				}

--- a/src/blocks/gallery-masonry/transforms.js
+++ b/src/blocks/gallery-masonry/transforms.js
@@ -55,17 +55,23 @@ const transforms = {
 			},
 		},
 	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ 'core/gallery' ],
-			transform: ( attributes ) => (
-				createBlock( 'core/gallery', {
+	to: ( function() {
+		return [
+			'coblocks/gallery-collage',
+			'coblocks/gallery-masonry',
+			'coblocks/gallery-stacked',
+			'coblocks/gallery-offset',
+			'core/gallery',
+		].map( x => {
+			return {
+				type: 'block',
+				blocks: [ x ],
+				transform: ( attributes ) => createBlock( x, {
 					...GalleryTransforms( attributes ),
-				} )
-			),
-		},
-	],
+				} ),
+			};
+		} );
+	}() ),
 };
 
 export default transforms;


### PR DESCRIPTION
New Transforms tests for Masonry Gallery block.
Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/gallery-masonry/test/transforms.spec.js
```

```javascript
 PASS  src/blocks/gallery-masonry/test/transforms.spec.js
  coblocks/gallery-masonry transforms
    ✓ should transform from coblocks/gallery-stacked block (4ms)
    ✓ should transform from coblocks/gallery-collage block (1ms)
    ✓ should transform from coblocks/gallery-offset block (1ms)
    ✓ should transform from coblocks/gallery-carousel block (1ms)
    ✓ should transform from core/gallery block (1ms)
    ✓ should transform from core/image block (1ms)
    ✓ should transform to coblocks/gallery-stacked block (1ms)
    ✓ should transform to coblocks/gallery-collage block (1ms)
    ✓ should transform to coblocks/gallery-offset block (1ms)
    ✓ should transform to coblocks/gallery-carousel block (1ms)
    ✓ should transform to core/gallery block
    ✓ should transform when ":masonry" prefix is seen (1ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        4.558s, estimated 5s
```