### PR TITLE
Stop unconditionally enqueuing slick.js

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -40,6 +40,7 @@ class CoBlocks_Block_Assets {
 	public function __construct() {
 		add_action( 'enqueue_block_assets', array( $this, 'block_assets' ) );
 		add_action( 'init', array( $this, 'editor_assets' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 		add_action( 'the_post', array( $this, 'frontend_scripts' ) );
 	}
@@ -325,6 +326,25 @@ class CoBlocks_Block_Assets {
 		}
 	}
 
+	/**
+	 * Enqueue editor scripts for blocks.
+	 *
+	 * @access public
+	 * @since 1.9.5
+	 */
+	public function editor_scripts() {
+		// Define where the vendor asset is loaded from.
+		$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
+
+		// Required by the events block
+		wp_enqueue_script(
+			'coblocks-slick',
+			$vendors_dir . '/slick.js',
+			array( 'jquery' ),
+			COBLOCKS_VERSION,
+			true
+		);
+	}
 }
 
 CoBlocks_Block_Assets::register();

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -134,16 +134,6 @@ function coblocks_register_events_block() {
 		return;
 	}
 
-	$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
-
-	wp_enqueue_script(
-		'coblocks-slick',
-		$vendors_dir . '/slick.js',
-		array( 'jquery' ),
-		COBLOCKS_VERSION,
-		true
-	);
-
 	// Load attributes from block.json.
 	ob_start();
 	include COBLOCKS_PLUGIN_DIR . 'src/blocks/events/block.json';


### PR DESCRIPTION
### Description
Currently, the events block unconditionally enqueues slick.js. It is enqueued regardless of whether it is needed.

This PR updates coblocks so slick.js is only enqueued for the editor and for front-end pages that include the events block.

Because slick.js depends on jQuery, this may address #1361, but I haven't been able to confirm yet because something else on my quite simple site is also enqueuing jQuery by default.

### Types of changes

Bug fix

### How has this been tested?

Setup:
Open browser dev tools to the network tab and search for slick.js

Testing:
1. On a test site, navigate to a page that does not contain the events block, and observe that slick.js is not requested.
2. Open the block editor to create a new post and note that slick.js is requested.
3. Add an events block, link to an external calendar with more than 5 events, and note that the event pages are rendered in a carousel.
4. Publish the new post, navigate to it, and note that slick.js is requested and that the events are rendered in a functioning carousel.

If a negative test is desired:
1. Comment out the line `add_action( 'enqueue_block_editor_assets', array( $this, 'editor_scripts' ) );`
2. Open the block editor to create a new post and note that slick.js is not requested.
3. Add an events block, and link to an external calendar with more than 5 events, and note that the events are not displayed in a carousel.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
