### PR TITLE
Resolve 404 error for utilities styles

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -77,11 +77,11 @@ class CoBlocks_Block_Assets {
 		);
 
 		/**
-		 * Filters whether to load utilitiy styles.
+		 * Filters whether to load utility styles.
 		 *
-		 * @param bool $load_utility_styles whether the utility css should be loaded. Default true.
+		 * @param bool $load_utility_styles whether the utility css should be loaded. Default false.
 		 */
-		$load_utility_styles = (bool) apply_filters( 'coblocks_utility_styles_enabled', true );
+		$load_utility_styles = (bool) apply_filters( 'coblocks_utility_styles_enabled', false );
 
 		if ( $load_utility_styles ) {
 


### PR DESCRIPTION
Closes #1215 
This PR resolves a bug in 1.19.0 CoBlocks where a 404 error is displayed.
![image](https://user-images.githubusercontent.com/30462574/71270105-fdedf980-230d-11ea-943e-e7567d8d12b3.png)

By setting the default status of the filter to false we can prevent this error.
