### PR TITLE
Remove has-custom-size class from Typography Controls

### DIFF
--- a/src/extensions/typography/index.js
+++ b/src/extensions/typography/index.js
@@ -144,11 +144,7 @@ function applyFontSettings( extraProps, blockType, attributes ) {
 			extraProps.style = applyStyle( attributes, blockType.name );
 		}
 
-		const { customFontSize, fontFamily, lineHeight, fontWeight, letterSpacing, textTransform, noBottomSpacing, noTopSpacing } = attributes;
-
-		if ( customFontSize ) {
-			extraProps.className = classnames( extraProps.className, 'has-custom-size' );
-		}
+		const { fontFamily, lineHeight, fontWeight, letterSpacing, textTransform, noBottomSpacing, noTopSpacing } = attributes;
 
 		if ( fontFamily ) {
 			extraProps.className = classnames( extraProps.className, 'has-custom-font' );

--- a/src/extensions/typography/styles/style.scss
+++ b/src/extensions/typography/styles/style.scss
@@ -37,20 +37,6 @@
 	}
 }
 
-.wp-block-cover {
-	&.has-custom-size {
-		p {
-			font-size: inherit !important;
-		}
-	}
-
-	&.has-custom-lineheight {
-		p {
-			line-height: inherit !important;
-		}
-	}
-}
-
 .wp-block-button {
 	&.has-custom-lineheight {
 		.wp-block-button__link {


### PR DESCRIPTION
Resolves #1220 

This PR removes the `has-custom-size` class being added to blocks through the Typography Controls. This class provides zero value and is causing paragraphs with custom font sizes selected. Removing it solves the issue.