### PR TITLE
Fix WPCS error

### DIFF
--- a/includes/ical-parser/class-coblocks-ical.php
+++ b/includes/ical-parser/class-coblocks-ical.php
@@ -1232,6 +1232,7 @@ class CoBlocks_ICal {
 			$event_keys_to_remove = array();
 
 			foreach ( $events as $key => $event ) {
+				$checks   = array();
 				$checks[] = ! isset( $event['RECURRENCE-ID'] );
 				$checks[] = isset( $event['UID'] );
 				$checks[] = isset( $event['UID'] ) && isset( $this->altered_recurrence_instances[ $event['UID'] ] );


### PR DESCRIPTION
Fixes a WPCS error spotted while deploying version `1.20.1` on [WordPress.com](https://wordpress.com). 