### PR TITLE
Improve Share and Social-Profiles block stability through transforms testing

### DIFF
--- a/src/blocks/share/block.json
+++ b/src/blocks/share/block.json
@@ -78,7 +78,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"youtube": {
+		"google": {
 			"type": "boolean",
 			"default": false
 		}

--- a/src/blocks/share/test/save.spec.js
+++ b/src/blocks/share/test/save.spec.js
@@ -99,11 +99,11 @@ describe( name, () => {
 		expect( serializedBlock ).toContain( JSON.stringify( { email: true } ) );
 	} );
 
-	it( 'should render with YouTube link', () => {
-		block.attributes.youtube = true;
+	it( 'should render with Google link', () => {
+		block.attributes.google = true;
 		serializedBlock = serialize( block );
 
 		expect( serializedBlock ).toBeDefined();
-		expect( serializedBlock ).toContain( JSON.stringify( { youtube: true } ) );
+		expect( serializedBlock ).toContain( JSON.stringify( { google: true } ) );
 	} );
 } );

--- a/src/blocks/share/test/save.spec.js
+++ b/src/blocks/share/test/save.spec.js
@@ -37,7 +37,7 @@ describe( name, () => {
 			tumblr: false,
 			reddit: false,
 			email: false,
-			youtube: false,
+			google: false,
 		} );
 		serializedBlock = serialize( block );
 		expect( serializedBlock ).toEqual( `<!-- wp:${ name } ${ JSON.stringify( { twitter: false, facebook: false, pinterest: false } ) } /-->` );

--- a/src/blocks/social-profiles/test/transforms.spec.js
+++ b/src/blocks/social-profiles/test/transforms.spec.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerBlockType, createBlock, switchToBlockType } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+/**
+ * Internal dependencies.
+ */
+import metadata from '../block.json';
+import shareMetadata from '../../share/block.json';
+import { name, settings } from '../index';
+import { name as shareName, settings as shareSettings } from '../../share/';
+
+describe( 'coblocks/shape-divider transforms', () => {
+	// social-profiles attributes
+	const socialAttributes = {
+		facebook: 'facebook.com',
+		twitter: 'twitter.com',
+		pinterest: 'pinterest.com',
+		linkedin: 'linkedin.com',
+		instagram: 'instagram.com',
+		houzz: 'houzz.com',
+		yelp: 'yelp.com',
+		youtube: 'youtube.com',
+	};
+
+	// share attributes
+	const shareAttributes = {
+		facebook: true,
+		twitter: true,
+		pinterest: true,
+		linkedin: true,
+		email: true,
+		tumblr: true,
+		google: true,
+		reddit: true,
+	};
+
+	beforeAll( () => {
+		// Register the block.
+		settings.attributes = metadata.attributes;
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	it( 'should transform from coblocks/social (share) block', () => {
+		shareSettings.attributes = shareMetadata.attributes;
+		registerBlockType( shareName, { category: 'common', ...shareSettings } );
+
+		const coblocksShare = createBlock( 'coblocks/social', shareAttributes );
+		const transformed = switchToBlockType( coblocksShare, name );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( name );
+	} );
+
+	it( 'should transform to coblocks/social (share) block', () => {
+		const block = createBlock( name, socialAttributes );
+		const transformed = switchToBlockType( block, 'coblocks/social' );
+
+		expect( transformed[ 0 ].isValid ).toBe( true );
+		expect( transformed[ 0 ].name ).toBe( 'coblocks/social' );
+		for ( const property in shareAttributes ) {
+			expect( transformed[ 0 ].attributes[ property ] ).toBe( shareAttributes[ property ] );
+		}
+	} );
+
+	it( 'should maintain attribute values in localStorage with transforms', () => {
+		const block = createBlock( name, socialAttributes );
+		const firstTransformed = switchToBlockType( block, 'coblocks/social' );
+		expect( firstTransformed[ 0 ].isValid ).toBe( true );
+		expect( firstTransformed[ 0 ].name ).toBe( 'coblocks/social' );
+		for ( const property in shareAttributes ) {
+			expect( firstTransformed[ 0 ].attributes[ property ] ).toBe( shareAttributes[ property ] );
+		}
+
+		const secondTransformed = switchToBlockType( firstTransformed, 'coblocks/social-profiles' );
+		expect( secondTransformed[ 0 ].isValid ).toBe( true );
+		expect( secondTransformed[ 0 ].name ).toBe( 'coblocks/social-profiles' );
+		for ( const property in socialAttributes ) {
+			expect( secondTransformed[ 0 ].attributes[ property ] ).toBe( socialAttributes[ property ] );
+		}
+	} );
+} );

--- a/src/blocks/social-profiles/transforms.js
+++ b/src/blocks/social-profiles/transforms.js
@@ -101,7 +101,11 @@ export const transforms = {
 						'houzz',
 						attributes
 					),
-					yelp: getPreviousAttributes( 'social-profiles', 'yelp', attributes ),
+					yelp: getPreviousAttributes(
+						'social-profiles',
+						'yelp',
+						attributes
+					),
 					youtube: getPreviousAttributes(
 						'social-profiles',
 						'youtube',


### PR DESCRIPTION
All transforms to and from these blocks are housed in the Social-Profiles block source at transforms.js. Made a minor fix to attribute names that are used in the Share block. This Jest test also tests that localStorage is working as expected.

New Transforms tests for Social-Profiles and Share blocks.

Test changes using
```bash
npx jest --config .dev/tests/jest/jest.config.js ./src/blocks/social-profiles/test/transforms.spec.js 
```

```javascript
 PASS  src/blocks/social-profiles/test/transforms.spec.js
  coblocks/shape-divider transforms
    ✓ should transform from coblocks/social (share) block (3ms)
    ✓ should transform to coblocks/social (share) block (2ms)
    ✓ should maintain attribute values in localStorage with transforms (2ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        3.494s
```