### PR TITLE
Fix template selector in the Form block when Gutenberg is active

### DIFF
--- a/src/blocks/form/deprecatedTemplates/layouts.js
+++ b/src/blocks/form/deprecatedTemplates/layouts.js
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import icons from '../icons';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Template option choices for predefined columns layouts.
+ *
+ * @constant
+ * @type {Array}
+ */
+export const TEMPLATE_OPTIONS = [
+	{
+		title: __( 'Contact', 'coblocks' ),
+		icon: icons.layoutContact,
+		template: [
+			[ 'coblocks/field-name', { required: false } ],
+			[ 'coblocks/field-email', { required: true } ],
+			[ 'coblocks/field-textarea', { required: true } ],
+		],
+		submitButtonText: __( 'Contact Us', 'coblocks' ),
+	},
+	{
+		title: __( 'RSVP', 'coblocks' ),
+		icon: icons.layoutRSVP,
+		template: [
+			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
+			/* translators: an additional guest */
+			[ 'coblocks/field-name', { label: __( 'Plus one', 'coblocks' ), hasLastName: true } ],
+			[ 'coblocks/field-email', { required: true } ],
+			[ 'coblocks/field-radio', { label: __( 'Will you be attending?', 'coblocks' ), required: true, options: [ __( 'Yes', 'coblocks' ), __( 'No', 'coblocks' ) ], isInline: true } ],
+			[ 'coblocks/field-textarea', { label: __( 'Notes?', 'coblocks' ) } ],
+		],
+		/* translators: RSVP is an initialism derived from the French phrase Répondez s'il vous plaît, meaning "Please respond" to require confirmation of an invitation */
+		submitButtonText: __( 'RSVP', 'coblocks' ),
+	},
+	{
+		title: __( 'Appointment', 'coblocks' ),
+		icon: icons.layoutAppointment,
+		template: [
+			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
+			[ 'coblocks/field-phone', { required: true } ],
+			[ 'coblocks/field-email', { required: true } ],
+			[ 'coblocks/field-date', { required: true } ],
+			[ 'coblocks/field-radio', { label: __( 'Time', 'coblocks' ), required: true, options: [ __( 'Morning', 'coblocks' ), __( 'Afternoon', 'coblocks' ) ], isInline: true } ],
+			[ 'coblocks/field-textarea', { label: __( 'Special Notes', 'coblocks' ) } ],
+
+		],
+		submitButtonText: __( 'Book Appointment', 'coblocks' ),
+	},
+];

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -320,9 +320,9 @@ class FormEdit extends Component {
 	}
 
 	setTemplate( layout ) {
-		const { setAttributes, patterns } = this.props;
+		const { setAttributes } = this.props;
 		let submitButtonText;
-		map( patterns, ( elem ) => {
+		map( TEMPLATE_OPTIONS, ( elem ) => {
 			if ( isEqual( elem.template, layout ) ) {
 				submitButtonText = elem.submitButtonText;
 			}
@@ -345,52 +345,48 @@ class FormEdit extends Component {
 	}
 
 	blockPatternPicker( ) {
-		const { className } = this.props;
-		const classes = classnames(
-			className,
-			'coblocks-form',
-		);
 		return (
-			<div className={ classes }>
+			<Fragment>
 				<InnerBlocks templateLock="all" allowedBlocks={ ALLOWED_BLOCKS } />
 				<SubmitButton { ...this.props } />
-			</div>
+			</Fragment>
 		);
 	}
 
 	innerBlocksPatternPicker( ) {
-		const { className, hasInnerBlocks } = this.props;
-		const classes = classnames(
-			className,
-			'coblocks-form',
-		);
-		return ( <div className={ classes }>
-			<InnerBlocks
-				__experimentalTemplateOptions={ TEMPLATE_OPTIONS }
-				__experimentalOnSelectTemplateOption={ ( chosenTemplate ) => {
-					if ( chosenTemplate === undefined ) {
-						chosenTemplate = TEMPLATE_OPTIONS[ 0 ].template;
-					}
-					this.setTemplate( chosenTemplate );
-				} }
-				__experimentalAllowTemplateOptionSkip
-				template={ this.supportsInnerBlocksPicker() ? this.state.template : TEMPLATE_OPTIONS[ 0 ].template }
-				allowedBlocks={ ALLOWED_BLOCKS }
-				renderAppender={ () => null }
-				templateInsertUpdatesSelection={ false }
-			/>
-			{ hasInnerBlocks && <SubmitButton { ...this.props } /> }
-		</div>
+		const { hasInnerBlocks } = this.props;
+		return (
+			<Fragment>
+				<InnerBlocks
+					__experimentalTemplateOptions={ TEMPLATE_OPTIONS }
+					__experimentalOnSelectTemplateOption={ ( chosenTemplate ) => {
+						if ( chosenTemplate === undefined ) {
+							chosenTemplate = TEMPLATE_OPTIONS[ 0 ].template;
+						}
+						this.setTemplate( chosenTemplate );
+					} }
+					__experimentalAllowTemplateOptionSkip
+					template={ this.supportsInnerBlocksPicker() ? this.state.template : TEMPLATE_OPTIONS[ 0 ].template }
+					allowedBlocks={ ALLOWED_BLOCKS }
+					renderAppender={ () => null }
+					templateInsertUpdatesSelection={ false }
+				/>
+				{ hasInnerBlocks && <SubmitButton { ...this.props } /> }
+			</Fragment>
 		);
 	}
 
 	render() {
-		const { blockType, defaultPattern, patterns, replaceInnerBlocks, hasInnerBlocks } = this.props;
+		const { className, blockType, defaultPattern, patterns, replaceInnerBlocks, hasInnerBlocks } = this.props;
+
+		const classes = classnames(
+			className,
+			'coblocks-form',
+		);
 
 		if ( hasInnerBlocks || ! this.supportsBlockPatternPicker() ) {
 			return (
 				<Fragment>
-
 					<InspectorControls>
 						<PanelBody title={ __( 'Form Settings', 'coblocks' ) }>
 							{ this.renderToAndSubjectFields() }
@@ -450,8 +446,9 @@ class FormEdit extends Component {
 							</div>
 						</PanelBody>
 					</InspectorControls>
-					{ this.supportsBlockPatternPicker() && this.blockPatternPicker() }
-					{ ! this.supportsBlockPatternPicker() && this.innerBlocksPatternPicker() }
+					<div className={ classes }>
+						{ this.supportsBlockPatternPicker() ? this.blockPatternPicker() : this.innerBlocksPatternPicker() }
+					</div>
 				</Fragment>
 			);
 		}
@@ -468,6 +465,14 @@ class FormEdit extends Component {
 						if ( nextPattern.attributes ) {
 							this.props.setAttributes( nextPattern.attributes );
 						}
+
+						const submitButtonText = map( patterns, ( elem ) => {
+							if ( isEqual( elem.innerBlocks, nextPattern.innerBlocks ) ) {
+								return elem.submitButtonText;
+							}
+						} );
+
+						this.props.setAttributes( { submitButtonText } );
 						if ( nextPattern.innerBlocks ) {
 							replaceInnerBlocks(
 								this.props.clientId,

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -9,6 +9,7 @@ import './styles/style.scss';
  */
 import edit from './edit';
 import icon from './icon';
+import patterns from './patterns';
 
 /**
  * WordPress dependencies
@@ -75,6 +76,7 @@ const settings = {
 		},
 	},
 	attributes,
+	patterns,
 	edit,
 	save: InnerBlocks.Content,
 };

--- a/src/blocks/form/patterns.js
+++ b/src/blocks/form/patterns.js
@@ -16,7 +16,8 @@ import { __ } from '@wordpress/i18n';
  */
 const patterns = [
 	{
-		title: __( 'Contact', 'coblocks' ),
+		name: 'contact-form',
+		label: __( 'Contact', 'coblocks' ),
 		icon: icons.layoutContact,
 		isDefault: true,
 		innerBlocks: [
@@ -24,10 +25,11 @@ const patterns = [
 			[ 'coblocks/field-email', { required: true } ],
 			[ 'coblocks/field-textarea', { required: true } ],
 		],
-		// submitButtonText: __( 'Contact Us', 'coblocks' ),
+		submitButtonText: __( 'Contact Us', 'coblocks' ),
 	},
 	{
-		title: __( 'RSVP', 'coblocks' ),
+		name: 'rsvp-form',
+		label: __( 'RSVP', 'coblocks' ),
 		icon: icons.layoutRSVP,
 		innerBlocks: [
 			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
@@ -38,10 +40,11 @@ const patterns = [
 			[ 'coblocks/field-textarea', { label: __( 'Notes?', 'coblocks' ) } ],
 		],
 		/* translators: RSVP is an initialism derived from the French phrase Répondez s'il vous plaît, meaning "Please respond" to require confirmation of an invitation */
-		// submitButtonText: __( 'RSVP', 'coblocks' ),
+		submitButtonText: __( 'RSVP', 'coblocks' ),
 	},
 	{
-		title: __( 'Appointment', 'coblocks' ),
+		name: 'appointment-form',
+		label: __( 'Appointment', 'coblocks' ),
 		icon: icons.layoutAppointment,
 		innerBlocks: [
 			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
@@ -52,7 +55,7 @@ const patterns = [
 			[ 'coblocks/field-textarea', { label: __( 'Special Notes', 'coblocks' ) } ],
 
 		],
-		// submitButtonText: __( 'Book Appointment', 'coblocks' ),
+		submitButtonText: __( 'Book Appointment', 'coblocks' ),
 	},
 ];
 

--- a/src/blocks/form/patterns.js
+++ b/src/blocks/form/patterns.js
@@ -14,21 +14,22 @@ import { __ } from '@wordpress/i18n';
  * @constant
  * @type {Array}
  */
-export const TEMPLATE_OPTIONS = [
+const patterns = [
 	{
 		title: __( 'Contact', 'coblocks' ),
 		icon: icons.layoutContact,
-		template: [
+		isDefault: true,
+		innerBlocks: [
 			[ 'coblocks/field-name', { required: false } ],
 			[ 'coblocks/field-email', { required: true } ],
 			[ 'coblocks/field-textarea', { required: true } ],
 		],
-		submitButtonText: __( 'Contact Us', 'coblocks' ),
+		// submitButtonText: __( 'Contact Us', 'coblocks' ),
 	},
 	{
 		title: __( 'RSVP', 'coblocks' ),
 		icon: icons.layoutRSVP,
-		template: [
+		innerBlocks: [
 			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
 			/* translators: an additional guest */
 			[ 'coblocks/field-name', { label: __( 'Plus one', 'coblocks' ), hasLastName: true } ],
@@ -37,12 +38,12 @@ export const TEMPLATE_OPTIONS = [
 			[ 'coblocks/field-textarea', { label: __( 'Notes?', 'coblocks' ) } ],
 		],
 		/* translators: RSVP is an initialism derived from the French phrase Répondez s'il vous plaît, meaning "Please respond" to require confirmation of an invitation */
-		submitButtonText: __( 'RSVP', 'coblocks' ),
+		// submitButtonText: __( 'RSVP', 'coblocks' ),
 	},
 	{
 		title: __( 'Appointment', 'coblocks' ),
 		icon: icons.layoutAppointment,
-		template: [
+		innerBlocks: [
 			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
 			[ 'coblocks/field-phone', { required: true } ],
 			[ 'coblocks/field-email', { required: true } ],
@@ -51,6 +52,8 @@ export const TEMPLATE_OPTIONS = [
 			[ 'coblocks/field-textarea', { label: __( 'Special Notes', 'coblocks' ) } ],
 
 		],
-		submitButtonText: __( 'Book Appointment', 'coblocks' ),
+		// submitButtonText: __( 'Book Appointment', 'coblocks' ),
 	},
 ];
+
+export default patterns;


### PR DESCRIPTION
Related to https://github.com/godaddy-wordpress/coblocks/issues/1226

Gutenberg and soon to be WordPress core have dropped support for `InnerBlocks.__experimentalTemplateOptions` in favor of the `__experimentalBlockPatternPicker` component. This PR will enable support for either component. 

Blocks should **not** require deprecation here. InnerBlocks are maintained across versions.

**Running 5.3.2 + GB 7.3**
![FormBlockTemplatesFix](https://user-images.githubusercontent.com/30462574/72931655-81d73f00-3d1b-11ea-8971-66ea47c06147.gif)

**Running 5.3.2 (No Gutenberg)**
![FormBlockTemplatesFix](https://user-images.githubusercontent.com/30462574/72931841-d24e9c80-3d1b-11ea-8810-f1e37b74894e.gif)
