### PR TITLE
Fix Gallery blocks when uploading images

### DIFF
--- a/src/components/block-gallery/gallery-placeholder.js
+++ b/src/components/block-gallery/gallery-placeholder.js
@@ -29,6 +29,9 @@ class GalleryPlaceholder extends Component {
 	}
 
 	selectCaption( newImage, images, attachmentCaptions ) {
+		if ( ! newImage.caption ) {
+			return '';
+		}
 		const currentImage = find( images, { id: newImage.id.toString() } ) ||	find( images, { id: newImage.id } );
 
 		const currentImageCaption = currentImage ? currentImage.caption : newImage.caption;


### PR DESCRIPTION
Closes #1258 

Freshly uploaded images do not possess a caption which resulted in a type error on assertion. Update logic to provide an empty caption if its a freshly uploaded image. 

This resolves the issue with the `offset`, `stacked` and `masonry` gallery blocks. 