### PR TITLE
Remove the separate utilities stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,6 @@ The vision for CoBlocks is to create a suite of WordPress blocks and tools to he
 
 ### Advanced Controls
 
-Disable CoBlocks utility styes with an optional filter.
-```php
-/**
- * Disable block utility styles.
- */
-add_filter( 'coblocks_utility_styles_enabled', '__return_false' );
-```
-
 Disable sending of email upon Form block submission.
 ```php
 /**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -75,24 +75,6 @@ class CoBlocks_Block_Assets {
 			array(),
 			COBLOCKS_VERSION
 		);
-
-		/**
-		 * Filters whether to load utility styles.
-		 *
-		 * @param bool $load_utility_styles whether the utility css should be loaded. Default false.
-		 */
-		$load_utility_styles = (bool) apply_filters( 'coblocks_utility_styles_enabled', false );
-
-		if ( $load_utility_styles ) {
-
-			// Mock wp_enqueue_style for utility styles.
-			wp_enqueue_style(
-				$this->slug . '-utilities',
-				$this->url . '/dist/utilities.style.build.css',
-				array(),
-				COBLOCKS_VERSION
-			);
-		};
 	}
 
 	/**


### PR DESCRIPTION
Now that #1253 is incoming, and we're working towards potentially using CSS properties to declare spacing utils, we don't need a separate utilities stylesheet. This PR removes the filter and wp_enqueue_style() that we added in preparation. 