### PR TITLE
Fix Icon block reset button for improved i18n support

### DIFF
--- a/src/blocks/icon/styles/editor.scss
+++ b/src/blocks/icon/styles/editor.scss
@@ -1,18 +1,12 @@
 .components-coblocks-icon-block--advanced-size {
-	position: relative;
+	align-items: center;
+	display: flex;
+	justify-content: center;
 
 	.is-small {
-		bottom: 3px;
-		position: absolute;
-		right: 0;
-	}
-
-	.components-range-control {
-		width: calc(100% - 60px);
-
-		.components-range-control__number {
-			margin-left: 12px;
-		}
+		margin-left: 6px;
+		margin-top: 5px;
+		order: 1;
 	}
 }
 


### PR DESCRIPTION
This PR tweaks the styling of the Icon block's `Icon Size` reset button, so that it displays properly when "Reset" is translated. 

Before: 
<img width="267" alt="Screen Shot 2020-01-27 at 5 49 15 PM" src="https://user-images.githubusercontent.com/1813435/73220836-5a261380-412d-11ea-8d41-c9cff5bb8d19.png">

Now:
<img width="268" alt="Screen Shot 2020-01-27 at 5 36 41 PM" src="https://user-images.githubusercontent.com/1813435/73220477-80977f00-412c-11ea-95f2-06976d579e35.png">
