### PR TITLE
Pass block name to custom class helper

### DIFF
--- a/src/blocks/highlight/test/highlight.cypress.js
+++ b/src/blocks/highlight/test/highlight.cypress.js
@@ -204,7 +204,7 @@ describe( 'Test CoBlocks Highlight Block', function() {
 		cy.get( 'p.wp-block-coblocks-highlight' )
 			.type( highlightData[ 0 ].text );
 
-		helpers.addCustomBlockClass( 'my-custom-class' );
+		helpers.addCustomBlockClass( 'my-custom-class', 'highlight' );
 
 		helpers.savePage();
 


### PR DESCRIPTION
Looks like one of the tests was not properly updated with my #1261 PR. This fix passes the block name to the `addCustomBlockClass` helper function.