### PR TITLE
Fix media placeholder visibility when using Spotlight mode

### DIFF
--- a/src/blocks/gallery-carousel/styles/editor.scss
+++ b/src/blocks/gallery-carousel/styles/editor.scss
@@ -69,7 +69,7 @@
 
 // Needed until GB 6.9 is merged into core or backward support.
 // Hide the placeholder when not selected.
-.editor-block-list__block[data-type="coblocks/gallery-carousel"]:not(.is-selected) {
+.editor-block-list__block[data-type="coblocks/gallery-carousel"]:not(.is-selected):not(.is-focused) {
 		div.components-form-file-upload {
 			display: none;
 		} 

--- a/src/blocks/gallery-masonry/styles/editor.scss
+++ b/src/blocks/gallery-masonry/styles/editor.scss
@@ -99,7 +99,7 @@
 
 // Needed until GB 6.9 is merged into core or backward support.
 // Hide the placeholder when not selected.
-.editor-block-list__block[data-type="coblocks/gallery-masonry"]:not(.is-selected) {
+.editor-block-list__block[data-type="coblocks/gallery-masonry"]:not(.is-selected):not(.is-focused)  {
 	div.components-form-file-upload {
 		display: none;
 	} 

--- a/src/blocks/gallery-offset/styles/editor.scss
+++ b/src/blocks/gallery-offset/styles/editor.scss
@@ -66,7 +66,7 @@
 
 // Needed until GB 6.9 is merged into core or backward support.
 // Hide the placeholder when not selected.
-.editor-block-list__block[data-type="coblocks/gallery-offset"]:not(.is-selected):not(.is-selected):not(.is-focused)  {
+.editor-block-list__block[data-type="coblocks/gallery-offset"]:not(.is-selected):not(.is-focused)  {
 	div.components-form-file-upload {
 		display: none;
 	}

--- a/src/blocks/gallery-offset/styles/editor.scss
+++ b/src/blocks/gallery-offset/styles/editor.scss
@@ -66,7 +66,7 @@
 
 // Needed until GB 6.9 is merged into core or backward support.
 // Hide the placeholder when not selected.
-.editor-block-list__block[data-type="coblocks/gallery-offset"]:not(.is-selected) {
+.editor-block-list__block[data-type="coblocks/gallery-offset"]:not(.is-selected):not(.is-selected):not(.is-focused)  {
 	div.components-form-file-upload {
 		display: none;
 	}

--- a/src/blocks/gallery-stacked/styles/editor.scss
+++ b/src/blocks/gallery-stacked/styles/editor.scss
@@ -41,7 +41,7 @@
 
 // Needed until GB 6.9 is merged into core or backward support.
 // Hide the placeholder when not selected.
-.editor-block-list__block[data-type="coblocks/gallery-stacked"]:not(.is-selected) {
+.editor-block-list__block[data-type="coblocks/gallery-stacked"]:not(.is-selected):not(.is-selected):not(.is-focused)  {
 	div.components-form-file-upload {
 		display: none;
 	} 

--- a/src/blocks/gallery-stacked/styles/editor.scss
+++ b/src/blocks/gallery-stacked/styles/editor.scss
@@ -41,7 +41,7 @@
 
 // Needed until GB 6.9 is merged into core or backward support.
 // Hide the placeholder when not selected.
-.editor-block-list__block[data-type="coblocks/gallery-stacked"]:not(.is-selected):not(.is-selected):not(.is-focused)  {
+.editor-block-list__block[data-type="coblocks/gallery-stacked"]:not(.is-selected):not(.is-focused)  {
 	div.components-form-file-upload {
 		display: none;
 	} 


### PR DESCRIPTION
When a block is selected in the typical editor view, an `is-selected` class is appended to the block. In the case that Spotlight mode is enabled, the class `is-focused` is appended instead. This change adds the correct conditional to hide the placeholder. 

![galleryBlocksHiddenPlaceholder](https://user-images.githubusercontent.com/30462574/71126221-d54af000-21a5-11ea-8281-764b09e0b2c5.gif)


![galleryBlocksHiddenPlaceholderFix](https://user-images.githubusercontent.com/30462574/71126147-a6cd1500-21a5-11ea-9bb0-e4d8c7205967.gif)
