### PR TITLE
Wrap Google fonts in filter

### DIFF
--- a/src/components/font-family/index.js
+++ b/src/components/font-family/index.js
@@ -19,7 +19,7 @@ function FontFamilyPicker( { label, value, help, instanceId, onChange, className
 		{ value: 'Times New Roman', label: 'Times New Roman' },
 		{ value: 'Georgia', label: 'Georgia' },
 	];
-	const fonts = [];
+	let fonts = [];
 
 	// Add Google Fonts
 	Object.keys( googleFonts ).forEach( ( k ) => {
@@ -31,6 +31,8 @@ function FontFamilyPicker( { label, value, help, instanceId, onChange, className
 	systemFonts.reverse().forEach( ( font ) => {
 		fonts.unshift( font );
 	} );
+
+	fonts = wp.hooks.applyFilters( 'coblocks.google_fonts', fonts );
 
 	const onChangeValue = ( event ) => {
 		const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );

--- a/src/components/font-family/index.js
+++ b/src/components/font-family/index.js
@@ -35,7 +35,7 @@ function FontFamilyPicker( { label, value, help, instanceId, onChange, className
 	/**
 	 * Filter the available list of Google fonts
 	 *
-	 * @type {array}
+	 * @type {Array}
 	 */
 	fonts = wp.hooks.applyFilters( 'coblocks.google_fonts', fonts );
 

--- a/src/components/font-family/index.js
+++ b/src/components/font-family/index.js
@@ -32,6 +32,11 @@ function FontFamilyPicker( { label, value, help, instanceId, onChange, className
 		fonts.unshift( font );
 	} );
 
+	/**
+	 * Filter the available list of Google fonts
+	 *
+	 * @type {array}
+	 */
 	fonts = wp.hooks.applyFilters( 'coblocks.google_fonts', fonts );
 
 	const onChangeValue = ( event ) => {


### PR DESCRIPTION
### Description
Wrap Google fonts in custom filter, allowing users to add additional fonts to CoBlocks typography controls.

### Screenshots
N/A

### Types of changes
New Feature

### How has this been tested?
Created a custom plugin to test that adding custom fonts works as intended, and renders as expected in the editor and on the front of site.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->

### Example Usage Code
```js
/**
 * Make additional custom Google fonts available
 *
 * @param {array} fonts Available Google fonts.
 *
 * @return {array} Filtered Google fonts array.
 */
function filterCoBlocksGoogleFonts( fonts ) {

	let customFonts = [
		'Trade Winds',
		'Odibee Sans',
		'Yeon Sung',
		'Anton',
	];

	for ( let i = 0; i < customFonts.length; i++ ) {
		fonts.push(
			{ value: customFonts[ i ], label: customFonts[ i ] }
		);
	}

	return fonts;

}
wp.hooks.addFilter( 'coblocks.google_fonts', 'coblocks/coblocks.google_fonts', filterCoBlocksGoogleFonts );
```