### PR TITLE
Add docs for settings panel hooks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @broken8        | @adomenico             |
 | @andreilupu     | @euthelup              |
 | @alexdenning    | @alexdenning           |
+| @p-jackson      |                        |

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -1,4 +1,4 @@
-# Editor Settings modal
+# Editor Settings
 
 ## Customize labels
 
@@ -8,11 +8,15 @@ label and panel titles:
 ```javascript
 import { addFilter } from '@wordpress/hooks';
 
-addFilter( 'coblocks-settings-title', 'coblocks-settings-title', updateSettingsTitle );
-
 function updateSettingsTitle() {
 	return __( 'Here is a new title!', 'textdomain' );
 }
+
+addFilter(
+	'coblocks-settings-title',
+	'coblocks-settings-title',
+	updateSettingsTitle,
+);
 ```
 
 ## Disable the modal entirely

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -1,4 +1,6 @@
-## Customize settings panel title
+## Editor Settings modal
+
+## Customize settings labels
 
 The following JavaScript filter will customize the text used for the menu item
 label and panel title.
@@ -13,10 +15,9 @@ function updateSettingsTitle() {
 }
 ```
 
-## Disable settings panel
+## Disable the modal entirely
 
-The following php filter can be used to prevent the settings panel from
-appearing in the editor.
+The following `PHP` filter can be used to prevent the editor settings panel from appearing within the editor.
 
 ```php
 add_filter( 'coblocks_show_settings_panel', '__return_false' );

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -1,0 +1,23 @@
+## Customize settings panel title
+
+The following JavaScript filter will customize the text used for the menu item
+label and panel title.
+
+```javascript
+import { addFilter } from '@wordpress/hooks';
+
+addFilter( 'coblocks-settings-title', 'coblocks-settings-title', updateSettingsTitle );
+
+function updateSettingsTitle() {
+	return __( 'Here is a new title!', 'textdomain' );
+}
+```
+
+## Disable settings panel
+
+The following php filter can be used to prevent the settings panel from
+appearing in the editor.
+
+```php
+add_filter( 'coblocks_show_settings_panel', '__return_false' );
+```

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -1,9 +1,9 @@
 # Editor Settings modal
 
-## Customize settings labels
+## Customize labels
 
 The following JavaScript filter will customize the text used for the menu item
-label and panel title.
+label and panel titles: 
 
 ```javascript
 import { addFilter } from '@wordpress/hooks';
@@ -22,3 +22,7 @@ The following `PHP` filter can be used to prevent the editor settings panel from
 ```php
 add_filter( 'coblocks_show_settings_panel', '__return_false' );
 ```
+
+## Screenshots
+![editor-settings](https://user-images.githubusercontent.com/1813435/74862708-9c043d00-531a-11ea-9410-61968ad0e86d.jpg)
+![editor-settings-open](https://user-images.githubusercontent.com/1813435/74862836-cfdf6280-531a-11ea-987c-2f795557b2d3.jpg)

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -1,4 +1,4 @@
-## Editor Settings modal
+# Editor Settings modal
 
 ## Customize settings labels
 


### PR DESCRIPTION
### Description
Added docs for hooks related to the new settings panel in 1.21.0

Text comes from reading the PR that introduced the changes #1313

`coblocks-settings-title` example from https://github.com/godaddy-wordpress/coblocks/pull/1313#issuecomment-585243849
`coblocks_show_settings_panel` example from https://github.com/godaddy-wordpress/coblocks/pull/1313#issuecomment-583119412

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
