### PR TITLE
Fix navigation arrow position on Carousel block

### DIFF
--- a/src/blocks/gallery-carousel/styles/style.scss
+++ b/src/blocks/gallery-carousel/styles/style.scss
@@ -76,8 +76,9 @@
 		}
 
 		&.previous {
-			width: 62px;
 			height: 62px;
+			left: 0;
+			width: 62px;
 
 			&::after {
 				width: 32px;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR tweaks the display of the previous arrow within the Carousel block, ensuring it displays properly.

### Screenshots
Before: 
<img width="626" alt="Screen Shot 2020-02-12 at 4 15 13 PM" src="https://user-images.githubusercontent.com/1813435/74377911-e03f8c80-4db2-11ea-9642-335532ae3602.png">

After: 
<img width="634" alt="Screen Shot 2020-02-12 at 4 15 04 PM" src="https://user-images.githubusercontent.com/1813435/74377918-e3d31380-4db2-11ea-9183-335578807c2d.png">

### Types of changes
Bug fix (non-breaking change which fixes an issue), styles only.