### PR TITLE
Improve Posts block stability through transforms testing

### DIFF
--- a/src/blocks/posts/test/transforms.spec.js
+++ b/src/blocks/posts/test/transforms.spec.js
@@ -11,6 +11,7 @@ registerCoreBlocks();
  */
 import * as helpers from '../../../../.dev/tests/jest/helpers';
 import metadata from '../block.json';
+import postCarouselMetadata from '../../post-carousel/block.json';
 import { name, settings } from '../index';
 import { name as postsCarouselBlockName, settings as postsCarouselBlockSettings } from '../../post-carousel/index';
 
@@ -20,12 +21,10 @@ describe( 'coblocks/posts transforms', () => {
 		align: 'center',
 		columns: 3,
 		displayPostContent: true,
-		displayPostContentRadio: 'excerpt',
 		displayPostDate: true,
 		excerptLength: 55,
 		order: 'desc',
 		orderBy: 'date',
-		postLayout: 'list',
 		postsToShow: 14,
 	};
 
@@ -48,6 +47,7 @@ describe( 'coblocks/posts transforms', () => {
 	} );
 
 	it( 'should transform from coblocks/post-carousel block', () => {
+		postsCarouselBlockSettings.attributes = postCarouselMetadata.attributes;
 		registerBlockType( postsCarouselBlockName, { category: 'common', ...postsCarouselBlockSettings } );
 
 		const coblocksPostCarousel = createBlock( 'coblocks/post-carousel', attributes );
@@ -58,6 +58,11 @@ describe( 'coblocks/posts transforms', () => {
 		expect( transformed[ 0 ].attributes.order ).toBe( attributes.order );
 		expect( transformed[ 0 ].attributes.orderBy ).toBe( attributes.orderBy );
 		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+		expect( transformed[ 0 ].attributes.columns ).toBe( attributes.columns );
+		expect( transformed[ 0 ].attributes.excerptLength ).toBe( attributes.excerptLength );
+		expect( transformed[ 0 ].attributes.postsToShow ).toBe( attributes.postsToShow );
+		expect( transformed[ 0 ].attributes.displayPostContent ).toBe( attributes.displayPostContent );
+		expect( transformed[ 0 ].attributes.displayPostDate ).toBe( attributes.displayPostDate );
 	} );
 
 	it( 'should transform to core/latest-posts block', () => {

--- a/src/blocks/posts/test/transforms.spec.js
+++ b/src/blocks/posts/test/transforms.spec.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import metadata from '../block.json';
+import { name, settings } from '../index';
+import { name as postsCarouselBlockName, settings as postsCarouselBlockSettings } from '../../post-carousel/index';
+
+describe( 'coblocks/posts transforms', () => {
+	// Shared attributes
+	const attributes = {
+		align: 'center',
+		columns: 3,
+		displayPostContent: true,
+		displayPostContentRadio: 'excerpt',
+		displayPostDate: true,
+		excerptLength: 55,
+		order: 'desc',
+		orderBy: 'date',
+		postLayout: 'list',
+		postsToShow: 14,
+	};
+
+	settings.attributes = metadata.attributes;
+
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform from core/latest-posts block', () => {
+		const coreLatestPosts = createBlock( 'core/latest-posts', attributes );
+		const transformed = switchToBlockType( coreLatestPosts, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( name );
+		expect( transformed[ 0 ].attributes.order ).toBe( attributes.order );
+		expect( transformed[ 0 ].attributes.orderBy ).toBe( attributes.orderBy );
+		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+	} );
+
+	it( 'should transform from coblocks/post-carousel block', () => {
+		registerBlockType( postsCarouselBlockName, { category: 'common', ...postsCarouselBlockSettings } );
+
+		const coblocksPostCarousel = createBlock( 'coblocks/post-carousel', attributes );
+		const transformed = switchToBlockType( coblocksPostCarousel, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( name );
+		expect( transformed[ 0 ].attributes.order ).toBe( attributes.order );
+		expect( transformed[ 0 ].attributes.orderBy ).toBe( attributes.orderBy );
+		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+	} );
+
+	it( 'should transform to core/latest-posts block', () => {
+		const block = createBlock( name, attributes );
+		const transformed = switchToBlockType( block, 'core/latest-posts' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( 'core/latest-posts' );
+		expect( transformed[ 0 ].attributes.align ).toBe( attributes.align );
+	} );
+	it( 'should transform when :posts prefix is seen', () => {
+		const block = helpers.performPrefixTransformation( name, ':posts', ':posts' );
+
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+		expect( block.attributes.order ).toBe( attributes.order );
+		expect( block.attributes.orderBy ).toBe( attributes.orderBy );
+	} );
+
+	// Should allow transform when prefixed with 2-6 numerals.
+	for ( let i = 2; i <= 6; i++ ) {
+		const prefix = ':' + i + 'posts';
+		it( `should transform when ${ prefix } prefix is seen`, () => {
+			const block = helpers.performPrefixTransformation( name, prefix, prefix );
+
+			expect( block.isValid ).toBe( true );
+			expect( block.name ).toBe( name );
+			expect( block.attributes.postsToShow ).toBe( i );
+			expect( block.attributes.order ).toBe( attributes.order );
+			expect( block.attributes.orderBy ).toBe( attributes.orderBy );
+		} );
+	}
+} );


### PR DESCRIPTION
New Transforms tests for Posts block.

Test changes using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/posts/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/posts/test/transforms.spec.js
  coblocks/posts transforms
    ✓ should transform from core/latest-posts block (3ms)
    ✓ should transform from coblocks/post-carousel block (1ms)
    ✓ should transform to core/latest-posts block (1ms)
    ✓ should transform when :posts prefix is seen (2ms)
    ✓ should transform when :2posts prefix is seen (1ms)
    ✓ should transform when :3posts prefix is seen (1ms)
    ✓ should transform when :4posts prefix is seen
    ✓ should transform when :5posts prefix is seen (1ms)
    ✓ should transform when :6posts prefix is seen

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        3.103s
```