### PR TITLE
Introduce columns into the food and drinks block

### DIFF
--- a/src/blocks/food-and-drinks/food-item/styles/editor.scss
+++ b/src/blocks/food-and-drinks/food-item/styles/editor.scss
@@ -251,6 +251,27 @@
 		}
 	}
 
+	[data-columns="4"] & {
+		flex: 1 25%;
+		max-width: calc(25% - 10px) !important;
+
+		@media all and (max-width: 514px) {
+			max-width: 100% !important;
+		}
+	}
+
+	[data-columns="3"] &,
+	[data-columns="4"] & {
+		.wp-block-coblocks-food-item__heading-wrapper {
+			display: block;
+			margin-bottom: 0.75rem !important;
+		}
+
+		.wp-block-coblocks-food-item__attributes {
+			display: inline-flex;
+		}
+	}
+
 	.block-editor-block-list__block-edit {
 		margin-bottom: 0;
 		margin-top: 0;

--- a/src/blocks/food-and-drinks/food-item/styles/style.scss
+++ b/src/blocks/food-and-drinks/food-item/styles/style.scss
@@ -14,6 +14,23 @@ $icons: (popular), (spicy), (vegan), (vegetarian), (pescatarian), (glutenFree);
 		width: 33.33%;
 	}
 
+	[data-columns="4"] & {
+		flex-grow: 1;
+		width: 25%;
+	}
+
+	[data-columns="3"] &,
+	[data-columns="4"] & {
+		.wp-block-coblocks-food-item__heading-wrapper {
+			display: block;
+		}
+
+		.wp-block-coblocks-food-item__attributes {
+			display: inline-block;
+			margin: 0;
+		}
+	}
+
 	.wp-block-coblocks-food-and-drinks[data-columns="2"]:not(.is-style-list) & {
 
 		&:nth-child(even) {

--- a/src/blocks/food-and-drinks/inspector.js
+++ b/src/blocks/food-and-drinks/inspector.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl, RangeControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
@@ -19,11 +19,13 @@ const Inspector = ( props ) => {
 		onToggleImages,
 		onTogglePrices,
 		onUpdateStyle,
+		onSetColumns,
 	} = props;
 
 	const {
 		showImages,
 		showPrices,
+		columns,
 	} = attributes;
 
 	return (
@@ -81,6 +83,13 @@ const Inspector = ( props ) => {
 					}
 					checked={ showPrices }
 					onChange={ onTogglePrices }
+				/>
+				<RangeControl
+					label={ __( 'Columns', 'coblocks' ) }
+					value={ columns }
+					onChange={ onSetColumns }
+					min={ 2 }
+					max={ 4 }
 				/>
 			</PanelBody>
 		</InspectorControls>


### PR DESCRIPTION
Resolves #662 

### Description
Added the ability to adjust the columns in the food and drinks block.
**Min:** 2
**Max:** 4

### Screenshots
### Settings
<img src="https://user-images.githubusercontent.com/5321364/76117741-5c944c80-5fba-11ea-8835-e41d981e9ec5.png" width="300" />

### Block Editor
![image](https://user-images.githubusercontent.com/5321364/76117786-79c91b00-5fba-11ea-8dbe-30bea8349900.png)

### Front of Site
![image](https://user-images.githubusercontent.com/5321364/76117703-4ab2a980-5fba-11ea-8219-ef30ad58c911.png)

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
