### PR TITLE
Improve Row block stability through transforms testing

### DIFF
--- a/src/blocks/row/test/transforms.spec.js
+++ b/src/blocks/row/test/transforms.spec.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+describe( 'coblocks/row transforms', () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform when :row prefix is seen', () => {
+		const block = helpers.performPrefixTransformation( name, ':row', ':row' );
+
+		expect( block.isValid ).toBe( true );
+		expect( block.name ).toBe( name );
+	} );
+
+	// Should allow transform when prefixed with 2-4 colons.
+	for ( let i = 2; i <= 4; i++ ) {
+		const prefix = Array( i + 1 ).join( ':' ) + 'row';
+		it( `should transform when ${ prefix } prefix is seen`, () => {
+			const block = helpers.performPrefixTransformation( name, prefix, prefix );
+
+			expect( block.isValid ).toBe( true );
+			expect( block.name ).toBe( name );
+			expect( block.attributes.columns ).toBe( i );
+		} );
+	}
+} );


### PR DESCRIPTION
New Transforms tests for Row block.

Test changes using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/row/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/row/test/transforms.spec.js
  coblocks/row transforms
    ✓ should transform when :row prefix is seen (2ms)
    ✓ should transform when ::row prefix is seen
    ✓ should transform when :::row prefix is seen (1ms)
    ✓ should transform when ::::row prefix is seen

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        3.257s
```