### PR TITLE
Fix selected font family option in the typography controls

### DIFF
--- a/src/components/font-family/index.js
+++ b/src/components/font-family/index.js
@@ -87,13 +87,13 @@ function FontFamilyPicker( { label, value, help, instanceId, onChange, className
 				className="components-select-control__input components-select-control__input--coblocks-fontfamily"
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? `${ id }__help` : undefined }
+				value={ value }
 				{ ...props }
 			>
 				{ fonts.map( ( option, index ) =>
 					<option
 						key={ `${ option.label }-${ option.value }-${ index }` }
 						value={ option.value }
-						defaultValue={ value === option.value ? 'selected' : '' }
 					>
 						{ option.label }
 					</option>

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -150,7 +150,7 @@ class TypographyControls extends Component {
 			} );
 		}
 
-		const onFontChange = ( value, onClose ) => {
+		const onFontChange = ( value ) => {
 			setAttributes( { fontFamily: value } );
 
 			if ( typeof googleFonts[ value ] !== 'undefined' && typeof googleFonts[ value ].weight !== 'undefined' ) {
@@ -158,8 +158,6 @@ class TypographyControls extends Component {
 					setAttributes( { fontWeight: undefined } );
 				}
 			}
-
-			onClose();
 		};
 
 		return (
@@ -191,13 +189,13 @@ class TypographyControls extends Component {
 							</IconButton>
 						);
 					} }
-					renderContent={ ( { onClose } ) => (
+					renderContent={ () => (
 						<Fragment>
 							<div className="components-coblocks-typography-dropdown__inner">
 								<FontFamilyPicker
 									label={ __( 'Font', 'coblocks' ) }
 									value={ fontFamily }
-									onChange={ ( nextFontFamily ) => onFontChange( nextFontFamily, onClose ) }
+									onChange={ ( nextFontFamily ) => onFontChange( nextFontFamily ) }
 									className="components-base-control--with-flex components-coblocks-typography-dropdown__inner--font"
 								/>
 								{ ( ( typeof attributes.textPanelFontWeight === 'undefined' || ( typeof attributes.textPanelFontWeight !== 'undefined' && typeof attributes.textPanelFontWeight === 'undefined' ) ) ) ?


### PR DESCRIPTION
Resolves #1374 

### Description
Fix the typography controls font family dropdown value not displaying the selected value. Additionally, changing the font family no longer closes the typography controls panel.

### Screenshots
![typography-controls](https://user-images.githubusercontent.com/5321364/76014468-afe99a80-5ee7-11ea-92b1-ab781fdb2aee.gif)

### Types of changes
This PR fixes the incorrect way to set the selected value in the font family typography controls component. Additionally, changing the font family no longer closes the typography controls panel.

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
