### PR TITLE
Improve Map block stability through transforms testing

### DIFF
--- a/src/blocks/map/test/transforms.spec.js
+++ b/src/blocks/map/test/transforms.spec.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+describe( 'coblocks/map transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform when :map prefix is seen', () => {
+		const prefix = ':map';
+		const block = helpers.performPrefixTransformation( name, prefix, prefix );
+
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+} );


### PR DESCRIPTION
New Transforms tests for Map block.

Test changes using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/map/test/transforms.spec.js 
```

```javascript
PASS  src/blocks/map/test/transforms.spec.js
  coblocks/map transforms
    ✓ should transform when :map prefix is seen (2ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.77s
```