### PR TITLE
Show gallery image captions in light box

### DIFF
--- a/src/components/block-gallery/styles/style/_lightbox.scss
+++ b/src/components/block-gallery/styles/style/_lightbox.scss
@@ -152,10 +152,15 @@
 	}
 }
 
+.coblocks-lightbox__caption {
+	color: #ffffff;
+	text-align: center;
+	margin-top: 10px;
+}
+
 .has-lightbox > :not(.carousel-nav) {
 
 	figure:hover {
 		cursor: zoom-in;
 	}
 }
-

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -19,6 +19,7 @@ import jQuery from 'jquery';
 		const counter = $( '<span/>', { class: 'coblocks-lightbox__count' } );
 		const imageContainer = $( '<div/>', { class: 'coblocks-lightbox__image' } );
 		const image = $( '<img/>' );
+		const caption = $( '<figcaption />', { class: 'coblocks-lightbox__caption' } );
 		const arrowLeftContainer = $( '<button/>', { class: 'coblocks-lightbox__arrow coblocks-lightbox__arrow--left' } );
 		const arrowRightContainer = $( '<button/>', { class: 'coblocks-lightbox__arrow coblocks-lightbox__arrow--right' } );
 		const arrowRight = $( '<div/>', { class: 'arrow-right' } );
@@ -29,6 +30,7 @@ import jQuery from 'jquery';
 
 		modalHeading.append( counter, close );
 		imageContainer.append( image );
+		imageContainer.append( caption );
 		arrowLeftContainer.append( arrowLeft );
 		arrowRightContainer.append( arrowRight );
 		wrapper.append( wrapperBackground, modalHeading, imageContainer, arrowLeftContainer, arrowRightContainer );
@@ -42,6 +44,7 @@ import jQuery from 'jquery';
 		images.each( function( imgIndex, img ) {
 			imagePreloader[ `img-${ imgIndex }` ] = new window.Image();
 			imagePreloader[ `img-${ imgIndex }` ].src = img.attributes.src.value;
+			imagePreloader[ `img-${ imgIndex }` ]['data-caption'] = $( images[ imgIndex ] ).next().text();
 
 			$( img ).click( function() {
 				changeImage( imgIndex );
@@ -71,6 +74,7 @@ import jQuery from 'jquery';
 			wrapper.css( 'display', 'flex' );
 			wrapperBackground.css( 'background-image', 'url(' + imagePreloader[ `img-${ index }` ].src + ')' );
 			image.attr( 'src', imagePreloader[ `img-${ index }` ].src );
+			$( '.coblocks-lightbox__caption' ).text( imagePreloader[ `img-${ index }` ]['data-caption'] );
 			counter.html( ( index + 1 ) + ' / ' + images.length );
 		}
 


### PR DESCRIPTION
Resolves #1099 

### Description
Display gallery image captions in the light box.

### Screenshots
![lightbox-captions-optomized](https://user-images.githubusercontent.com/5321364/76121315-56559e80-5fc1-11ea-9443-57932b127724.gif)

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
