### PR TITLE
Removed unused class from Accordion controls

### DIFF
--- a/src/blocks/accordion/accordion-item/controls.js
+++ b/src/blocks/accordion/accordion-item/controls.js
@@ -35,7 +35,7 @@ class Controls extends Component {
 		return (
 			<Fragment>
 				<BlockControls>
-					<Toolbar className="components-toolbar__block-coblocks-accordion" controls={ customControls } />
+					<Toolbar controls={ customControls } />
 				</BlockControls>
 			</Fragment>
 		);


### PR DESCRIPTION
This PR removes the `components-toolbar__block-coblocks-accordion` class, as its no longer being used.