### PR TITLE
Update PHPUnit tests to check for build assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ version: 2.1
 jobs:
   php56:
     docker:
-      - image: circleci/php:5.6
+      - image: circleci/php:5.6-node
       - image: circleci/mysql:5.7
     steps:
       - checkout
@@ -50,10 +50,26 @@ jobs:
             echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
             source /home/circleci/.bashrc
       - run:
+          name: Update npm
+          command: sudo npm install -g npm@latest
+      - restore_cache:
+          key: php56-dependency-cache--{{ checksum "package.json" }}
+      - run:
+          name: Install node packages
+          command: npm install
+      - save_cache:
+          key: php56-dependency-cache--{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
           name: "Install Dependencies"
           command: |
             bash .dev/bin/install-dependencies.sh
             cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
+      - run:
+          name: Build the plugin
+          command: |
+            ./node_modules/.bin/grunt build
       - run:
           name: "Run PHPCS"
           command: composer run lint -- -v
@@ -73,7 +89,7 @@ jobs:
 
   php72:
     docker:
-      - image: circleci/php:7.2
+      - image: circleci/php:7.2-node
       - image: circleci/mysql:5.7
     steps:
       - checkout
@@ -83,10 +99,26 @@ jobs:
             echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
             source /home/circleci/.bashrc
       - run:
+          name: Update npm
+          command: sudo npm install -g npm@latest
+      - restore_cache:
+          key: php56-dependency-cache--{{ checksum "package.json" }}
+      - run:
+          name: Install node packages
+          command: npm install
+      - save_cache:
+          key: php56-dependency-cache--{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
           name: "Install Dependencies"
           command: |
             bash .dev/bin/install-dependencies.sh
             cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
+      - run:
+          name: Build the plugin
+          command: |
+            ./node_modules/.bin/grunt build
       - run:
           name: "Run PHPCS"
           command: composer run lint -- -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,12 @@ jobs:
           name: Update npm
           command: sudo npm install -g npm@latest
       - restore_cache:
-          key: php56-dependency-cache--{{ checksum "package.json" }}
+          key: php56-build-dependency-cache--{{ checksum "package.json" }}
       - run:
           name: Install node packages
           command: npm install
       - save_cache:
-          key: php56-dependency-cache--{{ checksum "package.json" }}
+          key: php56-build-dependency-cache--{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:
@@ -114,12 +114,12 @@ jobs:
           name: Update npm
           command: sudo npm install -g npm@latest
       - restore_cache:
-          key: php56-dependency-cache--{{ checksum "package.json" }}
+          key: php72-build-dependency-cache--{{ checksum "package.json" }}
       - run:
           name: Install node packages
           command: npm install
       - save_cache:
-          key: php56-dependency-cache--{{ checksum "package.json" }}
+          key: php72-build-dependency-cache--{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Disable xdebug PHP extension
+          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - run:
           name: "Setup Environment Variables"
           command: |
             echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
@@ -61,9 +64,6 @@ jobs:
           key: php56-dependency-cache--{{ checksum "package.json" }}
           paths:
             - node_modules
-      - run:
-          name: Install gettext
-          command: sudo apt-get install gettext
       - run:
           name: "Install Dependencies"
           command: |
@@ -102,6 +102,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Disable xdebug PHP extension
+          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - run:
           name: "Setup Environment Variables"
           command: |
             echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
@@ -118,9 +121,6 @@ jobs:
           key: php56-dependency-cache--{{ checksum "package.json" }}
           paths:
             - node_modules
-      - run:
-          name: Install gettext
-          command: sudo apt-get install gettext
       - run:
           name: "Install Dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,10 +65,6 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: "Install Dependencies"
-          command: |
-            bash .dev/bin/install-dependencies.sh
-      - run:
           name: Install WPCLI
           command: |
             curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
@@ -78,6 +74,11 @@ jobs:
           name: Build the plugin
           command: |
             ./node_modules/.bin/grunt build
+      - run:
+          name: "Install Dependencies"
+          command: |
+            bash .dev/bin/install-dependencies.sh
+            cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
       - run:
           name: "Run PHPCS"
           command: composer run lint -- -v
@@ -122,10 +123,6 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: "Install Dependencies"
-          command: |
-            bash .dev/bin/install-dependencies.sh
-      - run:
           name: Install WPCLI
           command: |
             curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
@@ -135,6 +132,11 @@ jobs:
           name: Build the plugin
           command: |
             ./node_modules/.bin/grunt build
+      - run:
+          name: "Install Dependencies"
+          command: |
+            bash .dev/bin/install-dependencies.sh
+            cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
       - run:
           name: "Run PHPCS"
           command: composer run lint -- -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,12 @@ jobs:
             bash .dev/bin/install-dependencies.sh
             cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
       - run:
+          name: Install WPCLI
+          command: |
+            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            chmod +x wp-cli.phar
+            sudo mv wp-cli.phar /usr/local/bin/wp
+      - run:
           name: Build the plugin
           command: |
             ./node_modules/.bin/grunt build
@@ -115,6 +121,12 @@ jobs:
           command: |
             bash .dev/bin/install-dependencies.sh
             cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
+      - run:
+          name: Install WPCLI
+          command: |
+            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            chmod +x wp-cli.phar
+            sudo mv wp-cli.phar /usr/local/bin/wp
       - run:
           name: Build the plugin
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,12 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Install gettext
+          command: sudo apt-get install gettext
+      - run:
           name: "Install Dependencies"
           command: |
             bash .dev/bin/install-dependencies.sh
-            cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
       - run:
           name: Install WPCLI
           command: |
@@ -117,10 +119,12 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Install gettext
+          command: sudo apt-get install gettext
+      - run:
           name: "Install Dependencies"
           command: |
             bash .dev/bin/install-dependencies.sh
-            cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
       - run:
           name: Install WPCLI
           command: |

--- a/.dev/tests/phpunit/test-class-coblocks.php
+++ b/.dev/tests/phpunit/test-class-coblocks.php
@@ -242,18 +242,6 @@ class CoBlocks_Tests extends WP_UnitTestCase {
 					"${minfied_asset_string} ${asset_type} asset not found: " . COBLOCKS_PLUGIN_DIR . "${path_to_asset}"
 				);
 
-				// Asset the assets exist when SCRIPT_DEBUG is true
-				// if ( 'js' === $asset_type ) {
-				//
-				// 	$path_to_unminified_js_asset = str_replace( '.min', '', str_replace( 'dist', 'src', $path_to_asset ) );
-				//
-				// 	$this->assertTrue(
-				// 		file_exists( $path_to_unminified_js_asset ),
-				// 		"Unminified ${asset_type} asset not found: ${path_to_unminified_js_asset}"
-				// 	);
-				//
-				// }
-
 			}
 
 		}

--- a/.dev/tests/phpunit/test-class-coblocks.php
+++ b/.dev/tests/phpunit/test-class-coblocks.php
@@ -196,4 +196,69 @@ class CoBlocks_Tests extends WP_UnitTestCase {
 		$this->assertTrue( array_key_exists( 'coblocks-editor', $wp_scripts->registered ) );
 
 	}
+
+	/**
+	 * Test all expected final build assets exist
+	 */
+	public function test_final_build_assets_exist() {
+
+		$expected_assets = [
+			'js'  => [
+				'dist/js/coblocks-accordion-polyfill.min.js',
+				'src/js/coblocks-accordion-polyfill.js',
+				'dist/blocks.build.js',
+				'dist/js/coblocks-masonry.min.js',
+				'src/js/coblocks-masonry.js',
+				'dist/js/vendors/flickity.min.js',
+				'src/js/vendors/flickity.js',
+				'dist/js/vendors/slick.min.js',
+				'src/js/vendors/slick.js',
+				'dist/js/coblocks-slick-initializer-front.min.js',
+				'src/js/coblocks-slick-initializer-front.js',
+				'dist/js/coblocks-lightbox.min.js',
+				'src/js/coblocks-lightbox.js',
+				'dist/js/coblocks-google-recaptcha.min.js',
+				'src/js/coblocks-google-recaptcha.js',
+				'dist/js/coblocks-datepicker.min.js',
+				'src/js/coblocks-datepicker.js',
+				'dist/js/coblocks-google-maps.min.js',
+				'src/js/coblocks-google-maps.js',
+			],
+			'css' => [
+				'dist/blocks.style.build.css',
+				'dist/blocks.editor.build.css',
+				// 'dist/utilities.style.build.css',
+			],
+		];
+
+		foreach ( $expected_assets as $asset_type => $assets ) {
+
+			foreach ( $assets as $path_to_asset ) {
+
+				$minfied_asset_string = ( false !== strpos( $path_to_asset, '.min' ) ) ? 'Minified' : 'Unminified';
+
+				$this->assertTrue(
+					file_exists( COBLOCKS_PLUGIN_DIR . $path_to_asset ),
+					"${minfied_asset_string} ${asset_type} asset not found: " . COBLOCKS_PLUGIN_DIR . "${path_to_asset}"
+				);
+
+				// Asset the assets exist when SCRIPT_DEBUG is true
+				// if ( 'js' === $asset_type ) {
+				//
+				// 	$path_to_unminified_js_asset = str_replace( '.min', '', str_replace( 'dist', 'src', $path_to_asset ) );
+				//
+				// 	$this->assertTrue(
+				// 		file_exists( $path_to_unminified_js_asset ),
+				// 		"Unminified ${asset_type} asset not found: ${path_to_unminified_js_asset}"
+				// 	);
+				//
+				// }
+
+			}
+
+		}
+
+	}
+
+
 }


### PR DESCRIPTION
After issue https://github.com/godaddy-wordpress/coblocks/issues/1215 came up, there was some discussion on how we could prevent issues like this in future.

This PR updates the PHPUnit test suite to now test for all build assets. This will help ensure that when we deploy new releases we're confident that our `js` and `css` assets exist in their intended locations.

Builds will take a little longer to complete, because we now need to install node dependencies and build the plugin inside of the CircleCI job, but this will give us additional confidence in our future releases.