### PR TITLE
Don't translate date strings in the iCal parser

### DIFF
--- a/includes/ical-parser/class-coblocks-ical.php
+++ b/includes/ical-parser/class-coblocks-ical.php
@@ -566,10 +566,7 @@ class CoBlocks_ICal {
 			$this->default_time_zone = date_default_timezone_get();
 		}
 
-		// Ideally you would use `PHP_INT_MIN` from PHP 7
-		$php_int_min = -2147483648;
-
-		$this->window_min_timestamp = is_null( $this->filter_days_before ) ? $php_int_min : ( new \DateTime( 'now' ) )->sub( new \DateInterval( 'P' . $this->filter_days_before . 'D' ) )->getTimestamp();
+		$this->window_min_timestamp = is_null( $this->filter_days_before ) ? ~PHP_INT_MAX : ( new \DateTime( 'now' ) )->sub( new \DateInterval( 'P' . $this->filter_days_before . 'D' ) )->getTimestamp();
 		$this->window_max_timestamp = is_null( $this->filter_days_after ) ? PHP_INT_MAX : ( new \DateTime( 'now' ) )->add( new \DateInterval( 'P' . $this->filter_days_after . 'D' ) )->getTimestamp();
 
 		$this->should_filter_by_window = ! is_null( $this->filter_days_before ) || ! is_null( $this->filter_days_after );

--- a/includes/ical-parser/class-coblocks-ical.php
+++ b/includes/ical-parser/class-coblocks-ical.php
@@ -509,46 +509,50 @@ class CoBlocks_ICal {
 	public function __construct( $files = false, array $options = array() ) {
 		ini_set( 'auto_detect_line_endings', '1' );
 
+		// Used only for strtotime(), i18n not needed.
 		$this->day_ordinals = array(
-			1 => __('first', 'coblocks'),
-			2 => __('second', 'coblocks'),
-			3 => __('third', 'coblocks'),
-			4 => __('fourth', 'coblocks'),
-			5 => __('fifth', 'coblocks'),
+			1 => 'first',
+			2 => 'second',
+			3 => 'third',
+			4 => 'fourth',
+			5 => 'fifth',
 		);
 
+		// Used only for strtotime(), i18n not needed.
 		$this->weekdays  = array(
-			'SU'      => __('sunday of', 'coblocks'),
-			'MO'      => __('monday of', 'coblocks'),
-			'TU'      => __('tuesday of', 'coblocks'),
-			'WE'      => __('wednesday of', 'coblocks'),
-			'TH'      => __('thursday of', 'coblocks'),
-			'FR'      => __('friday of', 'coblocks'),
-			'SA'      => __('saturday of', 'coblocks'),
-			'day'     => __('day of', 'coblocks'),
-			'weekday' => __('weekday', 'coblocks'),
+			'SU'      => 'sunday of',
+			'MO'      => 'monday of',
+			'TU'      => 'tuesday of',
+			'WE'      => 'wednesday of',
+			'TH'      => 'thursday of',
+			'FR'      => 'friday of',
+			'SA'      => 'saturday of',
+			'day'     => 'day of',
+			'weekday' => 'weekday',
 		);
 
+		// Used only for strtotime(), i18n not needed.
 		$this->month_names = array(
-			1  => __('January', 'coblocks'),
-			2  => __('February', 'coblocks'),
-			3  => __('March', 'coblocks'),
-			4  => __('April', 'coblocks'),
-			5  => __('May', 'coblocks'),
-			6  => __('June', 'coblocks'),
-			7  => __('July', 'coblocks'),
-			8  => __('August', 'coblocks'),
-			9  => __('September', 'coblocks'),
-			10 => __('October', 'coblocks'),
-			11 => __('November', 'coblocks'),
-			12 => __('December', 'coblocks'),
+			1  => 'January',
+			2  => 'February',
+			3  => 'March',
+			4  => 'April',
+			5  => 'May',
+			6  => 'June',
+			7  => 'July',
+			8  => 'August',
+			9  => 'September',
+			10 => 'October',
+			11 => 'November',
+			12 => 'December',
 		);
 
+		// Used only for strtotime(), i18n not needed.
 		$this->frequency_conversion = array(
-			'DAILY'   => __('day', 'coblocks'),
-			'WEEKLY'  => __('week', 'coblocks'),
-			'MONTHLY' => __('month', 'coblocks'),
-			'YEARLY'  => __('year', 'coblocks'),
+			'DAILY'   => 'day',
+			'WEEKLY'  => 'week',
+			'MONTHLY' => 'month',
+			'YEARLY'  => 'year',
 		);
 
 		foreach ( $options as $option => $value ) {

--- a/includes/ical-parser/class-coblocks-ical.php
+++ b/includes/ical-parser/class-coblocks-ical.php
@@ -520,13 +520,13 @@ class CoBlocks_ICal {
 
 		// Used only for strtotime(), i18n not needed.
 		$this->weekdays  = array(
-			'SU'      => 'sunday of',
-			'MO'      => 'monday of',
-			'TU'      => 'tuesday of',
-			'WE'      => 'wednesday of',
-			'TH'      => 'thursday of',
-			'FR'      => 'friday of',
-			'SA'      => 'saturday of',
+			'SU'      => 'Sunday of',
+			'MO'      => 'Monday of',
+			'TU'      => 'Tuesday of',
+			'WE'      => 'Wednesday of',
+			'TH'      => 'Thursday of',
+			'FR'      => 'Friday of',
+			'SA'      => 'Saturday of',
 			'day'     => 'day of',
 			'weekday' => 'weekday',
 		);


### PR DESCRIPTION
The date strings defined in the iCal parser are never displayed to end-users and only used to convert iCal values to strings that PHP can recognize when calculating `strtotime()`, for this reason they should all map to English.

```php
strtotime( 'first monday of may 2020' ) === 1588550400
strtotime( 'primer lunes de mayo 2020' ) === false // Spanish not recognized
```

Additionally, there was a hardcoded value to represent `PHP_INT_MIN` as a 32 bit integer and the proper way to do this is to call a bitwise `~PHP_INT_MAX` which supports both 32 and 64 bit systems and still works on PHP 5.6.