### PR TITLE
Improve Post Carousel block stability through transforms testing 

### DIFF
--- a/src/blocks/post-carousel/test/transforms.spec.js
+++ b/src/blocks/post-carousel/test/transforms.spec.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import metadata from '../block.json';
+import { name, settings } from '../index';
+import { name as postsBlockName, settings as postsBlockSettings } from '../../posts/index';
+
+describe( 'coblocks/post-carousel transforms', () => {
+	// Shared attributes
+	const attributes = {
+		align: 'center',
+		columns: 3,
+		displayPostContent: true,
+		displayPostContentRadio: 'excerpt',
+		displayPostDate: true,
+		excerptLength: 55,
+		order: 'desc',
+		orderBy: 'date',
+		postLayout: 'list',
+		postsToShow: 14,
+	};
+
+	settings.attributes = metadata.attributes;
+
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform from core/latest-posts block', () => {
+		const coreLatestPosts = createBlock( 'core/latest-posts', attributes );
+		const transformed = switchToBlockType( coreLatestPosts, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( name );
+		expect( transformed[ 0 ].attributes.order ).toBe( attributes.order );
+		expect( transformed[ 0 ].attributes.orderBy ).toBe( attributes.orderBy );
+		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+	} );
+
+	it( 'should transform from coblocks/posts block', () => {
+		registerBlockType( postsBlockName, { category: 'common', ...postsBlockSettings } );
+
+		const coblocksPosts = createBlock( 'coblocks/posts', attributes );
+		const transformed = switchToBlockType( coblocksPosts, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( name );
+		expect( transformed[ 0 ].attributes.order ).toBe( attributes.order );
+		expect( transformed[ 0 ].attributes.orderBy ).toBe( attributes.orderBy );
+		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+	} );
+
+	it( 'should transform to core/latest-posts block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'core/latest-posts' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( 'core/latest-posts' );
+		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+	} );
+} );
+

--- a/src/blocks/post-carousel/test/transforms.spec.js
+++ b/src/blocks/post-carousel/test/transforms.spec.js
@@ -10,6 +10,7 @@ registerCoreBlocks();
  * Internal dependencies.
  */
 import metadata from '../block.json';
+import postsMetadata from '../../posts/block.json';
 import { name, settings } from '../index';
 import { name as postsBlockName, settings as postsBlockSettings } from '../../posts/index';
 
@@ -19,12 +20,10 @@ describe( 'coblocks/post-carousel transforms', () => {
 		align: 'center',
 		columns: 3,
 		displayPostContent: true,
-		displayPostContentRadio: 'excerpt',
 		displayPostDate: true,
 		excerptLength: 55,
 		order: 'desc',
 		orderBy: 'date',
-		postLayout: 'list',
 		postsToShow: 14,
 	};
 
@@ -47,6 +46,7 @@ describe( 'coblocks/post-carousel transforms', () => {
 	} );
 
 	it( 'should transform from coblocks/posts block', () => {
+		postsBlockSettings.attributes = postsMetadata.attributes;
 		registerBlockType( postsBlockName, { category: 'common', ...postsBlockSettings } );
 
 		const coblocksPosts = createBlock( 'coblocks/posts', attributes );
@@ -57,6 +57,11 @@ describe( 'coblocks/post-carousel transforms', () => {
 		expect( transformed[ 0 ].attributes.order ).toBe( attributes.order );
 		expect( transformed[ 0 ].attributes.orderBy ).toBe( attributes.orderBy );
 		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+		expect( transformed[ 0 ].attributes.columns ).toBe( attributes.columns );
+		expect( transformed[ 0 ].attributes.excerptLength ).toBe( attributes.excerptLength );
+		expect( transformed[ 0 ].attributes.postsToShow ).toBe( attributes.postsToShow );
+		expect( transformed[ 0 ].attributes.displayPostContent ).toBe( attributes.displayPostContent );
+		expect( transformed[ 0 ].attributes.displayPostDate ).toBe( attributes.displayPostDate );
 	} );
 
 	it( 'should transform to core/latest-posts block', () => {


### PR DESCRIPTION
New Transforms tests for Post Carousel block.

Test changes using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/post-carousel/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/post-carousel/test/transforms.spec.js
  coblocks/post-carousel transforms
    ✓ should transform from core/latest-posts block (2ms)
    ✓ should transform from coblocks/posts block (1ms)
    ✓ should transform to core/latest-posts block (1ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        3.371s, estimated 4s
```