### PR TITLE
Specify key file in scp during deployment to staging site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ jobs:
       - run:
           name: Deploy plugin to the CoBlocks i18n staging site
           command: |
-            scp -r /tmp/artifacts/coblocks-canary.zip ${STAGING_SITE_SSH_CREDS}:html/wp-content/
+            scp -i ~/.ssh/id_rsa -r /tmp/artifacts/coblocks-canary.zip ${STAGING_SITE_SSH_CREDS}:html/wp-content/
             ssh ${STAGING_SITE_SSH_CREDS} 'cd html/wp-content && wp plugin install coblocks-canary.zip --force --activate --skip-themes --skip-plugins && rm -rf coblocks-canary.zip languages/plugins/coblocks-*'
       - deploy:
           name: Create a canary release on GitHub


### PR DESCRIPTION
### Description
`scp` commands in the deployments were intermittently prompting the user for a password during the deployments to the i18n staging site.

This PR points to the `id_rsa` file so that we are not prompted for a password.
