### PR TITLE
Clicking captions opens the light box

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -25,6 +25,7 @@ import jQuery from 'jquery';
 		const arrowLeft = $( '<div/>', { class: 'arrow-left' } );
 
 		const images = $( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure img` );
+		const captions = $( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure figcaption` );
 		let index;
 
 		modalHeading.append( counter, close );
@@ -35,6 +36,14 @@ import jQuery from 'jquery';
 
 		if ( images.length > 0 ) {
 			$( 'body' ).append( wrapper );
+		}
+
+		if ( captions.length > 0 ) {
+			captions.each( function( captionIndex, caption ) {
+				$( caption ).click( function() {
+					changeImage( captionIndex );
+				} );
+			} );
 		}
 
 		const imagePreloader = {};


### PR DESCRIPTION
Resolves #1383 

### Description
Clicking on a gallery caption opens the light box with the respective image.

### Screenshots
https://cldup.com/mMRvkNRjn4.gif

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation -  **Not applicable**
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
