### PR TITLE
E2E Compatibility Refactor

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -7,77 +7,67 @@ import { wpUsername, wpPassword, testURL } from './constants';
  * Login to our test WordPress site
  */
 export function loginToSite() {
+	cy.get( 'html' ).then( ( $html ) => {
+		// Editor page, do nothing.
+		if ( $html.find( '.block-editor-page' ).length ) {
 
-  cy.get( 'html' ).then( ( $html ) => {
+		} else {
+			cy.visit( testURL + '/wp-admin' );
 
-    // Editor page, do nothing.
-    if ( $html.find( '.block-editor-page' ).length ) {
+			cy.url().then( ( $url ) => {
+				if ( $url.includes( '/wp-login.php' ) ) {
+					cy.wait( 2000 );
 
-      return;
+					cy.get( '#user_login' )
+						.type( wpUsername );
 
-    } else {
+					cy.get( '#user_pass' )
+						.type( wpPassword );
 
-      cy.visit( testURL + '/wp-admin' );
+					cy.get( '#wp-submit' )
+						.click();
 
-      cy.url().then( ( $url ) => {
-
-        if ( $url.includes( '/wp-login.php' ) ) {
-
-          cy.wait( 2000 );
-
-          cy.get( '#user_login' )
-            .type( wpUsername );
-
-          cy.get( '#user_pass' )
-            .type( wpPassword );
-
-          cy.get( '#wp-submit' )
-            .click();
-
-          cy.get( '.wrap h1' )
-            .should( 'contain', 'Dashboard' );
-        }
-
-      } );
-
-    }
-
-  } );
-
+					cy.get( '.wrap h1' )
+						.should( 'contain', 'Dashboard' );
+				}
+			} );
+		}
+	} );
 }
 
 /**
  * Create a new post to add blocks to
  */
 export function createNewPost() {
+	cy.visit( testURL + '/wp-admin/post-new.php?post_type=page' );
 
-  cy.visit( testURL + '/wp-admin/post-new.php?post_type=page' );
+	disableGutenbergFeatures();
 
-  disableGutenbergFeatures();
-
-  cy.get( 'textarea.editor-post-title__input' )
-    .type( 'CoBlocks ' + getBlockName() + ' Tests' );
-
+	cy.get( 'textarea.editor-post-title__input' )
+		.type( 'CoBlocks ' + getBlockName() + ' Tests' );
 }
 
 /**
  * Disable Gutenberg Tips
  */
 export function disableGutenbergFeatures() {
+	cy.window().then( ( win ) => {
+		if ( !! win.wp.data.select( 'core/nux' ) ) { // < GB 7.2 || < WP 5.4
+			if ( ! win.wp.data.select( 'core/nux' ).areTipsEnabled() ) {
+				return;
+			}
 
-  cy.window().then( ( win ) => {
+			win.wp.data.dispatch( 'core/nux' ).disableTips();
+			win.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
+		} else { // GB 7.2 || WP 5.4
+			if ( ! win.wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
+				return;
+			}
 
-    if ( ! win.wp.data.select('core/nux').areTipsEnabled() ) {
-
-      return;
-
-    }
-
-    win.wp.data.dispatch( 'core/nux' ).disableTips();
-    win.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
-
-  } );
-
+			win.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+			win.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
+		}
+	} );
 }
 
 /**
@@ -90,62 +80,54 @@ export function disableGutenbergFeatures() {
  *                           attempts to retreive the block from the spec file.
  */
 export function addCoBlocksBlockToPage( clearEditor = true, blockID = '' ) {
+	if ( clearEditor ) {
+		clearBlocks();
+	}
 
-  if ( clearEditor ) {
+	if ( ! blockID.length ) {
+		blockID = getBlockSlug();
+	}
 
-    clearBlocks();
+	cy.get( '.block-list-appender .wp-block .block-editor-inserter__toggle' )
+		.click();
 
-  }
+	// Close 'Most Used' panel
+	cy.get( '.components-panel__body-title' )
+		.contains( /most used/i ) // Regex to handle case difference WP 5.4
+		.then( ( $mostUsedPanel ) => {
+			const $parentPanel = Cypress.$( $mostUsedPanel ).closest( 'div.components-panel__body' );
+			if ( $parentPanel.hasClass( 'is-opened' ) ) {
+				$mostUsedPanel.click();
+			}
+		} );
 
-  if ( ! blockID.length ) {
+	// Show CoBlocks panel
+	cy.get( '.components-panel__body-title' )
+		.contains( 'CoBlocks' )
+		.then( ( $coblocksPanel ) => {
+			const $parentPanel = Cypress.$( $coblocksPanel ).closest( 'div.components-panel__body' );
+			if ( ! $parentPanel.hasClass( 'is-opened' ) ) {
+				$coblocksPanel.click();
+			}
+		} );
 
-    blockID = getBlockSlug();
+	cy.get( '.components-panel__body.is-opened .editor-block-list-item-coblocks-' + blockID )
+		.click();
 
-  }
-
-  cy.get( '.block-list-appender .wp-block .block-editor-inserter__toggle' )
-    .click();
-
-  // Close 'Most Used' panel
-  cy.get( '.components-panel__body-title' )
-    .contains( 'Most Used' )
-    .then( ( $mostUsedPanel ) => {
-      var $parentPanel = Cypress.$( $mostUsedPanel ).closest( 'div.components-panel__body' );
-      if ( $parentPanel.hasClass( 'is-opened' ) ) {
-        $mostUsedPanel.click();
-      }
-    } );
-
-  // Show CoBlocks panel
-  cy.get( '.components-panel__body-title' )
-    .contains( 'CoBlocks' )
-    .then( ( $mostUsedPanel ) => {
-      var $parentPanel = Cypress.$( $mostUsedPanel ).closest( 'div.components-panel__body' );
-      if ( ! $parentPanel.hasClass( 'is-opened' ) ) {
-        $mostUsedPanel.click();
-      }
-    } );
-
-  cy.get( '.components-panel__body.is-opened .editor-block-list-item-coblocks-' + blockID )
-    .click();
-
-  // Make sure the block was added to our page
-  cy.get( '.wp-block-coblocks-' + blockID ).should( 'exist' );
-
+	// Make sure the block was added to our page
+	cy.get( '.wp-block-coblocks-' + blockID ).should( 'exist' );
 }
 
 /**
  * From inside the WordPress editor open the CoBlocks Gutenberg editor panel
  */
 export function savePage() {
+	cy.get( '.edit-post-header__settings button.is-primary' ).click();
 
-  cy.get( '.edit-post-header__settings button.is-primary' ).click();
+	cy.get( '.components-snackbar-list__notice-container' ).should( 'be.visible' );
 
-  cy.get( '.components-snackbar-list__notice-container' ).should( 'be.visible' );
-
-  // Reload the page to ensure that we're not hitting any block errors
-  cy.reload();
-
+	// Reload the page to ensure that we're not hitting any block errors
+	cy.reload();
 }
 
 /**
@@ -157,64 +139,46 @@ export function savePage() {
  *               eg: accordion => div[data-type="coblocks/accordion"]
  */
 export function checkForBlockErrors( blockID = '' ) {
+	if ( ! blockID.length ) {
+		blockID = getBlockSlug();
+	}
 
-  if ( ! blockID.length ) {
+	cy.get( '#editor' ).then( ( $editor ) => {
+		disableGutenbergFeatures();
 
-    blockID = getBlockSlug();
+		cy.get( '.block-editor-warning' ).should( 'not.exist' );
 
-  }
-
-  cy.get( '#editor' ).then( ( $editor ) => {
-
-    disableGutenbergFeatures();
-
-    cy.get( '.block-editor-warning' ).should( 'not.exist' );
-
-    cy.get( 'div[data-type="coblocks/' + blockID + '"]' ).should( 'exist' );
-
-  } );
-
+		cy.get( 'div[data-type="coblocks/' + blockID + '"]' ).should( 'exist' );
+	} );
 }
 
 /**
  * View the currently edited page on the front of site
  */
 export function viewPage() {
-
-  cy.get( '#wpadminbar' ).then( ( $adminBar ) => {
-
-    if ( Cypress.$( '#wp-admin-bar-view' ).length ) {
-
-      cy.get( '#wp-admin-bar-view' )
-        .click();
-
-    }
-
-  } );
-
+	cy.get( '#wpadminbar' ).then( ( $adminBar ) => {
+		if ( Cypress.$( '#wp-admin-bar-view' ).length ) {
+			cy.get( '#wp-admin-bar-view' )
+				.click();
+		}
+	} );
 }
 
 /**
  * Edit the currently viewed page
  */
 export function editPage() {
-
-  cy.get( '#wp-admin-bar-edit' )
-    .click();
-
+	cy.get( '#wp-admin-bar-edit' )
+		.click();
 }
 
 /**
  * Clear all blocks from the editor
  */
 export function clearBlocks() {
-
-  cy.window().then( ( win ) => {
-
-    win.wp.data.dispatch( 'core/editor' ).resetBlocks( [] );
-
-  } );
-
+	cy.window().then( ( win ) => {
+		win.wp.data.dispatch( 'core/editor' ).resetBlocks( [] );
+	} );
 }
 
 /**
@@ -222,13 +186,11 @@ export function clearBlocks() {
  * eg: accordion.js => Accordion
  */
 export function getBlockName() {
+	let specFile = Cypress.spec.name,
+		fileBase = ( specFile.split( '/' ).pop().replace( '.cypress.js', '' ) ),
+		blockName = fileBase.charAt( 0 ).toUpperCase() + fileBase.slice( 1 );
 
-  var specFile  = Cypress.spec['name'],
-      fileBase  = ( specFile.split( '/' ).pop().replace( '.cypress.js', '' ) ),
-      blockName = fileBase.charAt( 0 ).toUpperCase() + fileBase.slice( 1 );
-
-  return blockName;
-
+	return blockName;
 }
 
 /**
@@ -236,12 +198,10 @@ export function getBlockName() {
  * eg: accordion.js => accordion
  */
 export function getBlockSlug() {
+	let specFile = Cypress.spec.name,
+		fileBase = ( specFile.split( '/' ).pop().replace( '.cypress.js', '' ) );
 
-  var specFile  = Cypress.spec['name'],
-      fileBase  = ( specFile.split( '/' ).pop().replace( '.cypress.js', '' ) );
-
-  return fileBase;
-
+	return fileBase;
 }
 
 /**
@@ -251,28 +211,41 @@ export function getBlockSlug() {
  * @param string hexColor    The custom hex color to set. eg: #55e7ff
  */
 export function setColorSetting( settingName, hexColor ) {
+	openSettingsPanel( 'Color Settings' );
 
-  openSettingsPanel( 'Color Settings' );
+	switch ( settingName ) {
+		case 'background':
+			cy.get( '.components-base-control__field' )
+				.contains( /background color/i )
+				.then( $backgroundPanel => {
+					cy.get( Cypress.$( $backgroundPanel ).parent() )
+						.contains( /custom color/i )
+						.click();
+					cy.get( '.components-color-picker__inputs-field input[type="text"]' )
+						.clear()
+						.type( hexColor );
+					cy.get( Cypress.$( $backgroundPanel ).parent() )
+						.contains( /custom color/i )
+						.click();
+				} );
+			break;
 
-  var elementSelector;
-
-  switch ( settingName ) {
-    case 'background':
-      elementSelector = '.editor-panel-color-settings .block-editor-color-palette-control:nth-child(2) .components-color-palette__custom-color';
-      break;
-
-    case 'text':
-      elementSelector = '.editor-panel-color-settings .block-editor-color-palette-control:nth-child(3) .components-color-palette__custom-color';
-      break;
-  }
-
-  cy.get( elementSelector )
-    .click();
-
-  cy.get( '.components-color-picker__inputs-field input[type="text"]' )
-    .clear()
-    .type( hexColor );
-
+		case 'text':
+			cy.get( '.components-base-control__field' )
+				.contains( /text color/i )
+				.then( $backgroundPanel => {
+					cy.get( Cypress.$( $backgroundPanel ).parent() )
+						.contains( /custom color/i )
+						.click();
+					cy.get( '.components-color-picker__inputs-field input[type="text"]' )
+						.clear()
+						.type( hexColor );
+					cy.get( Cypress.$( $backgroundPanel ).parent() )
+						.contains( /custom color/i )
+						.click();
+				} );
+			break;
+	}
 }
 
 /**
@@ -281,14 +254,12 @@ export function setColorSetting( settingName, hexColor ) {
  * @param string panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
-
-  cy.get( '.components-panel__body-title' ).contains( panelText ).then( ( $panelTop ) => {
-    var $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );
-    if ( ! $parentPanel.hasClass( 'is-opened' ) ) {
-      $panelTop.click();
-    }
-  } );
-
+	cy.get( '.components-panel__body-title' ).contains( panelText ).then( ( $panelTop ) => {
+		const $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );
+		if ( ! $parentPanel.hasClass( 'is-opened' ) ) {
+			$panelTop.click();
+		}
+	} );
 }
 
 /**
@@ -297,41 +268,41 @@ export function openSettingsPanel( panelText ) {
  * @param  string checkboxLabelText The checkbox label text. eg: Drop Cap
  */
 export function toggleSettingCheckbox( checkboxLabelText ) {
-
-  cy.get( '.components-toggle-control__label' )
-    .contains( checkboxLabelText )
-    .parent( '.components-base-control__field' )
-    .find( '.components-form-toggle__input' )
-    .click();
-
+	cy.get( '.components-toggle-control__label' )
+		.contains( checkboxLabelText )
+		.parent( '.components-base-control__field' )
+		.find( '.components-form-toggle__input' )
+		.click();
 }
 
 /**
  * Add custom classes to a block
  *
  * @param string classes Custom classe(s) to add to the block
+ * @param string blockID Optional ID to check for in the DOM.
+ *               Note: If no blockID is specified, getBlockSlug() attempts to
+ *               retreive the block from the spec file.
+ *               eg: accordion => div[data-type="coblocks/accordion"]
  */
-export function addCustomBlockClass( classes ) {
+export function addCustomBlockClass( classes, blockID = '' ) {
+	if ( ! blockID.length ) {
+		blockID = getBlockSlug();
+	}
 
-  var blockSlug = getBlockSlug();
+	cy.get( '.wp-block[data-type="coblocks/' + blockID + '"]' )
+		.dblclick( 'right' );
 
-  cy.get( '.wp-block[data-type="coblocks/' + blockSlug + '"]' )
-    .dblclick( 'right' );
+	cy.get( '.components-panel__body' )
+		.contains( 'Advanced' )
+		.click();
 
-  cy.get( '.components-panel__body-toggle' )
-    .contains( 'Advanced' )
-    .click();
+	cy.get( 'div.edit-post-sidebar' )
+		.contains( /Additional CSS/i )
+		.should( 'be.visible' )
+		.parent( '.components-base-control__field' )
+		.find( '.components-text-control__input' )
+		.type( classes );
 
-  cy.get( '.editor-block-inspector__advanced .components-base-control__label' )
-    .contains( 'Additional CSS Class(es)' )
-    .should( 'be.visible' );
-
-  cy.get( '.editor-block-inspector__advanced .components-base-control__label' )
-    .parent( '.components-base-control__field' )
-    .find( '.components-text-control__input' )
-    .type( classes );
-
-  cy.get( '.wp-block.is-selected[data-type="coblocks/' + blockSlug + '"] .wp-block-coblocks-' + blockSlug )
-    .should( 'have.class', classes );
-
+	cy.get( '.wp-block-coblocks-' + blockID )
+		.should( 'have.class', classes );
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,5 @@
 build
 coverage
 cypress
-**/*.cypress.js
 node_modules
 vendor

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
 		"node": true,
 		"mocha": true,
 		"jest/globals": true,
-		"jquery": true
+		"jquery": true,
+		"cypress/globals": true
 	},
 	"parserOptions": {
 		"sourceType": "module",
@@ -27,7 +28,7 @@
 		"window": true,
 		"document": true
 	},
-	"plugins": ["react", "jsx-a11y", "jest"],
+	"plugins": ["react", "jsx-a11y", "jest", "cypress"],
 	"settings": {
 		"react": {
 			"pragma": "wp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7785,6 +7785,15 @@
 				}
 			}
 		},
+		"eslint-plugin-cypress": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.8.1.tgz",
+			"integrity": "sha512-jDpcP+MmjmqQO/x3bwIXgp4cl7Q66RYS5/IsuOQP4Qo2sEqE3DI8tTxBQ1EhnV5qEDd2Z2TYHR+5vYI6oCN4uw==",
+			"dev": true,
+			"requires": {
+				"globals": "^11.12.0"
+			}
+		},
 		"eslint-plugin-eslint-plugin": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
 		"eslint": "^4.19.1",
 		"eslint-config-wordpress": "^2.0.0",
 		"eslint-loader": "^3.0.2",
+		"eslint-plugin-cypress": "^2.8.1",
 		"eslint-plugin-jest": "^21.6.1",
 		"eslint-plugin-jsx-a11y": "^6.0.3",
 		"eslint-plugin-react": "^7.17.0",

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -267,12 +267,21 @@ describe( 'Test CoBlocks Accordion Block', function() {
 		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
 			.type( accordionData[ 0 ].text );
 
-		cy.get( '.components-font-size-picker' )
-			.contains( /default/i )
-			.click()
+		cy.get( '.edit-post-sidebar' )
+			.contains( /default|regular/i )
 			.parent()
-			.contains( /large/i )
-			.click();
+			.then( ( $parentElm ) => {
+				if ( $parentElm[ 0 ].type === 'select-one' ) {
+					cy.get( $parentElm[ 0 ] )
+						.select( 'large' );
+				} else {
+					cy.get( $parentElm[ 0 ] )
+						.click()
+						.parent()
+						.contains( /large/i )
+						.click();
+				}
+			} );
 
 		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
 			.should( 'have.class', 'has-large-font-size' );

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -4,356 +4,341 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Accordion Block', function() {
-
-  /**
+	/**
    * Setup accordion data to be used
    */
-  var accordionData = [
-    {
-      'title': 'What is the best way to contact you?',
-      'text': 'You can reach us by calling (123) 456-7890.',
-    },
-    {
-      'title': 'What are your hours of operation?',
-      'text': 'We are open 24 hours a day, 7 days a week, 365 days a year.',
-    }
-  ];
+	const accordionData = [
+		{
+			title: 'What is the best way to contact you?',
+			text: 'You can reach us by calling (123) 456-7890.',
+		},
+		{
+			title: 'What are your hours of operation?',
+			text: 'We are open 24 hours a day, 7 days a week, 365 days a year.',
+		},
+	];
 
-  /**
+	/**
    * Test that we can add an accordion item to the content, not add any text or
    * alter any settings, and are able to successfuly save the block without errors.
    */
-  it( 'Test accordion block saves with empty values.', function() {
+	it( 'Test accordion block saves with empty values.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion .wp-block-coblocks-accordion-item' )
+			.should( 'be.empty' );
 
-    cy.get( '.wp-block-coblocks-accordion .wp-block-coblocks-accordion-item' )
-      .should( 'be.empty' );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test that we can add an accordion item to the page, add content to it,
    * save and it displays properly without errors.
    */
-  it( 'Test accordion block saves and displays correctly.', function() {
+	it( 'Test accordion block saves and displays correctly.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[0].title );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.type( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .type( accordionData[0].text );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'not.have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'not.have.attr', 'open' );
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.click();
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .click();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'have.attr', 'open' );
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.contains( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .contains( accordionData[0].title );
+		cy.get( '.wp-block-coblocks-accordion-item__content' )
+			.should( 'be.visible' )
+			.contains( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item__content' )
-      .should( 'be.visible' )
-      .contains( accordionData[0].text );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test 'Display Open' attribute works
    */
-  it( 'Test accordion block "Display Open" attribute works.', function() {
+	it( 'Test accordion block "Display Open" attribute works.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[0].title );
+		helpers.toggleSettingCheckbox( 'Display Open' );
 
-    helpers.toggleSettingCheckbox( 'Display Open' );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.type( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .type( accordionData[0].text );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'have.attr', 'open' );
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.click();
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .click();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'not.have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'not.have.attr', 'open' );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test that multiple accordion items display as expected, including a re-order
    */
-  it( 'Test multiple accordion items display as expected.', function() {
+	it( 'Test multiple accordion items display as expected.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[0].title );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.type( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .type( accordionData[0].text );
+		cy.get( '.wp-block[data-type="coblocks/accordion"]' )
+			.dblclick( 'right' );
 
-    cy.get( '.wp-block[data-type="coblocks/accordion"]' )
-      .dblclick( 'right' );
+		cy.get( '.components-coblocks-add-accordion-item__button' )
+			.should( 'be.visible' )
+			.click();
 
-    cy.get( '.components-coblocks-add-accordion-item__button' )
-      .should( 'be.visible' )
-      .click();
+		cy.get( '.wp-block-coblocks-accordion-item:nth-child(2) p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 1 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item:nth-child(2) p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[1].title );
+		cy.get( '.wp-block-coblocks-accordion-item:nth-child(2) p.wp-block-paragraph' )
+			.type( accordionData[ 1 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item:nth-child(2) p.wp-block-paragraph' )
-      .type( accordionData[1].text );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion-item' )
+			.should( 'have.length', 2 );
 
-    cy.get( '.wp-block-coblocks-accordion-item' )
-      .should( 'have.length', 2 );
+		cy.wrap( accordionData ).each( ( data, index ) => {
+			const iteration = index + 1,
+				$accordionItem = cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ')' );
 
-    cy.wrap( accordionData ).each( ( data, index ) => {
+			$accordionItem.parent()
+				.should( 'not.have.attr', 'open' );
 
-      var iteration      = index + 1,
-          $accordionItem = cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ')' );
+			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__title' )
+				.contains( accordionData[ index ].title );
 
-      $accordionItem.parent()
-                    .should( 'not.have.attr', 'open' );
+			$accordionItem.click();
 
-      cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__title' )
-        .contains( accordionData[ index ].title );
+			$accordionItem.parent()
+				.should( 'have.attr', 'open' );
 
-      $accordionItem.click();
+			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__content' )
+				.contains( accordionData[ index ].text );
+		} );
 
-      $accordionItem.parent()
-                    .should( 'have.attr', 'open' );
+		helpers.editPage();
 
-      cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__content' )
-        .contains( accordionData[ index ].text );
+		cy.get( '.wp-block[data-type="coblocks/accordion-item"]:nth-child(2)' )
+			.click( 'left' );
 
-    } );
+		cy.get( '.block-editor-block-mover button[aria-label="Move up"]' )
+			.click();
 
-    helpers.editPage();
+		cy.get( '.wp-block[data-type="coblocks/accordion-item"]:nth-child(2) p.wp-block-coblocks-accordion-item__title' )
+			.contains( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block[data-type="coblocks/accordion-item"]:nth-child(2)' )
-      .click( 'left' );
+		helpers.savePage();
 
-    cy.get( '.block-editor-block-mover button[aria-label="Move up"]' )
-      .click();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    cy.get( '.wp-block[data-type="coblocks/accordion-item"]:nth-child(2) p.wp-block-coblocks-accordion-item__title' )
-      .contains( accordionData[0].title );
+		helpers.viewPage();
 
-    helpers.savePage();
+		// non-destructive array reverse, since we've re-ordered the accordion tabs
+		const reverseAccordionData = accordionData.slice().reverse();
 
-    helpers.checkForBlockErrors();
+		cy.wrap( reverseAccordionData ).each( ( data, index ) => {
+			const iteration = index + 1,
+				$accordionItem = cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ')' );
 
-    helpers.viewPage();
+			$accordionItem.parent()
+				.should( 'not.have.attr', 'open' );
 
-    // non-destructive array reverse, since we've re-ordered the accordion tabs
-    var reverseAccordionData = accordionData.slice().reverse();
+			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__title' )
+				.contains( reverseAccordionData[ index ].title );
 
-    cy.wrap( reverseAccordionData ).each( ( data, index ) => {
+			$accordionItem.click();
 
-      var iteration      = index + 1,
-          $accordionItem = cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ')' );
+			$accordionItem.parent()
+				.should( 'have.attr', 'open' );
 
-      $accordionItem.parent()
-                    .should( 'not.have.attr', 'open' );
+			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__content' )
+				.contains( reverseAccordionData[ index ].text );
+		} );
 
-      cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__title' )
-        .contains( reverseAccordionData[ index ].title );
+		helpers.editPage();
+	} );
 
-      $accordionItem.click();
-
-      $accordionItem.parent()
-                    .should( 'have.attr', 'open' );
-
-      cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__content' )
-        .contains( reverseAccordionData[ index ].text );
-
-    } );
-
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test the accordion block color settings
    */
-  it( 'Test the accordion block color settings.', function() {
+	it( 'Test the accordion block color settings.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[0].title );
+		// Title - Background Color
+		helpers.setColorSetting( 'background', '#8589bd' );
 
-    // Title - Background Color
-    helpers.setColorSetting( 'background', '#8589bd' );
+		// Title - Text Color
+		helpers.setColorSetting( 'text', '#350745' );
 
-    // Title - Text Color
-    helpers.setColorSetting( 'text', '#350745' );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.type( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .type( accordionData[0].text );
+		// Content - Background Color
+		helpers.setColorSetting( 'background', '#55e7ff' );
 
-    // Content - Background Color
-    helpers.setColorSetting( 'background', '#55e7ff' );
+		// Content - Text Color
+		helpers.setColorSetting( 'text', '#201148' );
 
-    // Content - Text Color
-    helpers.setColorSetting( 'text', '#201148' );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.should( 'have.attr', 'style', 'background-color:#8589bd;color:#350745' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .should( 'have.attr', 'style', 'background-color:#8589bd;color:#350745' );
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.click();
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .click();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'have.attr', 'open' );
+		cy.get( '.wp-block-coblocks-accordion-item__content' )
+			.should( 'be.visible' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__content' )
-      .should( 'be.visible' );
+		cy.get( '.wp-block-coblocks-accordion-item__content p' )
+			.should( 'have.attr', 'style', 'background-color:#55e7ff;color:#201148' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__content p' )
-      .should( 'have.attr', 'style', 'background-color:#55e7ff;color:#201148' );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test the accordion block content font settings
    */
-  it( 'Test the accordion block text settings.', function() {
+	it( 'Test the accordion block text settings.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[0].title );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.type( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .type( accordionData[0].text );
+		cy.get( '.components-font-size-picker' )
+			.contains( /default/i )
+			.click()
+			.parent()
+			.contains( /large/i )
+			.click();
 
-    cy.get( '.components-font-size-picker__select select' )
-      .select( 'large' );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.should( 'have.class', 'has-large-font-size' );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .should( 'have.class', 'has-large-font-size' );
+		helpers.toggleSettingCheckbox( 'Drop Cap' );
 
-    helpers.toggleSettingCheckbox( 'Drop Cap' );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.should( 'have.class', 'has-drop-cap' );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .should( 'have.class', 'has-drop-cap' );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.should( 'have.class', 'has-large-font-size' )
+			.should( 'have.class', 'has-drop-cap' );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .should( 'have.class', 'has-large-font-size' )
-      .should( 'have.class', 'has-drop-cap' );
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'not.have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'not.have.attr', 'open' );
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.click();
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .click();
+		cy.get( '.wp-block-coblocks-accordion-item__title' )
+			.parent()
+			.should( 'have.attr', 'open' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__title' )
-      .parent()
-      .should( 'have.attr', 'open' );
+		cy.get( '.wp-block-coblocks-accordion-item__content' )
+			.should( 'be.visible' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__content' )
-      .should( 'be.visible' );
+		cy.get( '.wp-block-coblocks-accordion-item__content p' )
+			.should( 'have.class', 'has-large-font-size' )
+			.should( 'have.class', 'has-drop-cap' );
 
-    cy.get( '.wp-block-coblocks-accordion-item__content p' )
-      .should( 'have.class', 'has-large-font-size' )
-      .should( 'have.class', 'has-drop-cap' );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test the accordion block custom classes
    */
-  it( 'Test the accordion block custom classes.', function() {
+	it( 'Test the accordion block custom classes.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
+			.type( accordionData[ 0 ].title );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-      .type( accordionData[0].title );
+		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
+			.type( accordionData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-      .type( accordionData[0].text );
+		helpers.addCustomBlockClass( 'my-custom-class', 'accordion' );
 
-    helpers.addCustomBlockClass( 'my-custom-class' );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'accordion' );
 
-    helpers.checkForBlockErrors();
+		cy.get( '.wp-block-coblocks-accordion' )
+			.should( 'have.class', 'my-custom-class' );
 
-    cy.get( '.wp-block-coblocks-accordion' )
-      .should( 'have.class', 'my-custom-class' );
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-accordion' )
+			.should( 'have.class', 'my-custom-class' );
 
-    cy.get( '.wp-block-coblocks-accordion' )
-      .should( 'have.class', 'my-custom-class' );
-
-    helpers.editPage();
-
-  } );
+		helpers.editPage();
+	} );
 } );

--- a/src/blocks/alert/test/alert.cypress.js
+++ b/src/blocks/alert/test/alert.cypress.js
@@ -4,99 +4,91 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Alert Block', function() {
-
-  /**
+	/**
    * Test that we can add a alert block to the content, not add any text or
    * alter any settings, and are able to successfuly save the block without errors.
    */
-  it( 'Test alert block saves with empty values.', function() {
+	it( 'Test alert block saves with empty values.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'alert' );
 
-    helpers.addCoBlocksBlockToPage();
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'alert' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-alert' )
+			.should( 'be.empty' );
 
-    cy.get( '.wp-block-coblocks-alert' )
-      .should( 'be.empty' );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test that alert data saves
    */
-  it( 'Test alert block saves and displays properly.', function() {
+	it( 'Test alert block saves and displays properly.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'alert' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-alert__title' )
+			.type( 'Test Title' );
 
-    cy.get( '.wp-block-coblocks-alert__title' )
-      .type( 'Test Title' );
+		cy.get( '.wp-block-coblocks-alert__text' )
+			.type( 'Test text' );
 
-    cy.get( '.wp-block-coblocks-alert__text' )
-      .type( 'Test text' );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'alert' );
 
-    helpers.checkForBlockErrors();
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-alert__title' )
+			.should( 'not.be.empty' )
+			.contains( 'Test Title' );
 
-    cy.get( '.wp-block-coblocks-alert__title' )
-      .should( 'not.be.empty' )
-      .contains( 'Test Title' );
+		cy.get( '.wp-block-coblocks-alert__text' )
+			.should( 'not.be.empty' )
+			.contains( 'Test text' );
 
-    cy.get( '.wp-block-coblocks-alert__text' )
-      .should( 'not.be.empty' )
-      .contains( 'Test text' );
+		helpers.editPage();
+	} );
 
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test that the alert style classes are applied in the editor
    */
-  it( 'Test alert style classes are applied in the editor.', function() {
+	it( 'Test alert style classes are applied in the editor.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'alert' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block[data-type="coblocks/alert"]' )
+			.click( 'right' );
 
-    cy.get( '.wp-block[data-type="coblocks/alert"]' )
-      .click( 'right' );
+		helpers.openSettingsPanel( 'Styles' );
 
-    helpers.openSettingsPanel( 'Styles' );
+		cy.get( '.block-editor-block-styles__item-label' )
+			.contains( 'Info' )
+			.click();
 
-    cy.get( '.block-editor-block-styles__item-label' )
-      .contains( 'Info' )
-      .click();
+		cy.get( '.wp-block-coblocks-alert' )
+			.should( 'have.class', 'is-style-info' );
 
-    cy.get( '.wp-block-coblocks-alert' )
-      .should( 'have.class', 'is-style-info' );
+		cy.get( '.block-editor-block-styles__item-label' )
+			.contains( 'Success' )
+			.click();
 
-    cy.get( '.block-editor-block-styles__item-label' )
-      .contains( 'Success' )
-      .click();
+		cy.get( '.wp-block-coblocks-alert' )
+			.should( 'have.class', 'is-style-success' );
 
-    cy.get( '.wp-block-coblocks-alert' )
-      .should( 'have.class', 'is-style-success' );
+		cy.get( '.block-editor-block-styles__item-label' )
+			.contains( 'Warning' )
+			.click();
 
-    cy.get( '.block-editor-block-styles__item-label' )
-      .contains( 'Warning' )
-      .click();
+		cy.get( '.wp-block-coblocks-alert' )
+			.should( 'have.class', 'is-style-warning' );
 
-    cy.get( '.wp-block-coblocks-alert' )
-      .should( 'have.class', 'is-style-warning' );
+		cy.get( '.block-editor-block-styles__item-label' )
+			.contains( 'Error' )
+			.click();
 
-    cy.get( '.block-editor-block-styles__item-label' )
-      .contains( 'Error' )
-      .click();
-
-    cy.get( '.wp-block-coblocks-alert' )
-      .should( 'have.class', 'is-style-error' );
-
-  } );
-
+		cy.get( '.wp-block-coblocks-alert' )
+			.should( 'have.class', 'is-style-error' );
+	} );
 } );

--- a/src/blocks/highlight/test/highlight.cypress.js
+++ b/src/blocks/highlight/test/highlight.cypress.js
@@ -4,225 +4,220 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Highlight Block', function() {
-
-  /**
+	/**
    * Setup accordion data to be used
    */
-  var highlightData = [
-    {
-      'text': 'We are closed today from 2PM to 4PM.',
-      'backgroundColor': '#ff0000',
-      'textColor': '#ffffff',
-      'backgroundColorRGB': 'rgb(255, 0, 0)',
-      'textColorRGB': 'rgb(255, 255, 255)',
-    },
-    {
-      'text': 'Due to Server Maintenance, the Server will be down for a few hours.',
-      'backgroundColor': '#cce5ff',
-      'textColor': '#004085',
-      'backgroundColorRGB': 'rgb(204, 229, 255)',
-      'textColorRGB': 'rgb(0, 64, 133)',
-    },
-  ];
+	const highlightData = [
+		{
+			text: 'We are closed today from 2PM to 4PM.',
+			backgroundColor: '#ff0000',
+			textColor: '#ffffff',
+			backgroundColorRGB: 'rgb(255, 0, 0)',
+			textColorRGB: 'rgb(255, 255, 255)',
+		},
+		{
+			text: 'Due to Server Maintenance, the Server will be down for a few hours.',
+			backgroundColor: '#cce5ff',
+			textColor: '#004085',
+			backgroundColorRGB: 'rgb(204, 229, 255)',
+			textColorRGB: 'rgb(0, 64, 133)',
+		},
+	];
+
+	/**
+	 * Test that we can add a highlight block to the content, not add any text or
+	 * alter any settings, and are able to successfuly save the block without errors.
+	 */
+	it( 'Test highlight block saves with empty values.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'highlight' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'highlight' );
 
-  /**
-   * Test that we can add a highlight block to the content, not add any text or
-   * alter any settings, and are able to successfuly save the block without errors.
-   */
-  it( 'Test highlight block saves with empty values.', function() {
+		helpers.viewPage();
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( '.wp-block-coblocks-highlight' )
+			.should( 'have.length', 0 );
 
-    helpers.savePage();
+		helpers.editPage();
+	} );
 
-    helpers.checkForBlockErrors();
+	/**
+	 * Test that we can add a hightlight block to the page, add text to it,
+	 * save and it displays properly without errors.
+	 */
+	it( 'Test highlight block saves and displays correctly.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'highlight' );
 
-    helpers.viewPage();
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.type( highlightData[ 0 ].text );
 
-    cy.get( '.wp-block-coblocks-highlight' )
-      .should( 'have.length', 0 );
+		helpers.savePage();
 
-    helpers.editPage();
+		helpers.checkForBlockErrors( 'highlight' );
 
-  } );
+		helpers.viewPage();
 
-  /**
-   * Test that we can add a hightlight block to the page, add text to it,
-   * save and it displays properly without errors.
-   */
-  it( 'Test highlight block saves and displays correctly.', function() {
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.contains( highlightData[ 0 ].text );
 
-    helpers.addCoBlocksBlockToPage();
+		helpers.editPage();
+	} );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .type( highlightData[0].text );
+	/**
+	 * Test the accordion block content font settings
+	 */
+	it( 'Test highlight block font size setting.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'highlight' );
 
-    helpers.savePage();
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.type( highlightData[ 0 ].text );
 
-    helpers.checkForBlockErrors();
+		cy.get( '.edit-post-sidebar' )
+			.contains( /default|regular/i )
+			.parent()
+			.then( ( $parentElm ) => {
+				if ( $parentElm[ 0 ].type === 'select-one' ) {
+					cy.get( $parentElm[ 0 ] )
+						.select( 'large' );
+				} else {
+					cy.get( $parentElm[ 0 ] )
+						.click()
+						.parent()
+						.contains( /large/i )
+						.click();
+				}
+			} );
 
-    helpers.viewPage();
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+			.should( 'have.class', 'has-large-font-size' );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .contains( highlightData[0].text );
+		helpers.savePage();
 
-    helpers.editPage();
+		helpers.checkForBlockErrors( 'highlight' );
 
-  } );
+		helpers.viewPage();
 
-  /**
-   * Test the accordion block content font settings
-   */
-  it( 'Test highlight block font size setting.', function() {
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.contains( highlightData[ 0 ].text );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+			.should( 'have.class', 'has-large-font-size' );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .type( highlightData[0].text );
+		helpers.editPage();
+	} );
 
-    cy.get( '.components-font-size-picker__select select' )
-      .select( 'large' );
+	/**
+	 * Test the highlight block color settings
+	 */
+	it( 'Test highlight block color settings.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'highlight' );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-      .should( 'have.class', 'has-large-font-size' );
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.type( highlightData[ 0 ].text );
 
-    helpers.savePage();
+		helpers.setColorSetting( 'background', highlightData[ 0 ].backgroundColor );
+		helpers.setColorSetting( 'text', highlightData[ 0 ].textColor );
 
-    helpers.checkForBlockErrors();
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+			.should( 'have.class', 'has-background' );
 
-    helpers.viewPage();
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+			.should( 'have.css', 'background-color', highlightData[ 0 ].backgroundColorRGB );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .contains( highlightData[0].text );
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+			.should( 'have.class', 'has-text-color' );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-      .should( 'have.class', 'has-large-font-size' );
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+			.should( 'have.css', 'color', highlightData[ 0 ].textColorRGB );
 
-    helpers.editPage();
+		helpers.savePage();
 
-  } );
+		helpers.checkForBlockErrors( 'highlight' );
 
-  /**
-   * Test the highlight block color settings
-   */
-  it( 'Test highlight block color settings.', function() {
+		helpers.viewPage();
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.contains( highlightData[ 0 ].text );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .type( highlightData[0].text );
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'background-color:' + highlightData[ 0 ].backgroundColor + ';' );
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'color:' + highlightData[ 0 ].textColor );
 
-    helpers.setColorSetting( 'background', highlightData[0].backgroundColor );
-    helpers.setColorSetting( 'text', highlightData[0].textColor );
+		helpers.editPage();
+	} );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-      .should( 'have.class', 'has-background' );
+	/**
+	 * Test multiple highlight blocks with custom color settings on each
+	 */
+	it( 'Test multiple highlight blocks with custom color settings.', function() {
+		cy.wrap( highlightData ).each( ( text, index ) => {
+			const nthChild = ( index + 1 );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-      .should( 'have.css', 'background-color', highlightData[0].backgroundColorRGB );
+			// Only clear the editor window on the first block
+			helpers.addCoBlocksBlockToPage( ( 0 === index ), 'highlight' );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-      .should( 'have.class', 'has-text-color' );
+			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight' )
+				.type( highlightData[ index ].text );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-      .should( 'have.css', 'color', highlightData[0].textColorRGB );
+			helpers.setColorSetting( 'background', highlightData[ index ].backgroundColor );
+			helpers.setColorSetting( 'text', highlightData[ index ].textColor );
 
-    helpers.savePage();
+			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+				.should( 'have.class', 'has-background' );
 
-    helpers.checkForBlockErrors();
+			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+				.should( 'have.css', 'background-color', highlightData[ index ].backgroundColorRGB );
 
-    helpers.viewPage();
+			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+				.should( 'have.class', 'has-text-color' );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .contains( highlightData[0].text );
+			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
+				.should( 'have.css', 'color', highlightData[ index ].textColorRGB );
+		} );
 
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'background-color:' + highlightData[0].backgroundColor + ';' );
-    cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'color:' + highlightData[0].textColor );
+		helpers.savePage();
 
-    helpers.editPage();
+		helpers.checkForBlockErrors( 'highlight' );
 
-  } );
+		helpers.viewPage();
 
-  /**
-   * Test multiple highlight blocks with custom color settings on each
-   */
-  it( 'Test multiple highlight blocks with custom color settings.', function() {
+		cy.wrap( highlightData ).each( ( text, index ) => {
+			const nthChild = ( index + 1 );
 
-    cy.wrap( highlightData ).each( ( text, index ) => {
+			cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' )
+				.should( 'contain', highlightData[ index ].text );
 
-      var nthChild = ( index + 1 );
+			cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'background-color:' + highlightData[ index ].backgroundColor + ';' );
+			cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'color:' + highlightData[ index ].textColor );
+		} );
 
-      // Only clear the editor window on the first block
-      helpers.addCoBlocksBlockToPage( ( 0 === index ) );
+		helpers.editPage();
+	} );
 
-      cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight' )
-        .type( highlightData[ index ].text );
-
-      helpers.setColorSetting( 'background', highlightData[ index ].backgroundColor );
-      helpers.setColorSetting( 'text', highlightData[ index ].textColor );
-
-      cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-        .should( 'have.class', 'has-background' );
-
-      cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-        .should( 'have.css', 'background-color', highlightData[ index ].backgroundColorRGB );
-
-      cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-        .should( 'have.class', 'has-text-color' );
-
-      cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-        .should( 'have.css', 'color', highlightData[ index ].textColorRGB );
-
-    } );
-
-    helpers.savePage();
-
-    helpers.checkForBlockErrors();
-
-    helpers.viewPage();
-
-    cy.wrap( highlightData ).each( ( text, index ) => {
-
-      var nthChild = ( index + 1 );
-
-      cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' )
-        .should( 'contain', highlightData[ index ].text );
-
-      cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'background-color:' + highlightData[ index ].backgroundColor + ';' );
-      cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'color:' + highlightData[ index ].textColor );
-
-
-    } );
-
-    helpers.editPage();
-
-  } );
-
-  /**
+	/**
    * Test the highlight block custom classes
    */
-  it( 'Test the highlight block custom classes.', function() {
+	it( 'Test the highlight block custom classes.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'highlight' );
 
-    helpers.addCoBlocksBlockToPage();
+		cy.get( 'p.wp-block-coblocks-highlight' )
+			.type( highlightData[ 0 ].text );
 
-    cy.get( 'p.wp-block-coblocks-highlight' )
-      .type( highlightData[0].text );
+		helpers.addCustomBlockClass( 'my-custom-class' );
 
-    helpers.addCustomBlockClass( 'my-custom-class' );
+		helpers.savePage();
 
-    helpers.savePage();
+		helpers.checkForBlockErrors( 'highlight' );
 
-    helpers.checkForBlockErrors();
+		cy.get( '.wp-block-coblocks-highlight' )
+			.should( 'have.class', 'my-custom-class' );
 
-    cy.get( '.wp-block-coblocks-highlight' )
-      .should( 'have.class', 'my-custom-class' );
+		helpers.viewPage();
 
-    helpers.viewPage();
+		cy.get( '.wp-block-coblocks-highlight' )
+			.should( 'have.class', 'my-custom-class' );
 
-    cy.get( '.wp-block-coblocks-highlight' )
-      .should( 'have.class', 'my-custom-class' );
-
-    helpers.editPage();
-
-  } );
+		helpers.editPage();
+	} );
 } );


### PR DESCRIPTION
Refactor tests and helpers to support the expected features of WP 5.4 (or Gutenberg 7.2) and is compatible with and without the Gutenberg plugin active. 

**ESLint**
- Applied ESLint to all tests and `helper.js`.
- Installed `Cypress` ESLint plugin.
- Removed tests from `.eslintignore`

**helper.js**
- Added logic to deprecate `core/nux` into `select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' )`
- Enhanced selector specificity with `Regex` to click the appropreate elements. 
  * Resolves issues where referenced classes have been deprecated.
- Identified and implemented alternate solutions for Cypress changes around `getBlockSlug` function. 
  * `Cypress.spec.name` is not as expected in certain scenarios.
  *  https://github.com/cypress-io/cypress/issues/3090

****.cypress.js**
- Re-wrote logic around setting Font Sizes for cross-version compatibility. 
- Adjusted functions to pass the appropriate slug.
  * IE `helpers.addCoBlocksBlockToPage( true );` changed to 		`helpers.addCoBlocksBlockToPage( true, 'accordion' );`
