### PR TITLE
Remove typography controls from Features block

### DIFF
--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -52,6 +52,7 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
  */
 class TypographyControls extends Component {
 	render() {
+		// Blocks that should be allowed to display TypographyControls
 		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight' ];
 
 		const {

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -52,7 +52,7 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
  */
 class TypographyControls extends Component {
 	render() {
-		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight', 'coblocks/features' ];
+		const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/pricing-table', 'coblocks/highlight' ];
 
 		const {
 			attributes,


### PR DESCRIPTION
In the same vein as #1259, this PR removes the typography controls from the parent Features block. The controls don't always work within the editor anyhow, as themes' editor styling is too specific for applying fonts to a parent block, and having those styles permeate though to the child blocks.  