### PR TITLE
Improve Pricing Table block stability through transforms testing

### DIFF
--- a/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
+++ b/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
@@ -9,41 +9,42 @@ import { registerBlockType, rawHandler } from '@wordpress/blocks';
 import { name, settings } from '../';
 
 describe( 'coblocks/pricing-table-item transforms', () => {
+	const attributes = {
+		title: [ 'Plan 1', 'Plan 2', 'Plan 3', 'Plan 4' ],
+		amount: [ '99', '66', '33', '00' ],
+		features: [ 'Features 1', 'Features 2', 'Features 3', 'Features 4' ],
+	};
+
+	let HTML = '';
+
 	beforeAll( () => {
 		// Register the block.
 		registerBlockType( name, { category: 'common', ...settings } );
 	} );
 
-	it( 'should transform raw html to block', () => {
-		const attributes = {
-			title: [ 'Plan 1', 'Plan 2', 'Plan 3', 'Plan 4' ],
-			amount: [ '99', '66', '33', '00' ],
-			features: [ 'Features 1', 'Features 2', 'Features 3', 'Features 4' ],
-		};
-
-		let HTML = '';
-
-		attributes.title.forEach( ( item, index ) => {
+	attributes.title.forEach( ( item, index ) => {
+		it( `should transform raw html to ${ index + 1 } item block(s)`, () => {
 			HTML = HTML + `
-            <div class="wp-block-coblocks-pricing-table-item">
-            <span class="wp-block-coblocks-pricing-table-item__title">${ attributes.title[ index ] }</span>
-            <div class="wp-block-coblocks-pricing-table-item__price-wrapper">
-                <span class="wp-block-coblocks-pricing-table-item__currency">$</span>
-                <span class="wp-block-coblocks-pricing-table-item__amount">${ attributes.amount[ index ] }</span>
-            </div>
-            <ul class="wp-block-coblocks-pricing-table-item__features"><li>${ attributes.features[ index ] }</li></ul>
-            <div class="wp-block-button"><a class="wp-block-button__link">buy now</a></div>
-        </div>`;
-		} );
+                <div class="wp-block-coblocks-pricing-table-item">
+                <span class="wp-block-coblocks-pricing-table-item__title">${ attributes.title[ index ] }</span>
+                <div class="wp-block-coblocks-pricing-table-item__price-wrapper">
+                    <span class="wp-block-coblocks-pricing-table-item__currency">$</span>
+                    <span class="wp-block-coblocks-pricing-table-item__amount">${ attributes.amount[ index ] }</span>
+                </div>
+                <ul class="wp-block-coblocks-pricing-table-item__features"><li>${ attributes.features[ index ] }</li></ul>
+                <div class="wp-block-button"><a class="wp-block-button__link">buy now</a></div>
+            </div>`;
 
-		const block = rawHandler( { HTML } );
+			const block = rawHandler( { HTML } );
 
-		block.forEach( ( item, index ) => {
-			expect( item.isValid ).toBe( true );
-			expect( item.name ).toBe( name );
-			expect( item.attributes.title[ 0 ] ).toBe( attributes.title[ index ] );
-			expect( item.attributes.features[ 0 ].props.children[ 0 ] ).toBe( attributes.features[ index ] );
-			expect( item.attributes.amount[ 0 ] ).toBe( attributes.amount[ index ] );
+			block.forEach( ( item, index ) => {
+				expect( item.isValid ).toBe( true );
+				expect( item.name ).toBe( name );
+				expect( item.attributes.title[ 0 ] ).toBe( attributes.title[ index ] );
+				expect( item.attributes.features[ 0 ].props.children[ 0 ] ).toBe( attributes.features[ index ] );
+				expect( item.attributes.amount[ 0 ] ).toBe( attributes.amount[ index ] );
+			} );
 		} );
 	} );
 } );
+

--- a/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
+++ b/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
@@ -37,13 +37,14 @@ describe( 'coblocks/pricing-table-item transforms', () => {
 
 			const block = rawHandler( { HTML } );
 
-			block.forEach( ( item, index ) => {
-				expect( item.isValid ).toBe( true );
-				expect( item.name ).toBe( name );
-				expect( item.attributes.title[ 0 ] ).toBe( attributes.title[ index ] );
-				expect( item.attributes.features[ 0 ].props.children[ 0 ] ).toBe( attributes.features[ index ] );
-				expect( item.attributes.amount[ 0 ] ).toBe( attributes.amount[ index ] );
-			} );
+			expect( block[ index ].isValid ).toBe( true );
+			expect( block[ index ].name ).toBe( name );
+
+			expect( block ).toHaveLength( index + 1 );
+
+			expect( block[ index ].attributes.title[ 0 ] ).toBe( attributes.title[ index ] );
+			expect( block[ index ].attributes.features[ 0 ].props.children[ 0 ] ).toBe( attributes.features[ index ] );
+			expect( block[ index ].attributes.amount[ 0 ] ).toBe( attributes.amount[ index ] );
 		} );
 	} );
 } );

--- a/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
+++ b/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
@@ -26,14 +26,14 @@ describe( 'coblocks/pricing-table-item transforms', () => {
 		it( `should transform raw html to ${ index + 1 } item block(s)`, () => {
 			HTML = HTML + `
                 <div class="wp-block-coblocks-pricing-table-item">
-                <span class="wp-block-coblocks-pricing-table-item__title">${ attributes.title[ index ] }</span>
-                <div class="wp-block-coblocks-pricing-table-item__price-wrapper">
-                    <span class="wp-block-coblocks-pricing-table-item__currency">$</span>
-                    <span class="wp-block-coblocks-pricing-table-item__amount">${ attributes.amount[ index ] }</span>
-                </div>
-                <ul class="wp-block-coblocks-pricing-table-item__features"><li>${ attributes.features[ index ] }</li></ul>
-                <div class="wp-block-button"><a class="wp-block-button__link">buy now</a></div>
-            </div>`;
+                    <span class="wp-block-coblocks-pricing-table-item__title">${ attributes.title[ index ] }</span>
+                    <div class="wp-block-coblocks-pricing-table-item__price-wrapper">
+                        <span class="wp-block-coblocks-pricing-table-item__currency">$</span>
+                        <span class="wp-block-coblocks-pricing-table-item__amount">${ attributes.amount[ index ] }</span>
+                    </div>
+                    <ul class="wp-block-coblocks-pricing-table-item__features"><li>${ attributes.features[ index ] }</li></ul>
+                    <div class="wp-block-button"><a class="wp-block-button__link">buy now</a></div>
+                </div>`;
 
 			const block = rawHandler( { HTML } );
 

--- a/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
+++ b/src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType, rawHandler } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../';
+
+describe( 'coblocks/pricing-table-item transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform raw html to block', () => {
+		const attributes = {
+			title: [ 'Plan 1', 'Plan 2', 'Plan 3', 'Plan 4' ],
+			amount: [ '99', '66', '33', '00' ],
+			features: [ 'Features 1', 'Features 2', 'Features 3', 'Features 4' ],
+		};
+
+		let HTML = '';
+
+		attributes.title.forEach( ( item, index ) => {
+			HTML = HTML + `
+            <div class="wp-block-coblocks-pricing-table-item">
+            <span class="wp-block-coblocks-pricing-table-item__title">${ attributes.title[ index ] }</span>
+            <div class="wp-block-coblocks-pricing-table-item__price-wrapper">
+                <span class="wp-block-coblocks-pricing-table-item__currency">$</span>
+                <span class="wp-block-coblocks-pricing-table-item__amount">${ attributes.amount[ index ] }</span>
+            </div>
+            <ul class="wp-block-coblocks-pricing-table-item__features"><li>${ attributes.features[ index ] }</li></ul>
+            <div class="wp-block-button"><a class="wp-block-button__link">buy now</a></div>
+        </div>`;
+		} );
+
+		const block = rawHandler( { HTML } );
+
+		block.forEach( ( item, index ) => {
+			expect( item.isValid ).toBe( true );
+			expect( item.name ).toBe( name );
+			expect( item.attributes.title[ 0 ] ).toBe( attributes.title[ index ] );
+			expect( item.attributes.features[ 0 ].props.children[ 0 ] ).toBe( attributes.features[ index ] );
+			expect( item.attributes.amount[ 0 ] ).toBe( attributes.amount[ index ] );
+		} );
+	} );
+} );

--- a/src/blocks/pricing-table/pricing-table-item/transforms.js
+++ b/src/blocks/pricing-table/pricing-table-item/transforms.js
@@ -1,12 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock, getBlockAttributes } from '@wordpress/blocks';
+
 const transforms = {
 	from: [
 		{
 			type: 'raw',
-			selector: 'div.wp-block-coblocks-pricing-table',
-			schema: {
-				div: {
-					classes: [ 'wp-block-coblocks-pricing-table' ],
-				},
+			selector: '.wp-block-coblocks-pricing-table-item',
+			transform( node ) {
+				return createBlock( metadata.name, {
+					...getBlockAttributes( metadata.name, node.outerHTML ),
+				} );
 			},
 		},
 	],

--- a/src/blocks/pricing-table/test/transforms.spec.js
+++ b/src/blocks/pricing-table/test/transforms.spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType, rawHandler } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../';
+
+describe( 'coblocks/pricing-table transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	for ( let x = 1; x <= 4; x++ ) {
+		it( `should transform raw html to ${ x } column block`, () => {
+			const HTML =
+			`<div class="wp-block-coblocks-pricing-table has-${ x }-columns has-text-align-center"><div class="wp-block-coblocks-pricing-table__inner"></div><div class="wp-block-coblocks-pricing-table__inner"></div><div class="wp-block-coblocks-pricing-table__inner"></div></div></div>`;
+
+			const block = rawHandler( { HTML } );
+
+			expect( block[ 0 ].isValid ).toBe( true );
+			expect( block[ 0 ].name ).toBe( name );
+			expect( block[ 0 ].attributes.count ).toBe( x );
+		} );
+	}
+
+	it( 'should transform when ":pricing" prefix is seen', () => {
+		const prefix = ':pricing';
+		const block = helpers.performPrefixTransformation( name, prefix, prefix );
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+} );
+

--- a/src/blocks/pricing-table/transforms.js
+++ b/src/blocks/pricing-table/transforms.js
@@ -6,17 +6,19 @@ import metadata from './block.json';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
 		{
 			type: 'raw',
-			selector: 'div.wp-block-coblocks-pricing-table',
-			schema: {
-				div: {
-					classes: [ 'wp-block-coblocks-pricing-table' ],
-				},
+			selector: '.wp-block-coblocks-pricing-table',
+			transform( node ) {
+				const blockAttributes = getBlockAttributes( metadata.name, node.outerHTML );
+				return createBlock( metadata.name, {
+					...blockAttributes,
+					count: blockAttributes.className ? parseInt( blockAttributes.className.match( /(\d+)/ )[ 0 ] ) : 2,
+				} );
 			},
 		},
 		{


### PR DESCRIPTION
New Transforms tests for Pricing Table and Pricing Table Item block.

Test changes with the following:
**Pricing Table**
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/pricing-table/test/transforms.spec.js 
```

**Pricing Table Item**
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js 
```

**Pricing Table Tests**
```javascript
 PASS  src/blocks/pricing-table/test/transforms.spec.js
  coblocks/pricing-table transforms
    ✓ should transform raw html to 1 column block (16ms)
    ✓ should transform raw html to 2 column block (5ms)
    ✓ should transform raw html to 3 column block (4ms)
    ✓ should transform raw html to 4 column block (5ms)
    ✓ should transform when ":pricing" prefix is seen

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        1.975s, estimated 2s

```
**Pricing Table Item Tests**
```javascript
 PASS  src/blocks/pricing-table/pricing-table-item/test/transforms.spec.js
  coblocks/pricing-table-item transforms
    ✓ should transform raw html to 1 item block(s) (28ms)
    ✓ should transform raw html to 2 item block(s) (20ms)
    ✓ should transform raw html to 3 item block(s) (27ms)
    ✓ should transform raw html to 4 item block(s) (33ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.928s, estimated 2s
```