### PR TITLE
Add huge setting to the Features block gutter control

### DIFF
--- a/src/blocks/features/inspector.js
+++ b/src/blocks/features/inspector.js
@@ -86,6 +86,7 @@ class Inspector extends Component {
 			{ value: 'small', label: __( 'Small', 'coblocks' ) },
 			{ value: 'medium', label: __( 'Medium', 'coblocks' ) },
 			{ value: 'large', label: __( 'Large', 'coblocks' ) },
+			{ value: 'huge', label: __( 'Huge', 'coblocks' ) },
 		];
 
 		return (


### PR DESCRIPTION
This PR adds a new "huge" setting to the Features block gutter control. By doing so, we're allowing consistent gutter sizes across all our blocks that support them. 