### PR TITLE
Fix typo in Stacked Gallery description

### DIFF
--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -28,7 +28,7 @@ const settings = {
 	/* translators: block name */
 	title: __( 'Stacked', 'coblocks' ),
 	/* translators: block description */
-	description: __( 'Display multiple images in an single column stacked gallery.', 'coblocks' ),
+	description: __( 'Display multiple images in a single column stacked gallery.', 'coblocks' ),
 	icon,
 	keywords: [
 		'coblocks',


### PR DESCRIPTION
### Description
Change "Display multiple images in an single column stacked gallery" to "Display multiple images in a single column stacked gallery."

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
