### PR TITLE
Set Features block max count to four

### DIFF
--- a/src/blocks/features/inspector.js
+++ b/src/blocks/features/inspector.js
@@ -115,7 +115,7 @@ class Inspector extends Component {
 								wp.data.dispatch( 'core/block-editor' ).selectBlock( clientId );
 							} }
 							min={ 1 }
-							max={ 3 }
+							max={ 4 }
 						/>
 						<DimensionsControl { ...this.props }
 							type={ 'margin' }


### PR DESCRIPTION
This PR updated the max column count for the Features block from `3` to `4`. This provides a consistent columns experience across our blocks.