### PR TITLE
Introduce a filter to disable the CoBlocks bundled svg icons

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -133,6 +133,13 @@ class CoBlocks_Block_Assets {
 		 */
 		$typography_controls_enabled = (bool) apply_filters( 'coblocks_typography_controls_enabled', true, (int) $post_id );
 
+		/**
+		 * Filter to disable all bundled CoBlocks svg icons
+		 *
+		 * @param bool    true Whether or not the bundled icons are displayed.
+		 */
+		$bundled_icons_disabled = (bool) apply_filters( 'coblocks_bundled_icons_disabled', false );
+
 		$form_subject = ( new CoBlocks_Form() )->default_subject();
 
 		wp_localize_script(
@@ -145,6 +152,7 @@ class CoBlocks_Block_Assets {
 				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
+				'bundledIconsDisabled'           => $bundled_icons_disabled,
 				'customIcons'                    => $this->get_custom_icons(),
 				'typographyControlsEnabled'      => $typography_controls_enabled,
 			)

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -136,9 +136,9 @@ class CoBlocks_Block_Assets {
 		/**
 		 * Filter to disable all bundled CoBlocks svg icons
 		 *
-		 * @param bool    true Whether or not the bundled icons are displayed.
+		 * @param bool true Whether or not the bundled icons are displayed.
 		 */
-		$bundled_icons_disabled = (bool) apply_filters( 'coblocks_bundled_icons_disabled', false );
+		$bundled_icons_enabled = (bool) apply_filters( 'coblocks_bundled_icons_enabled', true );
 
 		$form_subject = ( new CoBlocks_Form() )->default_subject();
 
@@ -152,7 +152,7 @@ class CoBlocks_Block_Assets {
 				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
-				'bundledIconsDisabled'           => $bundled_icons_disabled,
+				'bundledIconsEnabled'            => $bundled_icons_enabled,
 				'customIcons'                    => $this->get_custom_icons(),
 				'typographyControlsEnabled'      => $typography_controls_enabled,
 			)

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -154,6 +154,7 @@ class CoBlocks_Block_Assets {
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
 				'bundledIconsEnabled'            => $bundled_icons_enabled,
 				'customIcons'                    => $this->get_custom_icons(),
+				'customIconConfigExists'         => file_exists( get_stylesheet_directory() . '/coblocks/icons/config.json' ),
 				'typographyControlsEnabled'      => $typography_controls_enabled,
 			)
 		);

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -182,7 +182,7 @@ export default compose( [
 	} ),
 ] )( Edit );
 
-if ( typeof wp.domReady === "function" ) {
+if ( 'function' === typeof wp.domReady ) {
 	wp.domReady( () => {
 		// Remove the icon styles when bundled icons are disabled and no custom icon config exists.
 		if ( ! bundledIconsEnabled && ! coblocksBlockData.customIconConfigExists ) {

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -29,10 +29,14 @@ export { MIN_ICON_SIZE, MAX_ICON_SIZE };
 
 class Edit extends Component {
 	componentDidMount() {
+		const bundledIconsEnabled = ( typeof coblocksBlockData === 'undefined' || coblocksBlockData.bundledIconsEnabled );
 		// Check if the icon is the default.
 		if ( this.props.attributes.icon === '' ) {
 			// Randomized the default icon when first added.
-			const defaultIcons = [ 'aperture', 'gesture', 'scatter_plot', 'waves', 'blocks', 'coblocks', 'drafts', 'device_hub', 'marker' ];
+			let defaultIcons = [ 'aperture', 'gesture', 'scatter_plot', 'waves', 'blocks', 'coblocks', 'drafts', 'device_hub', 'marker' ];
+			if ( ! bundledIconsEnabled && Object.keys( coblocksBlockData.customIcons ).length ) {
+				defaultIcons = Object.keys( coblocksBlockData.customIcons );
+			}
 			const rand = defaultIcons[ Math.floor( Math.random() * defaultIcons.length ) ];
 			this.props.setAttributes( { icon: rand } );
 		}

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -18,6 +18,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { ResizableBox } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { domReady } from '@wordpress/dom-ready';
 
 /**
  * Set and export block values.
@@ -27,9 +28,10 @@ const MAX_ICON_SIZE = 400;
 
 export { MIN_ICON_SIZE, MAX_ICON_SIZE };
 
+const bundledIconsEnabled = ( typeof coblocksBlockData === 'undefined' || coblocksBlockData.bundledIconsEnabled );
+
 class Edit extends Component {
 	componentDidMount() {
-		const bundledIconsEnabled = ( typeof coblocksBlockData === 'undefined' || coblocksBlockData.bundledIconsEnabled );
 		// Check if the icon is the default.
 		if ( this.props.attributes.icon === '' ) {
 			// Randomized the default icon when first added.
@@ -179,3 +181,13 @@ export default compose( [
 		};
 	} ),
 ] )( Edit );
+
+if ( typeof wp.domReady === "function" ) {
+	wp.domReady( () => {
+		// Remove the icon styles when bundled icons are disabled and no custom icon config exists.
+		if ( ! bundledIconsEnabled && ! coblocksBlockData.customIconConfigExists ) {
+			wp.blocks.unregisterBlockStyle( 'coblocks/icon', 'filled' );
+			wp.blocks.unregisterBlockStyle( 'coblocks/icon', 'outlined' );
+		}
+	} );
+}

--- a/src/blocks/icon/svgs.js
+++ b/src/blocks/icon/svgs.js
@@ -12,9 +12,9 @@ const svgs = {
 	filled: {},
 };
 
-const disableBundledIcons = ( typeof coblocksBlockData !== 'undefined' && coblocksBlockData.bundledIconsDisabled );
+const bundledIconsEnabled = ( typeof coblocksBlockData !== 'undefined' && coblocksBlockData.bundledIconsEnabled );
 
-let icons = disableBundledIcons ? {} : {
+let icons = bundledIconsEnabled ? {
 	coblocks: {
 		/* translators: icon label */
 		label: __( 'CoBlocks', 'coblocks' ),
@@ -1610,7 +1610,7 @@ let icons = disableBundledIcons ? {} : {
 		],
 		icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M23 7V1h-6v2H7V1H1v6h2v10H1v6h6v-2h10v2h6v-6h-2V7h2zM3 3h2v2H3V3zm2 18H3v-2h2v2zm12-2H7v-2H5V7h2V5h10v2h2v10h-2v2zm4 2h-2v-2h2v2zM19 5V3h2v2h-2zm-5.27 9h-3.49l-.73 2H7.89l3.4-9h1.4l3.41 9h-1.63l-.74-2zm-3.04-1.26h2.61L12 8.91l-1.31 3.83z"/><Path d="M0 0h24v24H0z" fill="none"/></SVG>,
 	},
-};
+} : {};
 
 if ( typeof coblocksBlockData !== 'undefined' && Object.keys( coblocksBlockData.customIcons ).length ) {
 	Object.keys( coblocksBlockData.customIcons ).forEach( function( key ) {

--- a/src/blocks/icon/svgs.js
+++ b/src/blocks/icon/svgs.js
@@ -12,7 +12,9 @@ const svgs = {
 	filled: {},
 };
 
-let icons = ( typeof coblocksBlockData !== 'undefined' && coblocksBlockData.bundledIconsDisabled ) ? {} : {
+const disableBundledIcons = ( typeof coblocksBlockData !== 'undefined' && coblocksBlockData.bundledIconsDisabled );
+
+let icons = disableBundledIcons ? {} : {
 	coblocks: {
 		/* translators: icon label */
 		label: __( 'CoBlocks', 'coblocks' ),

--- a/src/blocks/icon/svgs.js
+++ b/src/blocks/icon/svgs.js
@@ -12,7 +12,7 @@ const svgs = {
 	filled: {},
 };
 
-let icons = {
+let icons = ( typeof coblocksBlockData !== 'undefined' && coblocksBlockData.bundledIconsDisabled ) ? {} : {
 	coblocks: {
 		/* translators: icon label */
 		label: __( 'CoBlocks', 'coblocks' ),

--- a/src/blocks/icon/svgs.js
+++ b/src/blocks/icon/svgs.js
@@ -12,7 +12,7 @@ const svgs = {
 	filled: {},
 };
 
-const bundledIconsEnabled = ( typeof coblocksBlockData !== 'undefined' && coblocksBlockData.bundledIconsEnabled );
+const bundledIconsEnabled = ( typeof coblocksBlockData === 'undefined' || coblocksBlockData.bundledIconsEnabled );
 
 let icons = bundledIconsEnabled ? {
 	coblocks: {


### PR DESCRIPTION
Resolves #1394, #1405

### Description
Introduce a new filter to disable the bundled icons that ship with CoBlocks. This allows users who implement custom icons to remove the excess icons that they may not ever use.

### Screenshots
<img src="https://user-images.githubusercontent.com/5321364/76010443-e53eba00-5ee0-11ea-9e1c-796e2dc3286e.png" width="250" />

### Types of changes
**New filter:** `coblocks_bundled_icons_enabled`
**Note:** I named the filter this way to match the syntax of the typography controls filter, `coblocks_typography_controls_enabled`.

### Usage
```php
add_filter( 'coblocks_bundled_icons_enabled', '__return_false' );
```

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
