### PR TITLE
Add one column option to the Row block

### DIFF
--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -89,6 +89,7 @@ class Edit extends Component {
 		);
 
 		const columnOptions = [
+			{ columns: 1, name: __( 'One Column', 'coblocks' ), icon: rowIcons.colOne, key: '100' },
 			{ columns: 2, name: __( 'Two Columns', 'coblocks' ), icon: rowIcons.colTwo },
 			{ columns: 3, name: __( 'Three Columns', 'coblocks' ), icon: rowIcons.colThree },
 			{ columns: 4, name: __( 'Four Columns', 'coblocks' ), icon: rowIcons.colFour },

--- a/src/blocks/row/test/row.cypress.js
+++ b/src/blocks/row/test/row.cypress.js
@@ -13,16 +13,15 @@ describe( 'Test CoBlocks Row Block', function() {
 	};
 
 	/**
-	* Test that we can add a row block to the content, select
-	* two columns and save content without errors.
-	*/
-	it( 'Test row block saves with two columns.', function() {
+	 * Test that we can add a row block to the content, select
+	 * a single column and save content without errors.
+	 */
+	it( 'Test row block saves with one column.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
-		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
-		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 2 );
+		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 1 );
 
 		helpers.savePage();
 
@@ -30,22 +29,22 @@ describe( 'Test CoBlocks Row Block', function() {
 
 		helpers.viewPage();
 
-		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 2 );
+		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 1 );
 
 		helpers.editPage();
 	} );
 
 	/**
-	* Test that we can add a row block to the content, select
-	* three columns and save content without errors.
-	*/
-	it( 'Test row block saves with three columns.', function() {
+	 * Test that we can add a row block to the content, select
+	 * two columns and save content without errors.
+	 */
+	it( 'Test row block saves with two columns.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(2)' ).click();
 		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
-		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 3 );
+		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 2 );
 
 		helpers.savePage();
 
@@ -53,21 +52,44 @@ describe( 'Test CoBlocks Row Block', function() {
 
 		helpers.viewPage();
 
-		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 3 );
+		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 2 );
 
 		helpers.editPage();
 	} );
 
 	/**
-	* Test that we can add a row block to the content, select
-	* four columns and save content without errors.
-	*/
-	it( 'Test row block saves with four columns.', function() {
+	 * Test that we can add a row block to the content, select
+	 * three columns and save content without errors.
+	 */
+	it( 'Test row block saves with three columns.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(3)' ).click();
 		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
+		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 3 );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'row' );
+
+		helpers.viewPage();
+
+		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 3 );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test that we can add a row block to the content, select
+	 * four columns and save content without errors.
+	 */
+	it( 'Test row block saves with four columns.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'row' );
+
+		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(4)' ).click();
+		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
+
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 4 );
 
 		helpers.savePage();
@@ -82,15 +104,14 @@ describe( 'Test CoBlocks Row Block', function() {
 	} );
 
 	/**
-    * Test that we can add a row block to the content, adjust colors
-    * and are able to successfully save the block without errors.
-	*/
+	 * Test that we can add a row block to the content, adjust colors
+	 * and are able to successfully save the block without errors.
+	 */
 	it( 'Test row block saves with color values set.', function() {
 		const { textColor, backgroundColor, textColorRGB, backgroundColorRGB } = rowData;
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
-		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 
@@ -112,13 +133,12 @@ describe( 'Test CoBlocks Row Block', function() {
 	} );
 
 	/**
-	* Test the row block saves with custom classes
-	*/
+	 * Test the row block saves with custom classes
+	 */
 	it( 'Test the row block custom classes.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1)' ).click();
-		cy.get( 'div[aria-label="Select Row Layout"]' ).find( 'div > button' ).first().click( { force: true } );
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
PR will add back the one column option and related tests to the row block. 
Closes #1359

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/74848623-16ba6180-52f5-11ea-8ded-b4b3a862c0b1.png)

### Types of changes
The Row block has supported the One Column option previously. This change re-introduces the feature.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Passes all block related tests.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
