### PR TITLE
Replace older ButtonGroup controls with OptionSelectorControl

### DIFF
--- a/src/blocks/features/inspector.js
+++ b/src/blocks/features/inspector.js
@@ -5,6 +5,7 @@ import applyWithColors from './colors';
 import { BackgroundPanel } from '../../components/background';
 import DimensionsControl from '../../components/dimensions-control/';
 import HeadingToolbar from '../../components/heading-toolbar';
+import OptionSelectorControl from '../../components/option-selector-control';
 
 /**
  * WordPress dependencies
@@ -85,11 +86,35 @@ class Inspector extends Component {
 		} = attributes;
 
 		const gutterOptions = [
-			{ value: 'no', label: __( 'None', 'coblocks' ) },
-			{ value: 'small', label: __( 'Small', 'coblocks' ) },
-			{ value: 'medium', label: __( 'Medium', 'coblocks' ) },
-			{ value: 'large', label: __( 'Large', 'coblocks' ) },
-			{ value: 'huge', label: __( 'Huge', 'coblocks' ) },
+			{
+				value: 'no',
+				label: __( 'None', 'coblocks' ),
+				shortName: __( 'None', 'coblocks' ),
+			},
+			{
+				value: 'small',
+				/* translators: abbreviation for small size */
+				label: __( 'S', 'coblocks' ),
+				tooltip: __( 'Small', 'coblocks' ),
+			},
+			{
+				value: 'medium',
+				/* translators: abbreviation for medium size */
+				label: __( 'M', 'coblocks' ),
+				tooltip: __( 'Medium', 'coblocks' ),
+			},
+			{
+				value: 'large',
+				/* translators: abbreviation for large size */
+				label: __( 'L', 'coblocks' ),
+				tooltip: __( 'Large', 'coblocks' ),
+			},
+			{
+				value: 'huge',
+				/* translators: abbreviation for largest size */
+				label: __( 'XL', 'coblocks' ),
+				tooltip: __( 'Huge', 'coblocks' ),
+			},
 		];
 
 		return (
@@ -119,15 +144,12 @@ class Inspector extends Component {
 							min={ 1 }
 							max={ 4 }
 						/>
-						{ columns >= 2 &&
-							<SelectControl
-								label={ __( 'Gutter', 'coblocks' ) }
-								value={ gutter }
-								options={ gutterOptions }
-								help={ __( 'Space between each column.', 'coblocks' ) }
-								onChange={ ( value ) => setAttributes( { gutter: value } ) }
-							/>
-						}
+						{ columns >= 2 && <OptionSelectorControl
+							label={ __( 'Gutter', 'coblocks' ) }
+							currentOption={ gutter }
+							options={ gutterOptions }
+							onChange={ ( gutter ) => setAttributes( { gutter } ) }
+						/> }
 						<HeadingToolbar
 							minLevel={ 1 }
 							maxLevel={ 7 }

--- a/src/blocks/gallery-offset/inspector.js
+++ b/src/blocks/gallery-offset/inspector.js
@@ -4,6 +4,7 @@
 import GalleryLinkSettings from '../../components/block-gallery/gallery-link-settings';
 import captionOptions from '../../components/block-gallery/options/caption-options';
 import SizeControl from '../../components/size-control';
+import OptionSelectorControl from '../../components/option-selector-control';
 
 /**
  * WordPress dependencies
@@ -11,7 +12,7 @@ import SizeControl from '../../components/size-control';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, RangeControl, PanelRow, ToggleControl, ButtonGroup, Button, BaseControl, SelectControl } from '@wordpress/components';
+import { PanelBody, RangeControl, ToggleControl, SelectControl } from '@wordpress/components';
 
 /**
  * Inspector controls
@@ -82,34 +83,33 @@ class Inspector extends Component {
 			},
 			{
 				value: 'small',
-				label: __( 'Small', 'coblocks' ),
 				/* translators: abbreviation for small size */
-				shortName: __( 'S', 'coblocks' ),
+				label: __( 'S', 'coblocks' ),
+				tooltip: __( 'Small', 'coblocks' ),
 			},
 			{
 				value: 'medium',
-				label: __( 'Medium', 'coblocks' ),
 				/* translators: abbreviation for medium size */
-				shortName: __( 'M', 'coblocks' ),
+				label: __( 'M', 'coblocks' ),
+				tooltip: __( 'Medium', 'coblocks' ),
 			},
 			{
 				value: 'large',
-				label: __( 'Large', 'coblocks' ),
 				/* translators: abbreviation for large size */
-				shortName: __( 'L', 'coblocks' ),
+				label: __( 'L', 'coblocks' ),
+				tooltip: __( 'Large', 'coblocks' ),
 			},
 			{
 				value: 'huge',
-				label: __( 'Huge', 'coblocks' ),
 				/* translators: abbreviation for largest size */
-				shortName: __( 'XL', 'coblocks' ),
+				label: __( 'XL', 'coblocks' ),
+				tooltip: __( 'Huge', 'coblocks' ),
 			},
 		];
 
 		return (
 			<InspectorControls>
 				<PanelBody title={ __( 'Offset Settings', 'coblocks' ) }>
-
 					<SizeControl { ...this.props }
 						label={ __( 'Size', 'coblocks' ) }
 						type={ 'reverse-grid' }
@@ -117,63 +117,38 @@ class Inspector extends Component {
 						value={ gridSize }
 						reset={ false }
 					/>
-
-					<BaseControl label={ __( 'Gutter', 'coblocks' ) }>
-						<PanelRow>
-							<ButtonGroup aria-label={ __( 'Gutter', 'coblocks' ) }>
-								{ gutterOptions.map( ( option ) => {
-									const isCurrent = gutter === option.value;
-									return (
-										<Button
-											key={ `option-${ option.value }` }
-											isLarge
-											isSecondary={ ! isCurrent }
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											onClick={ () => setAttributes( { gutter: option.value } ) }
-										>
-											{ option.shortName }
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
-						</PanelRow>
-					</BaseControl>
-
-					{ gutter !== 'no' &&
-						<RangeControl
-							label={ __( 'Rounded Corners', 'coblocks' ) }
-							value={ radius }
-							onChange={ this.setRadiusTo }
-							min={ 0 }
-							max={ 20 }
-							step={ 1 }
-						/>
-					}
-
+					<OptionSelectorControl
+						label={ __( 'Gutter', 'coblocks' ) }
+						currentOption={ gutter }
+						options={ gutterOptions }
+						onChange={ ( gutter ) => setAttributes( { gutter } ) }
+					/>
+					{ gutter !== 'no' && <RangeControl
+						label={ __( 'Rounded Corners', 'coblocks' ) }
+						value={ radius }
+						onChange={ this.setRadiusTo }
+						min={ 0 }
+						max={ 20 }
+						step={ 1 }
+					/> }
 					<ToggleControl
 						label={ __( 'Lightbox', 'coblocks' ) }
 						checked={ !! lightbox }
 						onChange={ () => setAttributes( { lightbox: ! lightbox } ) }
 						help={ this.getLightboxHelp }
 					/>
-
 					<ToggleControl
 						label={ __( 'Captions', 'coblocks' ) }
 						checked={ !! captions }
 						onChange={ () => setAttributes( { captions: ! captions } ) }
 						help={ this.getCaptionsHelp }
 					/>
-
-					{ captions &&
-						<SelectControl
-							label={ __( 'Caption Style', 'coblocks' ) }
-							value={ captionStyle }
-							onChange={ this.setCaptionStyleTo }
-							options={ captionOptions }
-						/>
-					}
-
+					{ captions && <SelectControl
+						label={ __( 'Caption Style', 'coblocks' ) }
+						value={ captionStyle }
+						onChange={ this.setCaptionStyleTo }
+						options={ captionOptions }
+					/> }
 				</PanelBody>
 				<GalleryLinkSettings { ...this.props } />
 			</InspectorControls>

--- a/src/blocks/row/inspector.js
+++ b/src/blocks/row/inspector.js
@@ -11,6 +11,7 @@ import { layoutOptions } from './utilities';
 import applyWithColors from './colors';
 import { BackgroundPanel } from '../../components/background';
 import DimensionsControl from '../../components/dimensions-control';
+import OptionSelectorControl from '../../components/option-selector-control';
 
 /**
  * WordPress dependencies
@@ -96,11 +97,30 @@ class Inspector extends Component {
 		} = attributes;
 
 		const gutterOptions = [
-			{ value: 'no', label: __( 'None', 'coblocks' ) },
-			{ value: 'small', label: __( 'Small', 'coblocks' ) },
-			{ value: 'medium', label: __( 'Medium', 'coblocks' ) },
-			{ value: 'large', label: __( 'Large', 'coblocks' ) },
-			{ value: 'huge', label: __( 'Huge', 'coblocks' ) },
+			{
+				value: 'small',
+				/* translators: abbreviation for small size */
+				label: __( 'S', 'coblocks' ),
+				tooltip: __( 'Small', 'coblocks' ),
+			},
+			{
+				value: 'medium',
+				/* translators: abbreviation for medium size */
+				label: __( 'M', 'coblocks' ),
+				tooltip: __( 'Medium', 'coblocks' ),
+			},
+			{
+				value: 'large',
+				/* translators: abbreviation for large size */
+				label: __( 'L', 'coblocks' ),
+				tooltip: __( 'Large', 'coblocks' ),
+			},
+			{
+				value: 'huge',
+				/* translators: abbreviation for largest size */
+				label: __( 'XL', 'coblocks' ),
+				tooltip: __( 'Huge', 'coblocks' ),
+			},
 		];
 
 		let selectedRows = 1;
@@ -157,15 +177,12 @@ class Inspector extends Component {
 							{ layout &&
 								<Fragment>
 									<PanelBody title={ __( 'Row Settings', 'coblocks' ) }>
-										{ selectedRows >= 2 &&
-											<SelectControl
-												label={ __( 'Gutter', 'coblocks' ) }
-												value={ gutter }
-												options={ gutterOptions }
-												help={ __( 'Space between each column.', 'coblocks' ) }
-												onChange={ ( value ) => setAttributes( { gutter: value } ) }
-											/>
-										}
+										{ selectedRows >= 2 && <OptionSelectorControl
+											label={ __( 'Gutter', 'coblocks' ) }
+											currentOption={ gutter }
+											options={ gutterOptions }
+											onChange={ ( gutter ) => setAttributes( { gutter } ) }
+										/> }
 										<DimensionsControl { ...this.props }
 											type={ 'padding' }
 											label={ __( 'Padding', 'coblocks' ) }

--- a/src/blocks/services/inspector.js
+++ b/src/blocks/services/inspector.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import HeadingToolbar from '../../components/heading-toolbar';
+import OptionSelectorControl from '../../components/option-selector-control';
 
 /**
  * WordPress dependencies.
@@ -28,10 +29,30 @@ const Inspector = ( props ) => {
 	} = props;
 
 	const gutterOptions = [
-		{ value: 'small', label: __( 'Small', 'coblocks' ) },
-		{ value: 'medium', label: __( 'Medium', 'coblocks' ) },
-		{ value: 'large', label: __( 'Large', 'coblocks' ) },
-		{ value: 'huge', label: __( 'Huge', 'coblocks' ) },
+		{
+			value: 'small',
+			/* translators: abbreviation for small size */
+			label: __( 'S', 'coblocks' ),
+			tooltip: __( 'Small', 'coblocks' ),
+		},
+		{
+			value: 'medium',
+			/* translators: abbreviation for medium size */
+			label: __( 'M', 'coblocks' ),
+			tooltip: __( 'Medium', 'coblocks' ),
+		},
+		{
+			value: 'large',
+			/* translators: abbreviation for large size */
+			label: __( 'L', 'coblocks' ),
+			tooltip: __( 'Large', 'coblocks' ),
+		},
+		{
+			value: 'huge',
+			/* translators: abbreviation for largest size */
+			label: __( 'XL', 'coblocks' ),
+			tooltip: __( 'Huge', 'coblocks' ),
+		},
 	];
 
 	return (
@@ -78,16 +99,12 @@ const Inspector = ( props ) => {
 					max={ 4 }
 					onChange={ ( columns ) => setAttributes( { columns } ) }
 				/>
-				{ attributes.columns >= 2 &&
-					<SelectControl
-						label={ __( 'Gutter', 'coblocks' ) }
-						value={ attributes.gutter }
-						options={ gutterOptions }
-						help={ __( 'Space between each column.', 'coblocks' ) }
-						onChange={ ( value ) => setAttributes( { gutter: value } ) }
-					/>
-				}
-
+				{ attributes.columns >= 2 && <OptionSelectorControl
+					label={ __( 'Gutter', 'coblocks' ) }
+					currentOption={ attributes.gutter }
+					options={ gutterOptions }
+					onChange={ ( gutter ) => setAttributes( { gutter } ) }
+				/> }
 				<HeadingToolbar
 					minLevel={ 1 }
 					maxLevel={ 7 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -16,5 +16,4 @@
 
 // Legacy styling
 @import "legacy/margin";
-
 @import "legacy/padding";

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -16,4 +16,5 @@
 
 // Legacy styling
 @import "legacy/margin";
+
 @import "legacy/padding";


### PR DESCRIPTION
This PR replaces older `ButtonGroup` controls with the `OptionSelectorControl` that we've built to simplify similar experiences across the following blocks: 

- Features
- Row
- Offset Gallery
- Services

Old: 
<img width="263" alt="Screen Shot 2020-02-03 at 3 58 59 PM" src="https://user-images.githubusercontent.com/1813435/73698340-1cca0480-469e-11ea-9227-de7be62e63c3.png">

New:
<img width="222" alt="Screen Shot 2020-02-03 at 3 57 52 PM" src="https://user-images.githubusercontent.com/1813435/73698292-f3a97400-469d-11ea-921a-9fb828b979c2.png">
