### PR TITLE
Bundle languages in the canary package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,9 @@ jobs:
           command: |
             mkdir -p /tmp/artifacts
             grunt build
+            COBLOCKS_VERSION_LINE=$(awk '/\* Version:/{ print NR; exit }' build/coblocks/class-coblocks.php)
+            COBLOCKS_COMMIT_HASH=$(git rev-parse --verify HEAD | head -c 7)
+            sed -i '' -e "${COBLOCKS_VERSION_LINE}s/$/-${COBLOCKS_COMMIT_HASH}/" build/coblocks/class-coblocks.php
             npm run json2po
             npm run po2mo
             npm run po2jed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,7 +360,7 @@ jobs:
             ssh ${STAGING_SITE_SSH_CREDS} 'cd html/wp-content && wp plugin install coblocks-canary.zip --force --activate --skip-themes --skip-plugins && rm -rf coblocks-canary.zip languages/plugins/coblocks-*'
       - deploy:
           name: Create a canary release on Github
-          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace canary /tmp/artifacts/coblocks-canary.zip
+          command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch. This bleeding edge version is for testing purposes only and should not be used in production." -delete -prerelease -replace canary /tmp/artifacts/coblocks-canary.zip
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ jobs:
             - "0e:f8:0a:19:88:42:c3:5a:b9:82:17:34:6b:40:68:21"
       - checkout
       - run:
-          name: Add CoBlocks staging site to known_hosts
+          name: Add CoBlocks i18n staging site to known_hosts
           command: ssh-keyscan -H a90.8f7.myftpupload.com >> ~/.ssh/known_hosts
       - run:
           name: Update npm
@@ -344,12 +344,17 @@ jobs:
           command: |
             mkdir -p /tmp/artifacts
             grunt build
+            npm run json2po
+            npm run po2mo
+            npm run po2jed
+            cp -r languages/ build/coblocks/languages/
             grunt compress
             mv build/*.zip /tmp/artifacts/coblocks-canary.zip
       - run:
           name: Deploy CoBlocks to the test server
           command: |
-            rsync --stats --delete -avz -e "ssh -p22" ./build/coblocks/ ${STAGING_SITE_SSH_CREDS}:${STAGING_SITE_PLUGIN_PATH}
+            scp -r /tmp/artifacts/coblocks-canary.zip ${STAGING_SITE_SSH_CREDS}:html/wp-content/
+            ssh ${STAGING_SITE_SSH_CREDS} 'cd html/wp-content && wp plugin install coblocks-canary.zip --force --activate --skip-themes --skip-plugins && rm -rf coblocks-canary.zip languages/plugins/coblocks-*'
       - deploy:
           name: Create a canary release on Github
           command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -b "Latest build of the master branch." -delete -prerelease -replace canary /tmp/artifacts/coblocks-canary.zip


### PR DESCRIPTION
* Bundle all language files with the canary package (POT/PO/MO/JED)
* Remove any GlotPress translations from the i18n staging site after deploy
* Append the current commit hash to the end of canary versions
* Add disclaimer to the canary description that is should not be used in production
* Once merged, we can remove the `STAGING_SITE_PLUGIN_PATH` env var from CircleCI

<img width="287" alt="Screenshot_2020-01-15_16_58_45" src="https://user-images.githubusercontent.com/522158/72478924-a9c52080-37b8-11ea-9d99-d17810279c70.png">
<img width="506" alt="Screenshot_2020-01-15_16_59_56" src="https://user-images.githubusercontent.com/522158/72478941-b3e71f00-37b8-11ea-9025-64c501f2a28d.png">