### PR TITLE
Reinitialize Flickity carousel when used inside an Accordion block

### DIFF
--- a/.dev/config/webpack.config.js
+++ b/.dev/config/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		'coblocks-style': path.resolve( process.cwd(), 'src/styles/style.scss' ),
 
 		'js/coblocks-accordion-polyfill': path.resolve( process.cwd(), 'src/js/coblocks-accordion-polyfill.js' ),
+		'js/coblocks-accordion-carousel': path.resolve( process.cwd(), 'src/js/coblocks-accordion-carousel.js' ),
 		'js/coblocks-datepicker': path.resolve( process.cwd(), 'src/js/coblocks-datepicker.js' ),
 		'js/coblocks-events': path.resolve( process.cwd(), 'src/js/coblocks-events.js' ),
 		'js/coblocks-fromEntries': path.resolve( process.cwd(), 'src/js/coblocks-fromEntries.js' ),

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -258,7 +258,6 @@ class CoBlocks_Block_Assets {
 
 		// Carousel block.
 		if ( has_block( 'coblocks/gallery-carousel' ) ) {
-
 			wp_enqueue_script(
 				'coblocks-flickity',
 				$vendors_dir . '/flickity.js',
@@ -276,7 +275,6 @@ class CoBlocks_Block_Assets {
 					true
 				);
 			}
-
 		}
 
 		// Post Carousel block.

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -267,6 +267,16 @@ class CoBlocks_Block_Assets {
 				true
 			);
 
+			if ( has_block( 'coblocks/accordion' ) ) {
+				wp_enqueue_script(
+					'coblocks-accordion-carousel',
+					$dir . 'coblocks-accordion-carousel.js',
+					array( 'coblocks-flickity' ),
+					COBLOCKS_VERSION,
+					true
+				);
+			}
+
 		}
 
 		// Post Carousel block.

--- a/src/js/coblocks-accordion-carousel.js
+++ b/src/js/coblocks-accordion-carousel.js
@@ -1,4 +1,6 @@
-var flickiyTimer;
+/*global jQuery*/
+
+let flickiyTimer;
 
 ( function( $ ) {
 	$( '.wp-block-coblocks-accordion-item__content' ).each( function() {
@@ -20,11 +22,11 @@ var flickiyTimer;
 /**
  * Reinitialize the flickity carousel when it becomes visible.
  *
- * @param {object} target e.target from the click handler.
+ * @param {Object} target e.target from the click handler.
  */
 function reInitFlickityCarousel( target ) {
-	var $targetCarousel = jQuery( target ).next().find( '.has-carousel' );
-	if ( jQuery( target ).next().find( '.has-carousel' ).is( ':visible' ) && ! $targetCarousel.attr( 'data-reinit' ) ) {
+	const $targetCarousel = jQuery( target ).next().find( '.has-carousel' );
+	if ( jQuery( target ).next().find( '.has-carousel' ).is( ':visible' ) && !$targetCarousel.attr( 'data-reinit' ) ) {
 		$targetCarousel.attr( 'data-reinit', 1 ).flickity( 'destroy' ).flickity( JSON.parse( $targetCarousel.attr( 'data-flickity' ) ) ).flickity( 'resize' );
 		clearInterval( flickiyTimer );
 	}

--- a/src/js/coblocks-accordion-carousel.js
+++ b/src/js/coblocks-accordion-carousel.js
@@ -1,0 +1,31 @@
+var flickiyTimer;
+
+( function( $ ) {
+	$( '.wp-block-coblocks-accordion-item__content' ).each( function() {
+		if (
+			! $( this ).find( '.wp-block-coblocks-gallery-carousel' ).length ||
+			$( this ).closest( 'details' ).attr( 'open' )
+		) {
+			return;
+		}
+		$( this ).prev().click( function( e ) {
+			if ( $( e.target ).closest( 'details' ).attr( 'open' ) ) {
+				return;
+			}
+			flickiyTimer = setInterval( reInitFlickityCarousel, 1, e.target );
+		} );
+	} );
+} )( jQuery );
+
+/**
+ * Reinitialize the flickity carousel when it becomes visible.
+ *
+ * @param  {object} target e.target from the click handler.
+ */
+function reInitFlickityCarousel( target ) {
+	var $targetCarousel = jQuery( target ).next().find( '.has-carousel' );
+	if ( jQuery( target ).next().find( '.has-carousel' ).is( ':visible' ) && ! $targetCarousel.attr( 'data-reinit' ) ) {
+		$targetCarousel.attr( 'data-reinit', 1 ).flickity( 'destroy' ).flickity( JSON.parse( $targetCarousel.attr( 'data-flickity' ) ) ).flickity( 'resize' );
+		clearInterval( flickiyTimer );
+	}
+}

--- a/src/js/coblocks-accordion-carousel.js
+++ b/src/js/coblocks-accordion-carousel.js
@@ -20,7 +20,7 @@ var flickiyTimer;
 /**
  * Reinitialize the flickity carousel when it becomes visible.
  *
- * @param  {object} target e.target from the click handler.
+ * @param {object} target e.target from the click handler.
  */
 function reInitFlickityCarousel( target ) {
 	var $targetCarousel = jQuery( target ).next().find( '.has-carousel' );


### PR DESCRIPTION
Resolves #1307 

Introduce a script to re-initialize the flickity carousel when nested inside of an accordion item and _not_ visible on initial load.

**Note:** We're also going to need to reinitialize the post carousel (slick slider) in a similar fashion to how we're doing it here with flickity.