### PR TITLE
Control Food Item block headings from the parent Food and Drinks block

### DIFF
--- a/src/blocks/food-and-drinks/block.json
+++ b/src/blocks/food-and-drinks/block.json
@@ -13,6 +13,10 @@
 		"columns": {
 			"type": "number",
 			"default": 2
+		},
+		"headingLevel": {
+			"type": "integer",
+			"default": 3 
 		}
 	}
 }

--- a/src/blocks/food-and-drinks/block.json
+++ b/src/blocks/food-and-drinks/block.json
@@ -16,7 +16,7 @@
 		},
 		"headingLevel": {
 			"type": "integer",
-			"default": 3 
+			"default": 4
 		}
 	}
 }

--- a/src/blocks/food-and-drinks/controls.js
+++ b/src/blocks/food-and-drinks/controls.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import HeadingToolbar from '../../components/heading-toolbar';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { BlockControls } from '@wordpress/block-editor';
+
+class Controls extends Component {
+	render() {
+		const {
+			attributes,
+			onChangeHeadingLevel,
+		} = this.props;
+
+		const {
+			headingLevel,
+		} = attributes;
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<HeadingToolbar
+						minLevel={ 2 }
+						maxLevel={ 5 }
+						selectedLevel={ headingLevel }
+						onChange={ onChangeHeadingLevel }
+					/>
+				</BlockControls>
+			</Fragment>
+		);
+	}
+}
+
+export default Controls;

--- a/src/blocks/food-and-drinks/edit.js
+++ b/src/blocks/food-and-drinks/edit.js
@@ -2,7 +2,8 @@
  * Internal dependencies.
  */
 import CustomAppender from './appender';
-import InspectorControls from './inspector';
+import Inspector from './inspector';
+import Controls from './controls';
 import icons from './icons';
 
 /**
@@ -103,6 +104,18 @@ class FoodItem extends Component {
 		this.setColumns = this.setColumns.bind( this );
 		this.updateStyle = this.updateStyle.bind( this );
 		this.insertNewItem = this.insertNewItem.bind( this );
+		this.updateInnerAttributes = this.updateInnerAttributes.bind( this );
+		this.onChangeHeadingLevel = this.onChangeHeadingLevel.bind( this );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			this.props.attributes.headingLevel !== prevProps.attributes.headingLevel
+		) {
+			this.updateInnerAttributes( 'core/heading', {
+				level: this.props.attributes.headingLevel,
+			} );
+		}
 	}
 
 	updateInnerAttributes( blockName, newAttributes ) {
@@ -110,7 +123,7 @@ class FoodItem extends Component {
 			this.props.clientId
 		)[ 0 ].innerBlocks;
 
-		innerItems.map( ( item ) => {
+		innerItems.forEach( ( item ) => {
 			if ( item.name === blockName ) {
 				dispatch( 'core/block-editor' ).updateBlockAttributes(
 					item.clientId,
@@ -118,6 +131,13 @@ class FoodItem extends Component {
 				);
 			}
 		} );
+	}
+
+	onChangeHeadingLevel( headingLevel ) {
+		const { setAttributes } = this.props;
+
+		setAttributes( { headingLevel } );
+		this.updateInnerAttributes( 'coblocks/food-item', { headingLevel } );
 	}
 
 	toggleImages() {
@@ -195,7 +215,11 @@ class FoodItem extends Component {
 
 		return (
 			<Fragment>
-				<InspectorControls
+				<Controls
+					{ ...this.props }
+					onChangeHeadingLevel={ this.onChangeHeadingLevel }
+				/>
+				<Inspector
 					attributes={ attributes }
 					activeStyle={ activeStyle }
 					layoutOptions={ layoutOptions }

--- a/src/blocks/food-and-drinks/edit.js
+++ b/src/blocks/food-and-drinks/edit.js
@@ -108,16 +108,6 @@ class FoodItem extends Component {
 		this.onChangeHeadingLevel = this.onChangeHeadingLevel.bind( this );
 	}
 
-	componentDidUpdate( prevProps ) {
-		if (
-			this.props.attributes.headingLevel !== prevProps.attributes.headingLevel
-		) {
-			this.updateInnerAttributes( 'core/heading', {
-				level: this.props.attributes.headingLevel,
-			} );
-		}
-	}
-
 	updateInnerAttributes( blockName, newAttributes ) {
 		const innerItems = select( 'core/block-editor' ).getBlocksByClientId(
 			this.props.clientId

--- a/src/blocks/food-and-drinks/food-item/block.json
+++ b/src/blocks/food-and-drinks/food-item/block.json
@@ -65,6 +65,10 @@
 		"showPrice": {
 			"type": "boolean",
 			"default": true
+		},
+		"headingLevel": {
+			"type": "integer",
+			"default": 4
 		}
 	}
 }

--- a/src/blocks/food-and-drinks/food-item/edit.js
+++ b/src/blocks/food-and-drinks/food-item/edit.js
@@ -2,7 +2,8 @@
  * Internal dependencies.
  */
 import { hasEmptyAttributes } from '../../../utils/block-helpers';
-import InspectorControls from './inspector';
+import Inspector from './inspector';
+import Controls from '../controls';
 import fromEntries from '../../../js/coblocks-fromEntries';
 import icons from './icons';
 
@@ -89,6 +90,29 @@ class FoodAndDrinksEdit extends Component {
 		this.replaceImage = this.replaceImage.bind( this );
 		this.setSpicyTo = this.setSpicyTo.bind( this );
 		this.setHotTo = this.setHotTo.bind( this );
+		this.updateInnerAttributes = this.updateInnerAttributes.bind( this );
+		this.onChangeHeadingLevel = this.onChangeHeadingLevel.bind( this );
+	}
+
+	updateInnerAttributes( blockName, newAttributes ) {
+		const innerItems = select( 'core/block-editor' ).getBlocksByClientId(
+			this.props.clientId
+		)[ 0 ].innerBlocks;
+
+		innerItems.forEach( ( item ) => {
+			if ( item.name === blockName ) {
+				dispatch( 'core/block-editor' ).updateBlockAttributes(
+					item.clientId,
+					newAttributes
+				);
+			}
+		} );
+	}
+
+	onChangeHeadingLevel( headingLevel ) {
+		const { setAttributes } = this.props;
+
+		setAttributes( { headingLevel } );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -235,6 +259,7 @@ class FoodAndDrinksEdit extends Component {
 			url,
 			vegan,
 			vegetarian,
+			headingLevel,
 		} = attributes;
 
 		const richTextAttributes = {
@@ -244,7 +269,11 @@ class FoodAndDrinksEdit extends Component {
 
 		return (
 			<Fragment>
-				<InspectorControls
+				<Controls
+					{ ...this.props }
+					onChangeHeadingLevel={ this.onChangeHeadingLevel }
+				/>
+				<Inspector
 					{ ...this.props }
 					setSpicyTo={ this.setSpicyTo }
 					setHotTo={ this.setHotTo }
@@ -260,7 +289,7 @@ class FoodAndDrinksEdit extends Component {
 						<div className="wp-block-coblocks-food-item__heading-wrapper">
 							<RichText
 								value={ title }
-								tagName="h4"
+								tagName={ `h${ headingLevel }` }
 								wrapperClassName="wp-block-coblocks-food-item__heading"
 								placeholder={ __( 'Add title…', 'coblocks' ) }
 								onChange={ ( newTitle ) => setAttributes( { title: newTitle } ) }

--- a/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
+++ b/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
@@ -103,7 +103,7 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 	/**
 	 * Test the food-and-drinks block saves heading levels set
 	 */
-	it.only( 'Updates the inner blocks when the "Heading Level" control is changed.', function() {
+	it( 'Updates the inner blocks when the "Heading Level" control is changed.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'food-and-drinks' );
 
 		// Assert headings levels are set to default (h4)

--- a/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
+++ b/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
@@ -103,15 +103,15 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 	/**
 	 * Test the food-and-drinks block saves heading levels set
 	 */
-	it( 'Updates the inner blocks when the "Heading Level" control is changed.', function() {
+	it.only( 'Updates the inner blocks when the "Heading Level" control is changed.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'food-and-drinks' );
 
 		// Assert headings levels are set to default (h4)
 		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="coblocks/food-item"] h4' ).should( 'have.length', 2 );
 
 		// Modify the heading level
-		cy.get( '.block-editor-block-contextual-toolbar[data-type="coblocks/food-and-drinks"]' ).find( '[aria-label="Change heading level"]' ).click();
-		cy.get( '.components-popover [role="menu"] button' ).contains( 'Heading 2' ).click();
+		cy.get( '.block-editor-block-toolbar [aria-label="Change heading level"]' ).click();
+		cy.get( 'div[aria-label="Change heading level"][role="menu"] button' ).contains( 'Heading 2' ).click();
 
 		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="coblocks/food-item"] h2' ).should( 'have.length', 2 );
 

--- a/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
+++ b/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
@@ -6,8 +6,8 @@ import 'cypress-file-upload';
 
 describe( 'Test CoBlocks Food and Drinks Block', function() {
 	/**
-	* Setup food-and-drinks data
-	*/
+	 * Setup food-and-drinks data
+	 */
 	const foodData = {
 		price: 33.33,
 		image: {
@@ -19,9 +19,9 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 	};
 
 	/**
-	   * Test that we can add a food-and-drinks block to the content, not alter
-	   * any settings, and are able to successfully save the block without errors.
-	   */
+	 * Test that we can add a food-and-drinks block to the content, not alter
+	 * any settings, and are able to successfully save the block without errors.
+	 */
 	it( 'Test food-and-drinks block saves with empty values.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'food-and-drinks' );
 
@@ -38,9 +38,9 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 	} );
 
 	/**
-	   * Test that we can add a food-and-drinks block to the content,
-	   * and can trigger images attribute on items
-	   */
+	 * Test that we can add a food-and-drinks block to the content,
+	 * and can trigger images attribute on items
+	 */
 	it( 'Test food-and-drinks block saves with image attribute.', function() {
 		const { fileName, imageBase, pathToFixtures } = foodData.image;
 
@@ -52,7 +52,7 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 
 		cy.get( '.wp-block[data-type="coblocks/food-item"]' ).first().click( 'bottom' );
 
-		cy.fixture( pathToFixtures + fileName, 'base64' ).then( fileContent => {
+		cy.fixture( pathToFixtures + fileName, 'base64' ).then( ( fileContent ) => {
 			cy.get( 'div[data-type="coblocks/food-item"]' ).not( 'div[role="toolbar"]' ).first()
 				.find( 'div.components-drop-zone' ).first()
 				.upload(
@@ -78,8 +78,8 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 	} );
 
 	/**
-   * Test the food-and-drinks block saves with custom classes
-   */
+	 * Test the food-and-drinks block saves with custom classes
+	 */
 	it( 'Test the food-and-drinks block custom classes.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'food-and-drinks' );
 
@@ -98,5 +98,20 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 			.should( 'have.class', 'my-custom-class' );
 
 		helpers.editPage();
+	} );
+
+	/**
+	 * Test the food-and-drinks block saves heading levels set
+	 */
+	it( 'Updates the inner blocks when the "Heading Level" control is changed.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'food-and-drinks' );
+
+		cy.get( '.block-editor-block-toolbar [aria-label="Change heading level"]' ).click( { force: true } );
+		cy.get( 'div[aria-label="Change heading level"][role="menu"] button' ).contains( 'Heading 2' ).click( { force: true } );
+		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="core/heading"] h2' ).should( 'have.length', 1 );
+		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="coblocks/food-item"] h2' ).should( 'have.length', 2 );
+
+		helpers.savePage();
+		helpers.checkForBlockErrors( 'food-and-drinks' );
 	} );
 } );

--- a/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
+++ b/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
@@ -108,7 +108,6 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 
 		cy.get( '.block-editor-block-toolbar [aria-label="Change heading level"]' ).click( { force: true } );
 		cy.get( 'div[aria-label="Change heading level"][role="menu"] button' ).contains( 'Heading 2' ).click( { force: true } );
-		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="core/heading"] h2' ).should( 'have.length', 1 );
 		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="coblocks/food-item"] h2' ).should( 'have.length', 2 );
 
 		helpers.savePage();

--- a/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
+++ b/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
@@ -106,11 +106,15 @@ describe( 'Test CoBlocks Food and Drinks Block', function() {
 	it( 'Updates the inner blocks when the "Heading Level" control is changed.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'food-and-drinks' );
 
-		cy.get( '.block-editor-block-toolbar [aria-label="Change heading level"]' ).click( { force: true } );
-		cy.get( 'div[aria-label="Change heading level"][role="menu"] button' ).contains( 'Heading 2' ).click( { force: true } );
+		// Assert headings levels are set to default (h4)
+		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="coblocks/food-item"] h4' ).should( 'have.length', 2 );
+
+		// Modify the heading level
+		cy.get( '.block-editor-block-contextual-toolbar[data-type="coblocks/food-and-drinks"]' ).find( '[aria-label="Change heading level"]' ).click();
+		cy.get( '.components-popover [role="menu"] button' ).contains( 'Heading 2' ).click();
+
 		cy.get( '[data-type="coblocks/food-and-drinks"] [data-type="coblocks/food-item"] h2' ).should( 'have.length', 2 );
 
-		helpers.savePage();
 		helpers.checkForBlockErrors( 'food-and-drinks' );
 	} );
 } );

--- a/src/blocks/highlight/test/highlight.cypress.js
+++ b/src/blocks/highlight/test/highlight.cypress.js
@@ -1,78 +1,47 @@
-/*
+/**
  * Include our constants
  */
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
-describe( 'Test CoBlocks Highlight Block', function() {
+describe( 'Block: Highlight', function () {
 	/**
 	 * Setup accordion data to be used
 	 */
-	const highlightData = [
-		{
-			text: 'We are closed today from 2PM to 4PM.',
-			backgroundColor: '#ff0000',
-			textColor: '#ffffff',
-			backgroundColorRGB: 'rgb(255, 0, 0)',
-			textColorRGB: 'rgb(255, 255, 255)',
-		},
-		{
-			text: 'Due to Server Maintenance, the Server will be down for a few hours.',
-			backgroundColor: '#cce5ff',
-			textColor: '#004085',
-			backgroundColorRGB: 'rgb(204, 229, 255)',
-			textColorRGB: 'rgb(0, 64, 133)',
-		},
-	];
+	const highlightData = {
+		backgroundColor: '#ff0000',
+		textColor: '#ffffff',
+		backgroundColorRGB: 'rgb(255, 0, 0)',
+		textColorRGB: 'rgb(255, 255, 255)',
+	};
+
+	beforeEach( () => {
+		helpers.addCoBlocksBlockToPage( true, 'highlight' );
+	} );
 
 	/**
 	 * Test that we can add a highlight block to the content, not add any text or
 	 * alter any settings, and are able to successfully save the block without errors.
 	 */
-	it( 'Test highlight block saves with empty values.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'highlight' );
-
-		helpers.savePage();
-
+	it( 'can be inserted without errors', function () {
+		cy.get( '.wp-block-coblocks-highlight' ).should( 'exist' );
 		helpers.checkForBlockErrors( 'highlight' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-highlight' )
-			.should( 'have.length', 0 );
-
-		helpers.editPage();
 	} );
 
 	/**
 	 * Test that we can add a hightlight block to the page, add text to it,
 	 * save and it displays properly without errors.
 	 */
-	it( 'Test highlight block saves and displays correctly.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'highlight' );
-
-		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
-			.type( highlightData[ 0 ].text );
-
-		helpers.savePage();
-
+	it( 'can have content', function () {
+		cy.get( '.wp-block-coblocks-highlight' ).find( 'mark' ).click().type( 'highlighted text' );
 		helpers.checkForBlockErrors( 'highlight' );
-
-		helpers.viewPage();
-
-		cy.get( 'p.wp-block-coblocks-highlight' )
-			.contains( highlightData[ 0 ].text );
-
-		helpers.editPage();
 	} );
 
 	/**
 	 * Test the accordion block content font settings
 	 */
-	it( 'Test highlight block font size setting.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'highlight' );
-
+	it( 'Test highlight block font size setting.', function () {
 		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
-			.type( highlightData[ 0 ].text );
+			.type( 'highlighted text' );
 
 		cy.get( '.edit-post-sidebar' )
 			.contains( /default|regular/i )
@@ -93,131 +62,44 @@ describe( 'Test CoBlocks Highlight Block', function() {
 		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
 			.should( 'have.class', 'has-large-font-size' );
 
-		helpers.savePage();
-
 		helpers.checkForBlockErrors( 'highlight' );
-
-		helpers.viewPage();
-
-		cy.get( 'p.wp-block-coblocks-highlight' )
-			.contains( highlightData[ 0 ].text );
-
-		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-			.should( 'have.class', 'has-large-font-size' );
-
-		helpers.editPage();
 	} );
 
 	/**
 	 * Test the highlight block color settings
 	 */
-	it( 'Test highlight block color settings.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'highlight' );
-
+	it( 'Test highlight block color settings.', function () {
 		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
-			.type( highlightData[ 0 ].text );
+			.type( 'highlighted text' );
 
-		helpers.setColorSetting( 'background', highlightData[ 0 ].backgroundColor );
-		helpers.setColorSetting( 'text', highlightData[ 0 ].textColor );
+		helpers.setColorSetting( 'background', highlightData.backgroundColor );
+		helpers.setColorSetting( 'text', highlightData.textColor );
 
 		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
 			.should( 'have.class', 'has-background' );
 
 		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-			.should( 'have.css', 'background-color', highlightData[ 0 ].backgroundColorRGB );
+			.should( 'have.css', 'background-color', highlightData.backgroundColorRGB );
 
 		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
 			.should( 'have.class', 'has-text-color' );
 
 		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-			.should( 'have.css', 'color', highlightData[ 0 ].textColorRGB );
-
-		helpers.savePage();
+			.should( 'have.css', 'color', highlightData.textColorRGB );
 
 		helpers.checkForBlockErrors( 'highlight' );
-
-		helpers.viewPage();
-
-		cy.get( 'p.wp-block-coblocks-highlight' )
-			.contains( highlightData[ 0 ].text );
-
-		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'background-color:' + highlightData[ 0 ].backgroundColor + ';' );
-		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'color:' + highlightData[ 0 ].textColor );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test multiple highlight blocks with custom color settings on each
-	 */
-	it( 'Test multiple highlight blocks with custom color settings.', function() {
-		cy.wrap( highlightData ).each( ( text, index ) => {
-			const nthChild = ( index + 1 );
-
-			// Only clear the editor window on the first block
-			helpers.addCoBlocksBlockToPage( ( 0 === index ), 'highlight' );
-
-			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight' ).find( 'mark' )
-				.type( highlightData[ index ].text );
-
-			helpers.setColorSetting( 'background', highlightData[ index ].backgroundColor );
-			helpers.setColorSetting( 'text', highlightData[ index ].textColor );
-
-			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-				.should( 'have.class', 'has-background' );
-
-			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-				.should( 'have.css', 'background-color', highlightData[ index ].backgroundColorRGB );
-
-			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-				.should( 'have.class', 'has-text-color' );
-
-			cy.get( '.wp-block[data-type="coblocks/highlight"]:nth-child(' + nthChild + ') p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content' )
-				.should( 'have.css', 'color', highlightData[ index ].textColorRGB );
-		} );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'highlight' );
-
-		helpers.viewPage();
-
-		cy.wrap( highlightData ).each( ( text, index ) => {
-			const nthChild = ( index + 1 );
-
-			cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' )
-				.should( 'contain', highlightData[ index ].text );
-
-			cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'background-color:' + highlightData[ index ].backgroundColor + ';' );
-			cy.get( 'p.wp-block-coblocks-highlight:nth-child(' + nthChild + ') mark.wp-block-coblocks-highlight__content' ).invoke( 'attr', 'style' ).should( 'contain', 'color:' + highlightData[ index ].textColor );
-		} );
-
-		helpers.editPage();
 	} );
 
 	/**
 	 * Test the highlight block custom classes
 	 */
-	it( 'Test the highlight block custom classes.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'highlight' );
-
-		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
-			.type( highlightData[ 0 ].text );
+	it( 'Test the highlight block custom classes.', function () {
+		// Workaround for the advanced panel not loading consistently.
+		cy.get( '.editor-post-title' ).click();
 
 		helpers.addCustomBlockClass( 'my-custom-class', 'highlight' );
-
-		helpers.savePage();
+		cy.get( '.wp-block-coblocks-highlight' ).should( 'have.class', 'my-custom-class' );
 
 		helpers.checkForBlockErrors( 'highlight' );
-
-		cy.get( '.wp-block-coblocks-highlight' )
-			.should( 'have.class', 'my-custom-class' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-highlight' )
-			.should( 'have.class', 'my-custom-class' );
-
-		helpers.editPage();
 	} );
 } );

--- a/src/components/heading-toolbar/index.js
+++ b/src/components/heading-toolbar/index.js
@@ -13,7 +13,7 @@ import HeadingLevelIcon from './icon';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { BaseControl, Toolbar } from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
 
 class HeadingToolbar extends Component {
 	createLevelControl( targetLevel, selectedLevel, onChange ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR introduces Heading Toolbar controls to the Food and Drinks and Food Item blocks. Changes allow for hierarchical attribute propagation to inner blocks. Controls added to Food-Item blocks as well for more fine-grained control.

### Screenshots
<!-- if applicable -->
![foodDrinkHeadingControls](https://user-images.githubusercontent.com/30462574/75486244-5f16f680-5969-11ea-91a9-610fd2e98414.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Adds Heading Toolbar controls for Food and Drink and Food Item blocks. This PR also adds a new E2E test for the Heading Toolbar integration.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested with WP 5.3.2 with and without Gutenberg 7.6.
Tested and updated E2E tests for the changed blocks.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
