### PR TITLE
Persist Accordion block open state when editing a post

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,8 @@
   "projectId": "sovnn2",
   "integrationFolder": "./",
 	"testFiles": "**/*.cypress.js",
+	"viewportWidth": 1920,
+	"viewportHeight": 1080,
 	"env": {
 		"testURL": "http://localhost:8889",
 		"wpUsername": "admin",

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -16,22 +16,26 @@ import Controls from './controls';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
 
 /**
  * Constants
  */
-const TEMPLATE = [ [ 'core/paragraph', { placeholder: __( 'Add content…', 'coblocks' ) } ] ];
+const TEMPLATE = [
+	[ 'core/paragraph', { placeholder: __( 'Add content…', 'coblocks' ) } ],
+];
 
 /**
  * Block edit function
  */
-class Edit extends Component {
+class AccordionItemEdit extends Component {
 	render() {
 		const {
 			attributes,
 			backgroundColor,
 			className,
+			isEditing,
 			isSelected,
 			onReplace,
 			setAttributes,
@@ -85,15 +89,15 @@ class Edit extends Component {
 							}
 						} }
 					/>
-					<div
-						className="wp-block-coblocks-accordion-item__content"
-						style={ { borderColor: backgroundColor.color } }
-					>
-						<InnerBlocks
-							template={ TEMPLATE }
-							templateInsertUpdatesSelection={ false }
-						/>
-					</div>
+
+					{ ( isEditing === true || attributes.open ) &&
+						<div className="wp-block-coblocks-accordion-item__content" style={ { borderColor: backgroundColor.color } }>
+							<InnerBlocks
+								template={ TEMPLATE }
+								templateInsertUpdatesSelection={ false }
+							/>
+						</div>
+					}
 				</div>
 			</Fragment>
 		);
@@ -101,5 +105,22 @@ class Edit extends Component {
 }
 
 export default compose( [
+
+	withSelect( ( select, props ) => {
+		const {
+			getBlockHierarchyRootClientId,
+			getSelectedBlockClientId,
+		} = select( 'core/block-editor' );
+
+		// Get clientID of the parent block.
+		const rootClientId = getBlockHierarchyRootClientId( props.clientId );
+		const selectedRootClientId = getBlockHierarchyRootClientId( getSelectedBlockClientId() );
+
+		return {
+			isEditing: rootClientId === selectedRootClientId,
+		};
+	} ),
+
 	applyWithColors,
-] )( Edit );
+
+] )( AccordionItemEdit );

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -59,7 +59,8 @@ class AccordionItemEdit extends Component {
 				<div
 					className={ classnames(
 						className,
-						`${ className }--open`, {
+						{
+							[ `${ className }--open` ]: isEditing === true || attributes.open,
 							'is-selected': isSelected,
 						}
 					) }

--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -123,15 +123,22 @@ class AccordionEdit extends Component {
 
 export default compose( [
 
-	withSelect( ( select ) => {
+	withSelect( ( select, props ) => {
 		const {
 			getBlockAttributes,
 			getBlocksByClientId,
+			getBlockHierarchyRootClientId,
+			getSelectedBlockClientId,
 		} = select( 'core/block-editor' );
+
+		// Get clientID of the parent block.
+		const rootClientId = getBlockHierarchyRootClientId( props.clientId );
+		const selectedRootClientId = getBlockHierarchyRootClientId( getSelectedBlockClientId() );
 
 		return {
 			getBlockAttributes,
 			getBlocksByClientId,
+			isSelected: props.isSelected || rootClientId === selectedRootClientId,
 		};
 	} ),
 

--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -12,6 +12,8 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { IconButton } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -39,7 +41,7 @@ const getCount = memoize( ( count ) => {
 /**
  * Block edit function
  */
-class Edit extends Component {
+class AccordionEdit extends Component {
 	render() {
 		const {
 			clientId,
@@ -52,7 +54,7 @@ class Edit extends Component {
 			count,
 		} = attributes;
 
-		const items = wp.data.select( 'core/block-editor' ).getBlocksByClientId( clientId );
+		const items = this.props.getBlocksByClientId( clientId );
 
 		return (
 			<Fragment>
@@ -80,7 +82,7 @@ class Edit extends Component {
 										let copyAttributes = {};
 
 										if ( lastId ) {
-											const lastBlockClient 	= wp.data.select( 'core/block-editor' ).getBlockAttributes( lastId );
+											const lastBlockClient = this.props.getBlockAttributes( lastId );
 											if ( lastBlockClient.backgroundColor ) {
 												copyAttributes = Object.assign( copyAttributes, {
 													backgroundColor: lastBlockClient.backgroundColor,
@@ -107,7 +109,7 @@ class Edit extends Component {
 										}
 
 										const created = createBlock( 'coblocks/accordion-item', copyAttributes );
-										wp.data.dispatch( 'core/block-editor' ).insertBlock( created, undefined, clientId );
+										this.props.insertBlock( created, undefined, clientId );
 									}
 								} } >
 							</IconButton>
@@ -119,4 +121,28 @@ class Edit extends Component {
 	}
 }
 
-export default Edit;
+export default compose( [
+
+	withSelect( ( select ) => {
+		const {
+			getBlockAttributes,
+			getBlocksByClientId,
+		} = select( 'core/block-editor' );
+
+		return {
+			getBlockAttributes,
+			getBlocksByClientId,
+		};
+	} ),
+
+	withDispatch( ( dispatch ) => {
+		const {
+			insertBlock,
+		} = dispatch( 'core/block-editor' );
+
+		return {
+			insertBlock,
+		};
+	} ),
+
+] )( AccordionEdit );

--- a/src/blocks/accordion/styles/editor.scss
+++ b/src/blocks/accordion/styles/editor.scss
@@ -11,15 +11,6 @@
 	&[data-align="full"] .wp-block-coblocks-accordion {
 		padding: 0 12px;
 	}
-
-	.block-editor-inner-blocks .block-list-appender {
-		display: none;
-	}
-}
-
-// The "Add Accordion Item" button
-.components-coblocks-add-accordion-item {
-	margin-top: -28px;
 }
 
 .components-coblocks-add-accordion-item__button.components-button {

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -4,7 +4,6 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Block: Accordion', () => {
-
 	beforeEach( () => {
 		helpers.addCoBlocksBlockToPage( true, 'accordion' );
 	} );
@@ -47,7 +46,7 @@ describe( 'Block: Accordion', () => {
 	 * Test that multiple accordion items display as expected
 	 */
 	it( 'can add multiple accordion item blocks', () => {
-		cy.get( '[data-type="coblocks/accordion"]' ).click().find('.components-coblocks-add-accordion-item__button' ).click();
+		cy.get( '[data-type="coblocks/accordion"]' ).click( { force: true } ).find( '.components-coblocks-add-accordion-item__button' ).click( );
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
 		helpers.checkForBlockErrors( 'accordion' );

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -4,19 +4,6 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Block: Accordion', () => {
-	/**
-	 * Setup accordion data to be used
-	 */
-	const accordionData = [
-		{
-			title: 'What is the best way to contact you?',
-			text: 'You can reach us by calling (123) 456-7890.',
-		},
-		{
-			title: 'What are your hours of operation?',
-			text: 'We are open 24 hours a day, 7 days a week, 365 days a year.',
-		},
-	];
 
 	beforeEach( () => {
 		helpers.addCoBlocksBlockToPage( true, 'accordion' );
@@ -60,7 +47,6 @@ describe( 'Block: Accordion', () => {
 	 * Test that multiple accordion items display as expected
 	 */
 	it( 'can add multiple accordion item blocks', () => {
-		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item' ).click();
 		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item__button' ).click();
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
@@ -81,7 +67,7 @@ describe( 'Block: Accordion', () => {
 		helpers.setColorSetting( 'text', '#FFFFFF' );
 		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-coblocks-accordion-item__title' ).should( 'have.css', 'color', `rgb(255, 255, 255)` );
 
-		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-paragraph' ).type( 'Content' );
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-paragraph' ).click().type( 'Content' );
 
 		// Content - Background Color
 		helpers.setColorSetting( 'background', '#000000' );

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -47,7 +47,7 @@ describe( 'Block: Accordion', () => {
 	 * Test that multiple accordion items display as expected
 	 */
 	it( 'can add multiple accordion item blocks', () => {
-		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item__button' ).dblclick();
+		cy.get( '[data-type="coblocks/accordion"]' ).click().find('.components-coblocks-add-accordion-item__button' ).click();
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
 		helpers.checkForBlockErrors( 'accordion' );

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -1,12 +1,12 @@
-/*
+/**
  * Include our constants
  */
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
-describe( 'Test CoBlocks Accordion Block', function() {
+describe( 'Block: Accordion', () => {
 	/**
-   * Setup accordion data to be used
-   */
+	 * Setup accordion data to be used
+	 */
 	const accordionData = [
 		{
 			title: 'What is the best way to contact you?',
@@ -18,336 +18,92 @@ describe( 'Test CoBlocks Accordion Block', function() {
 		},
 	];
 
-	/**
-   * Test that we can add an accordion item to the content, not add any text or
-   * alter any settings, and are able to successfuly save the block without errors.
-   */
-	it( 'Test accordion block saves with empty values.', function() {
+	beforeEach( () => {
 		helpers.addCoBlocksBlockToPage( true, 'accordion' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'accordion' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion .wp-block-coblocks-accordion-item' )
-			.should( 'be.empty' );
-
-		helpers.editPage();
 	} );
 
 	/**
-   * Test that we can add an accordion item to the page, add content to it,
-   * save and it displays properly without errors.
-   */
-	it( 'Test accordion block saves and displays correctly.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'accordion' );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 0 ].title );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.type( accordionData[ 0 ].text );
-
-		helpers.savePage();
-
+	 * Test that we can add an accordion item to the content, not add any text or
+	 * alter any settings, and are able to successfuly save the block without errors.
+	 */
+	it( 'can be inserted without errors', () => {
+		cy.get( '[data-type="coblocks/accordion"]' ).should( 'exist' );
 		helpers.checkForBlockErrors( 'accordion' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'not.have.attr', 'open' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.click( { force: true } );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'have.attr', 'open' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.contains( accordionData[ 0 ].title );
-
-		cy.get( '.wp-block-coblocks-accordion-item__content' )
-			.should( 'be.visible' )
-			.contains( accordionData[ 0 ].text );
-
-		helpers.editPage();
 	} );
 
 	/**
-   * Test 'Display Open' attribute works
-   */
-	it( 'Test accordion block "Display Open" attribute works.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'accordion' );
+	 * Test that we can add an accordion item to the page, add content to it,
+	 * save and it displays properly without errors.
+	 */
+	it( 'can be modifed without errors', () => {
+		cy.get( '[data-type="coblocks/accordion"] .wp-block-coblocks-accordion-item__title' ).type( 'title' );
+		helpers.checkForBlockErrors( 'accordion' );
+	} );
 
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 0 ].title );
+	/**
+	 * Test 'Display Open' attribute works
+	 */
+	it( 'can be expanded by default when toggling the "open" attribute', () => {
+		cy.get( '.editor-post-title__input' ).click();
+		cy.get( '[data-type="coblocks/accordion"] .wp-block-coblocks-accordion-item__content' ).should( 'not.exist' );
 
+		cy.get( '[data-type="coblocks/accordion"]' ).click();
 		helpers.toggleSettingCheckbox( 'Display Open' );
 
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.type( accordionData[ 0 ].text );
-
-		helpers.savePage();
+		cy.get( '.editor-post-title__input' ).click();
+		cy.get( '[data-type="coblocks/accordion"] .wp-block-coblocks-accordion-item__content' ).should( 'exist' );
 
 		helpers.checkForBlockErrors( 'accordion' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'have.attr', 'open' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.click( { force: true } );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'not.have.attr', 'open' );
-
-		helpers.editPage();
 	} );
 
 	/**
-   * Test that multiple accordion items display as expected, including a re-order
-   */
-	it( 'Test multiple accordion items display as expected.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'accordion' );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 0 ].title );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.type( accordionData[ 0 ].text );
-
-		cy.get( '.wp-block[data-type="coblocks/accordion"]' )
-			.dblclick( 'right' );
-
-		cy.get( '.components-coblocks-add-accordion-item__button' )
-			.should( 'be.visible' )
-			.click();
-
-		cy.get( '.wp-block-coblocks-accordion-item:nth-child(2) p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 1 ].title );
-
-		cy.get( '.wp-block-coblocks-accordion-item:nth-child(2) p.wp-block-paragraph' )
-			.type( accordionData[ 1 ].text );
-
-		helpers.savePage();
+	 * Test that multiple accordion items display as expected
+	 */
+	it( 'can add multiple accordion item blocks', () => {
+		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item' ).click();
+		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item__button' ).click();
+		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
 		helpers.checkForBlockErrors( 'accordion' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion-item' )
-			.should( 'have.length', 2 );
-
-		cy.wrap( accordionData ).each( ( data, index ) => {
-			const iteration = index + 1,
-				$accordionItem = cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ')' );
-
-			$accordionItem.parent()
-				.should( 'not.have.attr', 'open' );
-
-			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__title' )
-				.contains( accordionData[ index ].title );
-
-			$accordionItem.click( { force: true } );
-
-			$accordionItem.parent()
-				.should( 'have.attr', 'open' );
-
-			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__content' )
-				.contains( accordionData[ index ].text );
-		} );
-
-		helpers.editPage();
-
-		cy.get( '.wp-block[data-type="coblocks/accordion-item"]:nth-child(2)' )
-			.click( 'left' );
-
-		cy.get( '.block-editor-block-mover button[aria-label="Move up"]' )
-			.click();
-
-		cy.get( '.wp-block[data-type="coblocks/accordion-item"]:nth-child(2) p.wp-block-coblocks-accordion-item__title' )
-			.contains( accordionData[ 0 ].title );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'accordion' );
-
-		helpers.viewPage();
-
-		// non-destructive array reverse, since we've re-ordered the accordion tabs
-		const reverseAccordionData = accordionData.slice().reverse();
-
-		cy.wrap( reverseAccordionData ).each( ( data, index ) => {
-			const iteration = index + 1,
-				$accordionItem = cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ')' );
-
-			$accordionItem.parent()
-				.should( 'not.have.attr', 'open' );
-
-			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__title' )
-				.contains( reverseAccordionData[ index ].title );
-
-			$accordionItem.click( { force: true } );
-
-			$accordionItem.parent()
-				.should( 'have.attr', 'open' );
-
-			cy.get( '.wp-block-coblocks-accordion-item:nth-child(' + iteration + ') .wp-block-coblocks-accordion-item__content' )
-				.contains( reverseAccordionData[ index ].text );
-		} );
-
-		helpers.editPage();
 	} );
 
 	/**
-   * Test the accordion block color settings
-   */
-	it( 'Test the accordion block color settings.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'accordion' );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 0 ].title );
+	 * Test the accordion block color settings
+	 */
+	it( 'can apply color settings', () => {
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-coblocks-accordion-item__title' ).type( 'Accordion Title' );
 
 		// Title - Background Color
-		helpers.setColorSetting( 'background', '#8589bd' );
+		helpers.setColorSetting( 'background', '#000000' );
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-coblocks-accordion-item__title' ).should( 'have.css', 'background-color', `rgb(0, 0, 0)` );
 
 		// Title - Text Color
-		helpers.setColorSetting( 'text', '#350745' );
+		helpers.setColorSetting( 'text', '#FFFFFF' );
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-coblocks-accordion-item__title' ).should( 'have.css', 'color', `rgb(255, 255, 255)` );
 
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.type( accordionData[ 0 ].text );
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-paragraph' ).type( 'Content' );
 
 		// Content - Background Color
-		helpers.setColorSetting( 'background', '#55e7ff' );
+		helpers.setColorSetting( 'background', '#000000' );
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-paragraph' ).should( 'have.css', 'background-color', `rgb(0, 0, 0)` );
 
 		// Content - Text Color
-		helpers.setColorSetting( 'text', '#201148' );
-
-		helpers.savePage();
+		helpers.setColorSetting( 'text', '#FFFFFF' );
+		cy.get( '[data-type="coblocks/accordion-item"] .wp-block-paragraph' ).should( 'have.css', 'color', `rgb(255, 255, 255)` );
 
 		helpers.checkForBlockErrors( 'accordion' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.should( 'have.attr', 'style', 'background-color:#8589bd;color:#350745' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.click( { force: true } );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'have.attr', 'open' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__content' )
-			.should( 'be.visible' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__content p' )
-			.should( 'have.attr', 'style', 'background-color:#55e7ff;color:#201148' );
-
-		helpers.editPage();
 	} );
 
 	/**
-   * Test the accordion block content font settings
-   */
-	it( 'Test the accordion block text settings.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'accordion' );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 0 ].title );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.type( accordionData[ 0 ].text );
-
-		cy.get( '.edit-post-sidebar' )
-			.contains( /default|regular/i )
-			.parent()
-			.then( ( $parentElm ) => {
-				if ( $parentElm[ 0 ].type === 'select-one' ) {
-					cy.get( $parentElm[ 0 ] )
-						.select( 'large' );
-				} else {
-					cy.get( $parentElm[ 0 ] )
-						.click()
-						.parent()
-						.contains( /large/i )
-						.click();
-				}
-			} );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.should( 'have.class', 'has-large-font-size' );
-
-		helpers.toggleSettingCheckbox( 'Drop Cap' );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.should( 'have.class', 'has-drop-cap' );
-
-		helpers.savePage();
+	 * Test the accordion block custom classes
+	 */
+	it( 'can have custom classes', () => {
+		cy.get( '[data-type="coblocks/accordion-item"]' ).first().click();
+		helpers.addCustomBlockClass( 'my-custom-class', 'accordion-item' );
 
 		helpers.checkForBlockErrors( 'accordion' );
 
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.should( 'have.class', 'has-large-font-size' )
-			.should( 'have.class', 'has-drop-cap' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'not.have.attr', 'open' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.click( { force: true } );
-
-		cy.get( '.wp-block-coblocks-accordion-item__title' )
-			.parent()
-			.should( 'have.attr', 'open' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__content' )
-			.should( 'be.visible' );
-
-		cy.get( '.wp-block-coblocks-accordion-item__content p' )
-			.should( 'have.class', 'has-large-font-size' )
-			.should( 'have.class', 'has-drop-cap' );
-
-		helpers.editPage();
-	} );
-
-	/**
-   * Test the accordion block custom classes
-   */
-	it( 'Test the accordion block custom classes.', function() {
-		helpers.addCoBlocksBlockToPage( true, 'accordion' );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-coblocks-accordion-item__title' )
-			.type( accordionData[ 0 ].title );
-
-		cy.get( '.wp-block-coblocks-accordion-item p.wp-block-paragraph' )
-			.type( accordionData[ 0 ].text );
-
-		helpers.addCustomBlockClass( 'my-custom-class', 'accordion' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'accordion' );
-
-		cy.get( '.wp-block-coblocks-accordion' )
+		cy.get( '.wp-block-coblocks-accordion-item' )
 			.should( 'have.class', 'my-custom-class' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-accordion' )
-			.should( 'have.class', 'my-custom-class' );
-
-		helpers.editPage();
 	} );
 } );

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -47,7 +47,7 @@ describe( 'Block: Accordion', () => {
 	 * Test that multiple accordion items display as expected
 	 */
 	it( 'can add multiple accordion item blocks', () => {
-		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item__button' ).click();
+		cy.get( '[data-type="coblocks/accordion"] .components-coblocks-add-accordion-item__button' ).dblclick();
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
 		helpers.checkForBlockErrors( 'accordion' );


### PR DESCRIPTION
### Description
Accordion Items display "closed" unless you are interacting with the Accordion Item block (isSelected) or the Accordion Item is set to display open with the open attribute. The Accordion Item will stay open when interacting with child blocks inside the Accordion Item.

### Screenshots
![accordion-block](https://user-images.githubusercontent.com/375788/75719679-32cde380-5ca3-11ea-9edf-77251959ac8b.gif)

### Types of changes
- UX enhancement

### How has this been tested?
Automated end-to-end tests have been created to verify functionality.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->

Closes #1377 