### PR TITLE
Explicitly pass the block type name when registering on the server side

### DIFF
--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -140,7 +140,7 @@ function coblocks_register_events_block() {
 	$metadata = json_decode( ob_get_clean(), true );
 
 	register_block_type(
-		$metadata['name'],
+		'coblocks/events',
 		array(
 			'attributes'      => $metadata['attributes'],
 			'render_callback' => 'coblocks_render_events_block',


### PR DESCRIPTION
This resolves an notice the following PHP notice.

```
Notice: WP_Block_Type_Registry::register was called incorrectly. Block type names must be strings. Please see Debugging in WordPress for more information. (This message was added in version 5.0.0.) in /var/www/wp-includes/functions.php on line 4986
```