### PR TITLE
Introduce E2E tests for CoBlocks Settings panel

### DIFF
--- a/src/extensions/coblocks-settings/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/coblocks-settings.cypress.js
@@ -3,6 +3,8 @@
  */
 import * as helpers from '../../../.dev/tests/cypress/helpers';
 
+import { addFilter } from '@wordpress/hooks';
+
 describe( 'Extension: CoBlocks Settings', function() {
 	let supportsGradients = false;
 	beforeEach( function() {
@@ -19,24 +21,6 @@ describe( 'Extension: CoBlocks Settings', function() {
 		} );
 		cy.get( '.components-modal__header' ).find( 'button[aria-label="Close dialog"]' ).click();
 	} );
-
-	// /**
-	//  * Test that the CoBlocks panel may be hidden
-	//  */
-	// it( 'Can be filtered to be hidden.', function() {
-	// 	helpers.addCoreBlockToPage( true, 'image' );
-
-	// 	cy.get( '.replace-image-button' ).should( 'not.exist' );
-	// } );
-
-	// /**
-	//  * Test that the CoBlocks panel may be renamed
-	//  */
-	// it( 'Can be filtered with a new title.', function() {
-	// 	helpers.addCoreBlockToPage( true, 'image' );
-
-	// 	cy.get( '.replace-image-button' ).should( 'not.exist' );
-	// } );
 
 	/**
 	 * Test that the CoBlocks panel typography controls function as expected.

--- a/src/extensions/coblocks-settings/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/coblocks-settings.cypress.js
@@ -3,8 +3,6 @@
  */
 import * as helpers from '../../../.dev/tests/cypress/helpers';
 
-import { addFilter } from '@wordpress/hooks';
-
 describe( 'Extension: CoBlocks Settings', function() {
 	let supportsGradients = false;
 	beforeEach( function() {

--- a/src/extensions/coblocks-settings/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/coblocks-settings.cypress.js
@@ -55,17 +55,20 @@ describe( 'Extension: CoBlocks Settings', function() {
 			cy.get( '.block-editor-color-gradient-control button' ).contains( 'Gradient' ).should( 'exist' );
 			cy.get( '.coblocks-modal__content' ).contains( 'Gradient styles' ).click();
 			cy.get( '.block-editor-color-gradient-control button' ).contains( 'Gradient' ).should( 'not.exist' );
+			cy.get( '.coblocks-modal__content' ).contains( 'Gradient styles' ).click(); // Re-enable
 		}
 
 		// Custom Color Picker
 		cy.get( 'button[aria-label="Custom color picker"]' ).should( 'exist' );
 		cy.get( '.coblocks-modal__content' ).contains( 'Custom color pickers' ).click();
 		cy.get( 'button[aria-label="Custom color picker"]' ).should( 'not.exist' );
+		cy.get( '.coblocks-modal__content' ).contains( 'Custom color pickers' ).click();// Re-enable
 
 		// Color Settings
 		cy.get( '.components-panel__body-title' ).contains( /background & text color/i ).should( 'exist' );
 		cy.get( '.coblocks-modal__content' ).contains( 'Color settings' ).click();
 		cy.get( '.components-panel__body-title' ).contains( /background & text color/i ).should( 'not.exist' );
+		cy.get( '.coblocks-modal__content' ).contains( 'Color settings' ).click(); // Re-enable
 
 		cy.get( '.components-modal__header' ).find( 'button[aria-label="Close dialog"]' ).click();
 	} );

--- a/src/extensions/coblocks-settings/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/coblocks-settings.cypress.js
@@ -4,6 +4,22 @@
 import * as helpers from '../../../.dev/tests/cypress/helpers';
 
 describe( 'Extension: CoBlocks Settings', function() {
+	let supportsGradients = false;
+	beforeEach( function() {
+		cy.get( '.edit-post-more-menu' ).click();
+		cy.get( '.components-menu-group' ).find( 'button' ).contains( 'Editor settings' ).click();
+		cy.get( '.coblocks-modal__content' ).find( 'input[type="checkbox"]' ).each( ( checkbox ) => {
+			if ( ! Cypress.$( checkbox ).prop( 'checked' ) ) {
+				cy.get( checkbox ).click();
+			}
+
+			if ( Cypress.$( checkbox ).parents( '.components-base-control__field' ).text() === 'Gradient styles' ) {
+				supportsGradients = true;
+			}
+		} );
+		cy.get( '.components-modal__header' ).find( 'button[aria-label="Close dialog"]' ).click();
+	} );
+
 	// /**
 	//  * Test that the CoBlocks panel may be hidden
 	//  */
@@ -23,20 +39,52 @@ describe( 'Extension: CoBlocks Settings', function() {
 	// } );
 
 	/**
-	 * Test that the CoBlocks panel controls function as expected.
+	 * Test that the CoBlocks panel typography controls function as expected.
 	 */
-	it( 'Can control settings as expected.', function() {
+	it( 'Can control typography settings as expected.', function() {
 		helpers.addCoBlocksBlockToPage( true, 'row' );
 		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
-		helpers.openSettingsPanel( /color settings/i );
 
 		cy.get( '.edit-post-more-menu' ).click();
 		cy.get( '.components-menu-group' ).find( 'button' ).contains( 'Editor settings' ).click();
-		//TODO: get all buttons, look for checked status, and make sure all are enabled before testing.
 
+		// Typography Test
 		cy.get( 'button[aria-label="Change typography"]' ).should( 'exist' );
 		cy.get( '.coblocks-modal__content' ).contains( 'Typography controls' ).click();
 		cy.get( 'button[aria-label="Change typography"]' ).should( 'not.exist' );
+
+		cy.get( '.components-modal__header' ).find( 'button[aria-label="Close dialog"]' ).click();
+	} );
+
+	/**
+	 * Test that the CoBlocks panel colors controls function as expected.
+	 */
+	it( 'Can control color settings as expected.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'hero' );
+		cy.get( '.wp-block-button' ).first().click( { force: true } );
+		helpers.openSettingsPanel( /background & text color/i );
+
+		cy.get( '.edit-post-more-menu' ).click();
+		cy.get( '.components-menu-group' ).find( 'button' ).contains( 'Editor settings' ).click();
+
+		if ( supportsGradients ) {
+			// Gradient Panels
+			cy.get( '.block-editor-color-gradient-control button' ).contains( 'Gradient' ).should( 'exist' );
+			cy.get( '.coblocks-modal__content' ).contains( 'Gradient styles' ).click();
+			cy.get( '.block-editor-color-gradient-control button' ).contains( 'Gradient' ).should( 'not.exist' );
+		}
+
+		// Custom Color Picker
+		cy.get( 'button[aria-label="Custom color picker"]' ).should( 'exist' );
+		cy.get( '.coblocks-modal__content' ).contains( 'Custom color pickers' ).click();
+		cy.get( 'button[aria-label="Custom color picker"]' ).should( 'not.exist' );
+
+		// Color Settings
+		cy.get( '.components-panel__body-title' ).contains( /background & text color/i ).should( 'exist' );
+		cy.get( '.coblocks-modal__content' ).contains( 'Color settings' ).click();
+		cy.get( '.components-panel__body-title' ).contains( /background & text color/i ).should( 'not.exist' );
+
+		cy.get( '.components-modal__header' ).find( 'button[aria-label="Close dialog"]' ).click();
 	} );
 } );

--- a/src/extensions/coblocks-settings/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/coblocks-settings.cypress.js
@@ -1,0 +1,42 @@
+/*
+ * Include our constants
+ */
+import * as helpers from '../../../.dev/tests/cypress/helpers';
+
+describe( 'Extension: CoBlocks Settings', function() {
+	// /**
+	//  * Test that the CoBlocks panel may be hidden
+	//  */
+	// it( 'Can be filtered to be hidden.', function() {
+	// 	helpers.addCoreBlockToPage( true, 'image' );
+
+	// 	cy.get( '.replace-image-button' ).should( 'not.exist' );
+	// } );
+
+	// /**
+	//  * Test that the CoBlocks panel may be renamed
+	//  */
+	// it( 'Can be filtered with a new title.', function() {
+	// 	helpers.addCoreBlockToPage( true, 'image' );
+
+	// 	cy.get( '.replace-image-button' ).should( 'not.exist' );
+	// } );
+
+	/**
+	 * Test that the CoBlocks panel controls function as expected.
+	 */
+	it( 'Can control settings as expected.', function() {
+		helpers.addCoBlocksBlockToPage( true, 'row' );
+		cy.get( 'div[aria-label="Select Row Columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
+		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
+		helpers.openSettingsPanel( /color settings/i );
+
+		cy.get( '.edit-post-more-menu' ).click();
+		cy.get( '.components-menu-group' ).find( 'button' ).contains( 'Editor settings' ).click();
+		//TODO: get all buttons, look for checked status, and make sure all are enabled before testing.
+
+		cy.get( 'button[aria-label="Change typography"]' ).should( 'exist' );
+		cy.get( '.coblocks-modal__content' ).contains( 'Typography controls' ).click();
+		cy.get( 'button[aria-label="Change typography"]' ).should( 'not.exist' );
+	} );
+} );


### PR DESCRIPTION
### Description
Add tests for the CoBlocks settings panel. These tests ensure that the basic functionalities of the CoBlocks Settings control work as expected.

### Screenshots
<!-- if applicable -->
![cypressCoblocksSettings](https://user-images.githubusercontent.com/30462574/75785832-9696f180-5d21-11ea-8581-e9c2e77be85d.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Enhancing stability of CoBlocks by adding tests for plugin extensions.

### How has this been tested?
Tested changed in WordPress 5.3.2 as well as 5.4beta-2. Tested with and without Gutenberg plugin active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
