### PR TITLE
Improve Collage Gallery block stability through transforms testing

### DIFF
--- a/.dev/tests/jest/helpers.js
+++ b/.dev/tests/jest/helpers.js
@@ -13,11 +13,31 @@ import '../../../src/extensions/colors';
 import '../../../src/extensions/image-crop';
 import '../../../src/extensions/typography';
 
+// Imports used for registerGalleryBlocks().
+import { name as stackedName, settings as stackedSettings } from '../../../src/blocks/gallery-stacked';
+import { name as collageName, settings as collageSettings } from '../../../src/blocks/gallery-collage/';
+import { name as carouselName, settings as carouselSettings } from '../../../src/blocks/gallery-carousel';
+import { name as offsetName, settings as offsetSettings } from '../../../src/blocks/gallery-offset';
+import { name as masonryName, settings as masonrySettings } from '../../../src/blocks/gallery-masonry';
+
 /**
  * WordPress dependencies
  */
 import { sprintf } from '@wordpress/i18n';
 import { registerBlockType, unregisterBlockType, createBlock, getBlockTransforms, serialize, parse } from '@wordpress/blocks';
+
+/**
+ * Register all gallery blocks to be used for transforms testing.
+ *
+ * @returns null;
+ */
+export const registerGalleryBlocks = () => {
+	registerBlockType( stackedName, { category: 'common', ...stackedSettings } ); // Register stacked block
+	registerBlockType( collageName, { category: 'common', ...collageSettings } ); // Register collage block
+	registerBlockType( carouselName, { category: 'common', ...carouselSettings } ); // Register carousel block
+	registerBlockType( offsetName, { category: 'common', ...offsetSettings } ); // Register offset block
+	registerBlockType( masonryName, { category: 'common', ...masonrySettings } ); // Register masonry block
+};
 
 /**
  * A simplified version of the prefix trigger located in the RichText component.

--- a/src/blocks/gallery-collage/test/transforms.spec.js
+++ b/src/blocks/gallery-collage/test/transforms.spec.js
@@ -32,7 +32,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -44,7 +44,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -56,7 +56,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -68,7 +68,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -79,7 +79,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( coreGallery, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -90,10 +90,10 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( coreImage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i; i <= attributes.images.length; i++ ) {
-			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
-			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
-		}
+		expect( transformed[ 0 ].attributes.images.length ).toBeGreaterThan( 0 );
+
+		expect( transformed[ 0 ].attributes.images[ 0 ].index ).toBe( coreImage.attributes.id );
+		expect( transformed[ 0 ].attributes.images[ 0 ].url ).toBe( coreImage.attributes.url );
 	} );
 
 	it( 'should transform to coblocks/gallery-stacked block', () => {
@@ -102,7 +102,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -114,7 +114,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -126,7 +126,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -138,7 +138,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}
@@ -149,7 +149,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i; i <= attributes.images.length; i++ ) {
+		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
 		}

--- a/src/blocks/gallery-collage/test/transforms.spec.js
+++ b/src/blocks/gallery-collage/test/transforms.spec.js
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name } from '../index';
+
+describe( 'coblocks/gallery-collage transforms', () => {
+	// Shared attributes
+	const attributes = {
+		gutter: 5,
+		images: [
+			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
+			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
+		] };
+
+	beforeAll( () => {
+		// Register all gallery blocks.
+		helpers.registerGalleryBlocks();
+	} );
+
+	it( 'should transform from coblocks/gallery-stacked block', () => {
+		const galleryStacked = createBlock( 'coblocks/gallery-stacked',	attributes );
+		const transformed = switchToBlockType( galleryStacked, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from coblocks/gallery-masonry block', () => {
+		const galleryMasonry = createBlock( 'coblocks/gallery-masonry', attributes );
+		const transformed = switchToBlockType( galleryMasonry, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from coblocks/gallery-offset block', () => {
+		const galleryOffset = createBlock( 'coblocks/gallery-offset', attributes );
+		const transformed = switchToBlockType( galleryOffset, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from coblocks/gallery-carousel block', () => {
+		const galleryCollage = createBlock( 'coblocks/gallery-carousel', attributes );
+		const transformed = switchToBlockType( galleryCollage, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from core/gallery block', () => {
+		const coreGallery = createBlock( 'core/gallery', { images: attributes.images } );
+		const transformed = switchToBlockType( coreGallery, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform from core/image block', () => {
+		const coreImage = createBlock( 'core/image', { id: attributes.images[ 0 ].index, url: attributes.images[ 0 ].url } );
+		const transformed = switchToBlockType( coreImage, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-stacked block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-masonry block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-offset block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to coblocks/gallery-carousel block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform to core/gallery block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'core/gallery' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		for ( let i; i <= attributes.images.length; i++ ) {
+			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
+		}
+	} );
+
+	it( 'should transform when ":collage" prefix is seen', () => {
+		const prefix = ':collage';
+		const block = helpers.performPrefixTransformation( name, prefix, prefix );
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+} );

--- a/src/blocks/gallery-collage/transforms.js
+++ b/src/blocks/gallery-collage/transforms.js
@@ -35,10 +35,10 @@ const transforms = {
 			isMultiBlock: true,
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
-				const validImages = filter( attributes, ( { id, url } ) => ( id || id === 0 ) && url );
+				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { id, url, alt, caption, index } ) ),
+						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
 					} );
 				}
@@ -51,63 +51,26 @@ const transforms = {
 			transform: ( content ) => createBlock( metadata.name, { content } ),
 		},
 	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ 'core/gallery' ],
-			transform: ( attributes ) => {
-				const newAttributes = Object.assign(
-					GalleryTransforms( attributes ),
-					{ images: attributes.images.filter( image => typeof image.id !== 'undefined' ) }
-				);
-				return createBlock( 'core/gallery', newAttributes );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'coblocks/gallery-carousel' ],
-			transform: ( attributes ) => {
-				const newAttributes = Object.assign(
-					GalleryTransforms( attributes ),
-					{ images: attributes.images.filter( image => typeof image.id !== 'undefined' ) }
-				);
-				return createBlock( 'coblocks/gallery-carousel', newAttributes );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'coblocks/gallery-masonry' ],
-			transform: ( attributes ) => {
-				const newAttributes = Object.assign(
-					GalleryTransforms( attributes ),
-					{ images: attributes.images.filter( image => typeof image.id !== 'undefined' ) }
-				);
-				return createBlock( 'coblocks/gallery-masonry', newAttributes );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'coblocks/gallery-stacked' ],
-			transform: ( attributes ) => {
-				const newAttributes = Object.assign(
-					GalleryTransforms( attributes ),
-					{ images: attributes.images.filter( image => typeof image.id !== 'undefined' ) }
-				);
-				return createBlock( 'coblocks/gallery-stacked', newAttributes );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'coblocks/gallery-offset' ],
-			transform: ( attributes ) => {
-				const newAttributes = Object.assign(
-					GalleryTransforms( attributes ),
-					{ images: attributes.images.filter( image => typeof image.id !== 'undefined' ) }
-				);
-				return createBlock( 'coblocks/gallery-offset', newAttributes );
-			},
-		},
-	],
+	to: ( function() {
+		return [
+			'coblocks/gallery-carousel',
+			'coblocks/gallery-masonry',
+			'coblocks/gallery-stacked',
+			'coblocks/gallery-offset',
+			'blockgallery/carousel',
+			'blockgallery/masonry',
+			'blockgallery/stacked',
+			'core/gallery',
+		].map( x => {
+			return {
+				type: 'block',
+				blocks: [ x ],
+				transform: ( attributes ) => createBlock( x, {
+					...GalleryTransforms( attributes ),
+				} ),
+			};
+		} );
+	}() ),
 };
 
 export default transforms;

--- a/src/blocks/gallery-collage/transforms.js
+++ b/src/blocks/gallery-collage/transforms.js
@@ -57,9 +57,6 @@ const transforms = {
 			'coblocks/gallery-masonry',
 			'coblocks/gallery-stacked',
 			'coblocks/gallery-offset',
-			'blockgallery/carousel',
-			'blockgallery/masonry',
-			'blockgallery/stacked',
 			'core/gallery',
 		].map( x => {
 			return {

--- a/src/blocks/gallery-collage/transforms.js
+++ b/src/blocks/gallery-collage/transforms.js
@@ -35,7 +35,7 @@ const transforms = {
 			isMultiBlock: true,
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
-				const validImages = filter( attributes, ( { id, url } ) => id && url );
+				const validImages = filter( attributes, ( { id, url } ) => ( id || id === 0 ) && url );
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
 						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { id, url, alt, caption, index } ) ),
@@ -47,7 +47,7 @@ const transforms = {
 		},
 		{
 			type: 'prefix',
-			prefix: ':masonry',
+			prefix: ':collage',
 			transform: ( content ) => createBlock( metadata.name, { content } ),
 		},
 	],


### PR DESCRIPTION
New Transforms tests for Collage Gallery block.
Test changes by using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/gallery-collage/test/transforms.spec.js 
```
```javascript
PASS  src/blocks/gallery-collage/test/transforms.spec.js
  coblocks/gallery-collage transforms
    ✓ should transform from coblocks/gallery-stacked block (4ms)
    ✓ should transform from coblocks/gallery-masonry block (1ms)
    ✓ should transform from coblocks/gallery-offset block (1ms)
    ✓ should transform from coblocks/gallery-carousel block (1ms)
    ✓ should transform from core/gallery block (1ms)
    ✓ should transform from core/image block (1ms)
    ✓ should transform to coblocks/gallery-stacked block (1ms)
    ✓ should transform to coblocks/gallery-masonry block (1ms)
    ✓ should transform to coblocks/gallery-offset block (1ms)
    ✓ should transform to coblocks/gallery-carousel block
    ✓ should transform to core/gallery block (1ms)
    ✓ should transform when ":collage" prefix is seen

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        3.523s, estimated 10s
```