### PR TITLE
Switch DimensionsControls padding and margin

### DIFF
--- a/src/blocks/features/inspector.js
+++ b/src/blocks/features/inspector.js
@@ -129,27 +129,6 @@ class Inspector extends Component {
 							/>
 						}
 						<DimensionsControl { ...this.props }
-							type={ 'margin' }
-							label={ __( 'Margin', 'coblocks' ) }
-							valueTop={ marginTop }
-							valueRight={ marginRight }
-							valueBottom={ marginBottom }
-							valueLeft={ marginLeft }
-							valueTopTablet={ marginTopTablet }
-							valueRightTablet={ marginRightTablet }
-							valueBottomTablet={ marginBottomTablet }
-							valueLeftTablet={ marginLeftTablet }
-							valueTopMobile={ marginTopMobile }
-							valueRightMobile={ marginRightMobile }
-							valueBottomMobile={ marginBottomMobile }
-							valueLeftMobile={ marginLeftMobile }
-							unit={ marginUnit }
-							syncUnits={ marginSyncUnits }
-							syncUnitsTablet={ marginSyncUnitsTablet }
-							syncUnitsMobile={ marginSyncUnitsMobile }
-							dimensionSize={ marginSize }
-						/>
-						<DimensionsControl { ...this.props }
 							type={ 'padding' }
 							label={ __( 'Padding', 'coblocks' ) }
 							valueTop={ paddingTop }
@@ -169,6 +148,27 @@ class Inspector extends Component {
 							syncUnitsTablet={ paddingSyncUnitsTablet }
 							syncUnitsMobile={ paddingSyncUnitsMobile }
 							dimensionSize={ paddingSize }
+						/>
+						<DimensionsControl { ...this.props }
+							type={ 'margin' }
+							label={ __( 'Margin', 'coblocks' ) }
+							valueTop={ marginTop }
+							valueRight={ marginRight }
+							valueBottom={ marginBottom }
+							valueLeft={ marginLeft }
+							valueTopTablet={ marginTopTablet }
+							valueRightTablet={ marginRightTablet }
+							valueBottomTablet={ marginBottomTablet }
+							valueLeftTablet={ marginLeftTablet }
+							valueTopMobile={ marginTopMobile }
+							valueRightMobile={ marginRightMobile }
+							valueBottomMobile={ marginBottomMobile }
+							valueLeftMobile={ marginLeftMobile }
+							unit={ marginUnit }
+							syncUnits={ marginSyncUnits }
+							syncUnitsTablet={ marginSyncUnitsTablet }
+							syncUnitsMobile={ marginSyncUnitsMobile }
+							dimensionSize={ marginSize }
 						/>
 					</PanelBody>
 					<PanelColorSettings

--- a/src/blocks/row/column/inspector.js
+++ b/src/blocks/row/column/inspector.js
@@ -107,28 +107,6 @@ class Inspector extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Column Settings', 'coblocks' ) } className="components-panel__body--column-settings">
 						<DimensionsControl { ...this.props }
-							type={ 'margin' }
-							label={ __( 'Margin', 'coblocks' ) }
-							help={ __( 'Space around the container.', 'coblocks' ) }
-							valueTop={ marginTop }
-							valueRight={ marginRight }
-							valueBottom={ marginBottom }
-							valueLeft={ marginLeft }
-							valueTopTablet={ marginTopTablet }
-							valueRightTablet={ marginRightTablet }
-							valueBottomTablet={ marginBottomTablet }
-							valueLeftTablet={ marginLeftTablet }
-							valueTopMobile={ marginTopMobile }
-							valueRightMobile={ marginRightMobile }
-							valueBottomMobile={ marginBottomMobile }
-							valueLeftMobile={ marginLeftMobile }
-							unit={ marginUnit }
-							syncUnits={ marginSyncUnits }
-							syncUnitsTablet={ marginSyncUnitsTablet }
-							syncUnitsMobile={ marginSyncUnitsMobile }
-							dimensionSize={ marginSize }
-						/>
-						<DimensionsControl { ...this.props }
 							type={ 'padding' }
 							label={ __( 'Padding', 'coblocks' ) }
 							help={ __( 'Space inside of the container.', 'coblocks' ) }
@@ -149,6 +127,28 @@ class Inspector extends Component {
 							syncUnitsTablet={ paddingSyncUnitsTablet }
 							syncUnitsMobile={ paddingSyncUnitsMobile }
 							dimensionSize={ paddingSize }
+						/>
+						<DimensionsControl { ...this.props }
+							type={ 'margin' }
+							label={ __( 'Margin', 'coblocks' ) }
+							help={ __( 'Space around the container.', 'coblocks' ) }
+							valueTop={ marginTop }
+							valueRight={ marginRight }
+							valueBottom={ marginBottom }
+							valueLeft={ marginLeft }
+							valueTopTablet={ marginTopTablet }
+							valueRightTablet={ marginRightTablet }
+							valueBottomTablet={ marginBottomTablet }
+							valueLeftTablet={ marginLeftTablet }
+							valueTopMobile={ marginTopMobile }
+							valueRightMobile={ marginRightMobile }
+							valueBottomMobile={ marginBottomMobile }
+							valueLeftMobile={ marginLeftMobile }
+							unit={ marginUnit }
+							syncUnits={ marginSyncUnits }
+							syncUnitsTablet={ marginSyncUnitsTablet }
+							syncUnitsMobile={ marginSyncUnitsMobile }
+							dimensionSize={ marginSize }
 						/>
 						{ ( lastId !== clientId ) ?
 							<RangeControl

--- a/src/blocks/row/inspector.js
+++ b/src/blocks/row/inspector.js
@@ -160,6 +160,28 @@ class Inspector extends Component {
 												onChange={ ( value ) => setAttributes( { gutter: value } ) }
 											/>
 										}
+										<DimensionsControl { ...this.props }
+											type={ 'padding' }
+											label={ __( 'Padding', 'coblocks' ) }
+											help={ __( 'Space inside of the container.', 'coblocks' ) }
+											valueTop={ paddingTop }
+											valueRight={ paddingRight }
+											valueBottom={ paddingBottom }
+											valueLeft={ paddingLeft }
+											valueTopTablet={ paddingTopTablet }
+											valueRightTablet={ paddingRightTablet }
+											valueBottomTablet={ paddingBottomTablet }
+											valueLeftTablet={ paddingLeftTablet }
+											valueTopMobile={ paddingTopMobile }
+											valueRightMobile={ paddingRightMobile }
+											valueBottomMobile={ paddingBottomMobile }
+											valueLeftMobile={ paddingLeftMobile }
+											unit={ paddingUnit }
+											syncUnits={ paddingSyncUnits }
+											syncUnitsTablet={ paddingSyncUnitsTablet }
+											syncUnitsMobile={ paddingSyncUnitsMobile }
+											dimensionSize={ paddingSize }
+										/>
 										{ hasMarginControl &&
 											<DimensionsControl { ...this.props }
 												type={ 'margin' }
@@ -184,28 +206,6 @@ class Inspector extends Component {
 												dimensionSize={ marginSize }
 											/>
 										}
-										<DimensionsControl { ...this.props }
-											type={ 'padding' }
-											label={ __( 'Padding', 'coblocks' ) }
-											help={ __( 'Space inside of the container.', 'coblocks' ) }
-											valueTop={ paddingTop }
-											valueRight={ paddingRight }
-											valueBottom={ paddingBottom }
-											valueLeft={ paddingLeft }
-											valueTopTablet={ paddingTopTablet }
-											valueRightTablet={ paddingRightTablet }
-											valueBottomTablet={ paddingBottomTablet }
-											valueLeftTablet={ paddingLeftTablet }
-											valueTopMobile={ paddingTopMobile }
-											valueRightMobile={ paddingRightMobile }
-											valueBottomMobile={ paddingBottomMobile }
-											valueLeftMobile={ paddingLeftMobile }
-											unit={ paddingUnit }
-											syncUnits={ paddingSyncUnits }
-											syncUnitsTablet={ paddingSyncUnitsTablet }
-											syncUnitsMobile={ paddingSyncUnitsMobile }
-											dimensionSize={ paddingSize }
-										/>
 									</PanelBody>
 									<PanelColorSettings
 										title={ __( 'Color Settings', 'coblocks' ) }


### PR DESCRIPTION
To ensure a consistent experience, this PR moves the more important `padding` DimensionsControl above the `margin` control. 

This PR only affects InspectorControls so no deprecations are needed.