### PR TITLE
Remove Typography controls from the core Cover block

### DIFF
--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -21,7 +21,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { DOWN } from '@wordpress/keycodes';
-import { RangeControl, withFallbackStyles, ToggleControl, Dropdown, IconButton, SelectControl } from '@wordpress/components';
+import { RangeControl, withFallbackStyles, ToggleControl, Dropdown, IconButton, SelectControl, Toolbar } from '@wordpress/components';
 
 /**
  * Export
@@ -52,12 +52,19 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
  */
 class TypographyControls extends Component {
 	render() {
+		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight', 'coblocks/features' ];
+
 		const {
 			attributes,
 			setAttributes,
 			icon = icons.typography,
 			label = __( 'Change typography', 'coblocks' ),
 		} = this.props;
+
+		// Show line height on appropriate blocks.
+		if ( ! allowedBlocks.includes( this.props.name ) ) {
+			return null;
+		}
 
 		const {
 			customFontSize,
@@ -137,7 +144,7 @@ class TypographyControls extends Component {
 		};
 
 		return (
-			<Fragment>
+			<Toolbar>
 				<Dropdown
 					className={ classnames( 'components-dropdown-menu', 'components-coblocks-typography-dropdown' ) }
 					contentClassName="components-dropdown-menu__popover components-coblocks-typography-dropdown"
@@ -243,7 +250,7 @@ class TypographyControls extends Component {
 						</Fragment>
 					) }
 				/>
-			</Fragment>
+			</Toolbar>
 		);
 	}
 }

--- a/src/extensions/typography/controls.js
+++ b/src/extensions/typography/controls.js
@@ -10,7 +10,6 @@ import TypographyControls from './../../components/typography-controls';
  */
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
 
 class Controls extends Component {
 	render() {
@@ -24,7 +23,7 @@ class Controls extends Component {
 		}
 
 		let hideToolbar = false;
-		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight', 'coblocks/features' ];
+		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/cover', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight', 'coblocks/features' ];
 
 		attributes.textPanelHideColor = true;
 		attributes.textPanelShowSpacingControls = true;
@@ -58,9 +57,7 @@ class Controls extends Component {
 			return (
 				<Fragment>
 					<BlockControls>
-						<Toolbar>
-							<TypographyControls { ...this.props } />
-						</Toolbar>
+						<TypographyControls { ...this.props } />
 					</BlockControls>
 				</Fragment>
 			);

--- a/src/extensions/typography/controls.js
+++ b/src/extensions/typography/controls.js
@@ -8,7 +8,7 @@ import TypographyControls from './../../components/typography-controls';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 
 class Controls extends Component {
@@ -55,11 +55,9 @@ class Controls extends Component {
 
 		if ( ! hideToolbar ) {
 			return (
-				<Fragment>
-					<BlockControls>
-						<TypographyControls { ...this.props } />
-					</BlockControls>
-				</Fragment>
+				<BlockControls>
+					<TypographyControls { ...this.props } />
+				</BlockControls>
 			);
 		}
 

--- a/src/extensions/typography/controls.js
+++ b/src/extensions/typography/controls.js
@@ -24,7 +24,7 @@ class Controls extends Component {
 		}
 
 		let hideToolbar = false;
-		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/cover', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight', 'coblocks/features' ];
+		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight', 'coblocks/features' ];
 
 		attributes.textPanelHideColor = true;
 		attributes.textPanelShowSpacingControls = true;

--- a/src/extensions/typography/index.js
+++ b/src/extensions/typography/index.js
@@ -20,7 +20,7 @@ import { addFilter } from '@wordpress/hooks';
 import { Fragment }	from '@wordpress/element';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 
-const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/cover', 'core/pullquote', 'core/quote', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/highlight', 'coblocks/pricing-table', 'coblocks/features' ];
+const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/pullquote', 'core/quote', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/highlight', 'coblocks/pricing-table', 'coblocks/features' ];
 
 /**
  * Filters registered block settings, extending attributes with settings

--- a/src/extensions/typography/index.js
+++ b/src/extensions/typography/index.js
@@ -20,7 +20,7 @@ import { addFilter } from '@wordpress/hooks';
 import { Fragment }	from '@wordpress/element';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 
-const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/pullquote', 'core/quote', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/highlight', 'coblocks/pricing-table', 'coblocks/features' ];
+const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/pullquote', 'core/cover', 'core/quote', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/highlight', 'coblocks/pricing-table', 'coblocks/features' ];
 
 /**
  * Filters registered block settings, extending attributes with settings


### PR DESCRIPTION
This PR removes the Typography controls from the core Cover block, as the Cover block contains InnerBlocks blocks which already have Type controls.

Closes #947.