### PR TITLE
Add utility script that audits i18n strings against a wporg glossary

### DIFF
--- a/.dev/bin/wporg-glossary-audit
+++ b/.dev/bin/wporg-glossary-audit
@@ -1,0 +1,74 @@
+#!/usr/bin/env php
+<?php
+
+if ( ! isset( $argv[1], $argv[2] ) ) {
+	echo "Error: Missing required parameters.\n";
+	exit;
+}
+
+$msgids = json_decode( file_get_contents( $argv[1] ), true );
+
+if ( ! $msgids ) {
+	echo "Error: No msgid input data.\n";
+	exit;
+}
+
+$msgstrs = json_decode( file_get_contents( $argv[2] ), true );
+
+if ( ! $msgstrs ) {
+	echo "Error: No msgstr input data.\n";
+	exit;
+}
+
+$locale   = strtolower( pathinfo( str_replace( '_', '-', $argv[2] ), PATHINFO_FILENAME ) );
+$parts    = explode( '-', $locale );
+$locale   = ( ! empty( $parts[1] ) && $parts[0] === $parts[1] ) ? $parts[0] : $locale;
+$csv      = file_get_contents(
+	"https://translate.wordpress.org/locale/{$locale}/default/glossary/-export/",
+	false,
+	stream_context_create( [ 'ssl' => [ 'verify_peer' => false ] ] )
+);
+$glossary = array_map( 'str_getcsv', explode( "\n", $csv ) );
+
+array_shift( $glossary );
+
+$output = [];
+
+foreach ( $msgids as $hash => $msgid ) {
+	$output[ $hash ] = [
+		'en'    => $msgid,
+		$locale => $msgstrs[ $hash ],
+	];
+	foreach ( $glossary as $i => $rule ) {
+		if ( empty( $rule[0] ) || empty( $rule[1] ) || $msgid == $msgstrs[ $hash ] ) {
+			continue;
+		}
+		$pattern_1 = sprintf( '~\b%s\b~i', preg_quote( $rule[0] ) );
+		$word_list = array_map( 'preg_quote', array_map( 'trim', explode( '/', $rule[1] ) ) );
+		$pattern_2 = sprintf( '~\b%s\b~i', implode( '|', $word_list ) );
+		if ( preg_match( $pattern_1, strip_tags( $msgid ) ) && ! preg_match( $pattern_2, strip_tags( $msgstrs[ $hash ] ) ) ) {
+			$output[ $hash ]['glossary'][] = [
+				'en'    => $rule[0],
+				$locale => $rule[1],
+				'pos'   => $rule[2],
+				'info'  => $rule[3],
+			];
+		}
+	}
+}
+
+$output = array_filter( $output, function ( $v ) {
+	return ! empty( $v['glossary'] );
+} );
+
+$json = preg_replace_callback(
+	'/^ +/m',
+	function ( $m ) {
+		return str_repeat( ' ', strlen( $m[0] ) / 2 );
+	},
+	json_encode( $output, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT )
+);
+
+echo $json . "\n\n";
+printf( "Done. %d strings flagged.\n", count( $output ) );
+exit;


### PR DESCRIPTION
This PR adds a utility script that can be used to audit i18n strings against the WordPress.org Glossary for the given locale. It is meant to be run locally and flag any strings potentially not following the Glossary so a human (preferably a native speaker of the locale in question) can manually review the part of speech (noun, verb, adjective, etc) and whether the translation is OK or not.

This program accepts 2 arguments:

1. Path to a JSON file of English source strings
2. Path to a JSON file of translated Locale strings

**Note: The WordPress.org locale will be determined by the filename of the 2nd argument!**
e.g. `es_ES.json = es` and `es_MX.json = es-mx`

**Example:**

```sh
$ .dev/bin/wporg-glossary-audit languages/coblocks.json languages/es_ES.json
```

^ This will check all `es_ES` CoBlocks strings against the Glossary found at https://translate.wordpress.org/locale/es/default/glossary/

**Result:**

```json
{
  "6956038c79101484e0bb8bab87357442": {
    "en": "Toggle to show the publish date.",
    "es": "Alternar para mostrar la fecha de publicación.",
    "glossary": [
      {
        "en": "toggle",
        "es": "conmutador",
        "pos": "noun",
        "info": ""
      }
    ]
  },
  "fee8ee71554f9edb44051fb9de318739": {
    "en": "Post Content",
    "es": "Contenido de la publicación",
    "glossary": [
      {
        "en": "Post",
        "es": "Entrada",
        "pos": "noun",
        "info": ""
      }
    ]
  },
  "7eca39de358415bfb69b727a9557cd1c": {
    "en": "RSS Feed",
    "es": "Fuente de RSS",
    "glossary": [
      {
        "en": "RSS Feed",
        "es": "Feed RSS",
        "pos": "noun",
        "info": "No se traduce. Se refiere al feed RSS."
      }
    ]
  }
}

Done. 3 strings flagged.
```
