### PR TITLE
Canary release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,9 +340,8 @@ jobs:
       - deploy:
           name: Deploy the plugin
           command: |
-            PLUGIN_VERSION=$(grep '"version":' package.json -m1 | cut -d\" -f4)
             # Deploy a Coblocks Github pre-release
-            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete ${PLUGIN_VERSION}-canary /tmp/artifacts/go-canary.zip
+            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete go-canary -prerelease -replace /tmp/artifacts/go-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,9 @@ jobs:
             - "0e:f8:0a:19:88:42:c3:5a:b9:82:17:34:6b:40:68:21"
       - checkout
       - run:
+          name: Add Heroku to known_hosts
+          command: ssh-keyscan -H a90.8f7.myftpupload.com >> ~/.ssh/known_hosts
+      - run:
           name: Update npm
           command: sudo npm install -g npm@latest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ jobs:
       - run:
           name: Deploy CoBlocks to the test server
           command: |
-            rsync --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
+            rsync --stats --delete -avz -e "ssh -p22" ./build/coblocks/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
           name: Create a canary release on Github
           command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace canary /tmp/artifacts/coblocks-canary.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,10 +301,10 @@ jobs:
     docker:
       - image: circleci/golang:latest-node-browsers-legacy
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "73:17:41:85:6e:96:47:ff:85:73:df:c0:bf:06:85:9f"
       - checkout
-      - run:
-          name: Add test server to the known hosts file
-          command: ssh-keyscan 198.71.233.109 >> ~/.ssh/known_hosts
       - run:
           name: Update npm
           command: sudo npm install -g npm@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
             - e2e
           filters:
             tags:
-              only: /.*/
+              only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*)?(\+[0-9-]+(\.[0-9]+)*)?/ # Run on semantic version tags only
             branches:
               ignore: /.*/
 
@@ -359,12 +359,6 @@ jobs:
       - image: circleci/golang:latest-node-browsers-legacy
     steps:
       - checkout
-      - run:
-          name: Determine if this is a canary build
-          command: |
-            if [[ ${CIRCLE_TAG} == *"canary"* ]]; then
-              circleci-agent step halt
-            fi
       - run:
           name: Update npm
           command: sudo npm install -g npm@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,12 +336,12 @@ jobs:
             mkdir -p /tmp/artifacts
             grunt build
             grunt compress
-            mv build/*.zip /tmp/artifacts/go-canary.zip
+            mv build/*.zip /tmp/artifacts/coblocks-canary.zip
       - deploy:
           name: Deploy the plugin
           command: |
             # Deploy a Coblocks Github pre-release
-            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete -prerelease -replace go-canary /tmp/artifacts/go-canary.zip
+            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,8 +351,8 @@ jobs:
           command: |
             rsync --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
-          name: Create a CoBlocks-canary release on Github
-          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
+          name: Create a canary release on Github
+          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace canary /tmp/artifacts/coblocks-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
       - canary-release:
           filters:
             branches:
-              only: canary-release
+              only: master
       - i18n:
           filters:
             branches:
@@ -306,7 +306,7 @@ jobs:
             - "0e:f8:0a:19:88:42:c3:5a:b9:82:17:34:6b:40:68:21"
       - checkout
       - run:
-          name: Add Heroku to known_hosts
+          name: Add CoBlocks staging site to known_hosts
           command: ssh-keyscan -H a90.8f7.myftpupload.com >> ~/.ssh/known_hosts
       - run:
           name: Update npm
@@ -351,10 +351,8 @@ jobs:
           command: |
             rsync --dry-run --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
-          name: Deploy the plugin
-          command: |
-            # Deploy a Coblocks Github pre-release
-            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the `master` branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
+          name: Create a CoBlocks-canary release on Github
+          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the `master` branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,10 +304,13 @@ jobs:
       - checkout
       - run:
           name: Add test server to the known hosts file
-          command: ssh-keyscan a90.8f7.myftpupload.com >> ~/.ssh/known_hosts
+          command: ssh-keyscan ${STAGING_SITE_PORT} >> ~/.ssh/known_hosts
       - run:
           name: Update npm
           command: sudo npm install -g npm@latest
+      - run:
+          name: Install rsync
+          command: sudo apt install rsync
       - run:
           name: Install Grunt.js
           command: sudo npm install -g grunt-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ jobs:
             rsync --dry-run --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
           name: Create a CoBlocks-canary release on Github
-          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the `master` branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
+          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
           name: Deploy the plugin
           command: |
             # Deploy a Coblocks Github pre-release
-            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
+            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the `master` branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "73:17:41:85:6e:96:47:ff:85:73:df:c0:bf:06:85:9f" 
+            - "0e:f8:0a:19:88:42:c3:5a:b9:82:17:34:6b:40:68:21"
       - checkout
       - run:
           name: Update npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
       - canary-release:
           filters:
             branches:
-              only: canary-release
+              only: master
       - i18n:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ jobs:
       - run:
           name: Deploy CoBlocks to the test server
           command: |
-            rsync --dry-run --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
+            rsync --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
           name: Create a CoBlocks-canary release on Github
           command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace CoBlocks-canary /tmp/artifacts/coblocks-canary.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
           name: Deploy the plugin
           command: |
             # Deploy a Coblocks Github pre-release
-            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete go-canary -prerelease -replace /tmp/artifacts/go-canary.zip
+            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete -prerelease -replace go-canary /tmp/artifacts/go-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "73:17:41:85:6e:96:47:ff:85:73:df:c0:bf:06:85:9f"
+            - "73:17:41:85:6e:96:47:ff:85:73:df:c0:bf:06:85:9f" 
       - checkout
       - run:
           name: Update npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
       - checkout
       - run:
           name: Add test server to the known hosts file
-          command: ssh-keyscan ${STAGING_SITE_PORT} >> ~/.ssh/known_hosts
+          command: ssh-keyscan 198.71.233.109 >> ~/.ssh/known_hosts
       - run:
           name: Update npm
           command: sudo npm install -g npm@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Add test server to the known hosts file
+          command: ssh-keyscan a90.8f7.myftpupload.com >> ~/.ssh/known_hosts
+      - run:
           name: Update npm
           command: sudo npm install -g npm@latest
       - run:
@@ -337,6 +340,10 @@ jobs:
             grunt build
             grunt compress
             mv build/*.zip /tmp/artifacts/coblocks-canary.zip
+      - run:
+          name: Deploy CoBlocks to the test server
+          command: |
+            rsync --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
           name: Deploy the plugin
           command: |
@@ -348,6 +355,12 @@ jobs:
       - image: circleci/golang:latest-node-browsers-legacy
     steps:
       - checkout
+      - run:
+          name: Determine if this is a canary build
+          command: |
+            if [[ ${CIRCLE_TAG} == *"canary"* ]]; then
+              circleci-agent step halt
+            fi
       - run:
           name: Update npm
           command: sudo npm install -g npm@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
       - canary-release:
           filters:
             branches:
-              only: master
+              only: canary-release
       - i18n:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - canary-release:
+          filters:
+            branches:
+              only: canary-release
       - i18n:
           filters:
             branches:
@@ -292,6 +296,53 @@ jobs:
               git push origin master --quiet
             fi
           path: ~/coblocks
+
+  canary-release:
+    docker:
+      - image: circleci/golang:latest-node-browsers-legacy
+    steps:
+      - checkout
+      - run:
+          name: Update npm
+          command: sudo npm install -g npm@latest
+      - run:
+          name: Install Grunt.js
+          command: sudo npm install -g grunt-cli
+      - run:
+          name: Install SVN
+          command: sudo apt-get update && sudo apt-get install subversion
+      - run:
+          name: Install PHP
+          command: sudo apt-get install php libapache2-mod-php php-mbstring
+      - run:
+          name: Install gettext
+          command: sudo apt-get install gettext
+      - run:
+          name: Install WPCLI
+          command: |
+            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            chmod +x wp-cli.phar
+            sudo mv wp-cli.phar /usr/local/bin/wp
+      - run:
+          name: Install ghr
+          command: |
+            go get -u github.com/tcnksm/ghr
+      - run:
+          name: Install node packages
+          command: npm install
+      - run:
+          name: Build the plugin
+          command: |
+            mkdir -p /tmp/artifacts
+            grunt build
+            grunt compress
+            mv build/*.zip /tmp/artifacts/go-canary.zip
+      - deploy:
+          name: Deploy the plugin
+          command: |
+            PLUGIN_VERSION=$(grep '"version":' package.json -m1 | cut -d\" -f4)
+            # Deploy a Coblocks Github pre-release
+            ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "${CHANGELOG}" -delete ${PLUGIN_VERSION}-canary /tmp/artifacts/go-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Deploy CoBlocks to the test server
           command: |
-            rsync --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
+            rsync --dry-run --stats --delete -avz -e "ssh -p22" ./build/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
       - deploy:
           name: Deploy the plugin
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,23 +7,23 @@ workflows:
       - php56:
           filters:
             tags:
-              only: /.*/
+              only: /^(?!canary).*$/
       - php72: # Will be deprecated on 30 Nov 2020
           filters:
             tags:
-              only: /.*/
+              only: /^(?!canary).*$/
       - jest:
           filters:
             tags:
-              only: /.*/
+              only: /^(?!canary).*$/
       - e2e:
           filters:
             tags:
-              only: /.*/
+              only: /^(?!canary).*$/
       - canary-release:
           filters:
             branches:
-              only: canary-release
+              only: master
       - i18n:
           filters:
             branches:


### PR DESCRIPTION
- Run a canary build on each commit to master, which is them tagged as a `pre-release` here on Github as a `CoBlocks-canary` release.
- Deploy the CoBlocks-canary build to the CoBlocks staging site for testing.
- Switch the regex on the `deploy` job to run on semantic version tags only.

### Pre-release
![image](https://user-images.githubusercontent.com/5321364/72447359-3654ec00-3783-11ea-932a-188d2fc44205.png)

### Deploy
![image](https://user-images.githubusercontent.com/5321364/72391543-6f497e00-36fb-11ea-91f9-7eb0b08c41c0.png)
_(see job https://circleci.com/gh/godaddy-wordpress/coblocks/8089)_