### PR TITLE
Remove one column option from the Row block

### DIFF
--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -91,7 +91,6 @@ class Edit extends Component {
 		);
 
 		const columnOptions = [
-			{ columns: 1, name: __( 'One Column', 'coblocks' ), icon: rowIcons.colOne, key: '100' },
 			{ columns: 2, name: __( 'Two Columns', 'coblocks' ), icon: rowIcons.colTwo },
 			{ columns: 3, name: __( 'Three Columns', 'coblocks' ), icon: rowIcons.colThree },
 			{ columns: 4, name: __( 'Four Columns', 'coblocks' ), icon: rowIcons.colFour },

--- a/src/blocks/row/test/row.cypress.js
+++ b/src/blocks/row/test/row.cypress.js
@@ -14,28 +14,6 @@ describe( 'Test CoBlocks Row Block', function() {
 
 	/**
 	* Test that we can add a row block to the content, select
-	* a single column and save content without errors.
-	*/
-	it( 'Test row block saves with one column.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'row' );
-
-		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
-
-		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 1 );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'row' );
-
-		helpers.viewPage();
-
-		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 1 );
-
-		helpers.editPage();
-	} );
-
-	/**
-	* Test that we can add a row block to the content, select
 	* two columns and save content without errors.
 	*/
 	it( 'Test row block saves with two columns.', function() {

--- a/src/blocks/row/test/row.cypress.js
+++ b/src/blocks/row/test/row.cypress.js
@@ -90,6 +90,7 @@ describe( 'Test CoBlocks Row Block', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
+		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 
@@ -117,6 +118,7 @@ describe( 'Test CoBlocks Row Block', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
+		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 

--- a/src/blocks/row/test/row.cypress.js
+++ b/src/blocks/row/test/row.cypress.js
@@ -19,7 +19,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with two columns.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
-		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(2)' ).click();
+		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
 		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 2 );
@@ -42,7 +42,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with three columns.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
-		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(3)' ).click();
+		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(2)' ).click();
 		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 3 );
@@ -65,7 +65,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with four columns.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
-		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(4)' ).click();
+		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(3)' ).click();
 		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 4 );


### PR DESCRIPTION
This PR removes the one column option from our Row block to make things less confusing. 

Current: 
<img width="666" alt="Screen Shot 2020-01-27 at 12 24 29 PM" src="https://user-images.githubusercontent.com/1813435/73198173-9bec9500-4100-11ea-90e3-fd9f12e9e946.png">
