### PR TITLE
Add Form block Text field

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -148,6 +148,7 @@ class CoBlocks_Form {
 			'name',
 			'email',
 			'textarea',
+			'text',
 			'date',
 			'phone',
 			'radio',
@@ -358,6 +359,37 @@ class CoBlocks_Form {
 		<?php
 
 		$textarea_count++;
+
+		return ob_get_clean();
+
+	}
+
+	/**
+	 * Render the text field
+	 *
+	 * @param  array $atts    Block attributes.
+	 *
+	 * @return mixed Markup for the text field.
+	 */
+	public function render_field_text( $atts ) {
+
+		static $text_count = 1;
+
+		$label         = isset( $atts['label'] ) ? $atts['label'] : __( 'Custom response', 'coblocks' );
+		$label_slug    = $text_count > 1 ? sanitize_title( $label . '-' . $text_count ) : sanitize_title( $label );
+		$required_attr = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
+
+		ob_start();
+
+		$this->render_field_label( $atts, $label, $text_count );
+
+		?>
+
+		<input type="text" name="field-<?php echo esc_attr( $label_slug ); ?>[value]" id="<?php echo esc_attr( $label_slug ); ?>" class="coblocks-field coblocks-text" <?php echo esc_attr( $required_attr ); ?>>
+
+		<?php
+
+		$text_count++;
 
 		return ob_get_clean();
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -375,7 +375,7 @@ class CoBlocks_Form {
 
 		static $text_count = 1;
 
-		$label         = isset( $atts['label'] ) ? $atts['label'] : __( 'Custom response', 'coblocks' );
+		$label         = isset( $atts['label'] ) ? $atts['label'] : __( 'Text', 'coblocks' );
 		$label_slug    = $text_count > 1 ? sanitize_title( $label . '-' . $text_count ) : sanitize_title( $label );
 		$required_attr = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
 

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -55,6 +55,7 @@ import * as fieldName from './blocks/form/fields/name';
 import * as fieldRadio from './blocks/form/fields/radio';
 import * as fieldTelephone from './blocks/form/fields/phone';
 import * as fieldTextarea from './blocks/form/fields/textarea';
+import * as fieldText from './blocks/form/fields/text';
 import * as fieldSelect from './blocks/form/fields/select';
 import * as fieldCheckbox from './blocks/form/fields/checkbox';
 import * as fieldWebsite from './blocks/form/fields/website';
@@ -131,6 +132,7 @@ export const registerCoBlocksBlocks = () => {
 		fieldRadio,
 		fieldTelephone,
 		fieldTextarea,
+		fieldText,
 		fieldSelect,
 		fieldCheckbox,
 		fieldWebsite,

--- a/src/blocks/form/fields/text/edit.js
+++ b/src/blocks/form/fields/text/edit.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import CoBlocksFieldLabel from '../field-label';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { TextControl } from '@wordpress/components';
+
+function CoBlocksFieldTextControl( props ) {
+	const { attributes, setAttributes, isSelected } = props;
+	const { required, label } = attributes;
+
+	return (
+		<Fragment>
+			<div className="coblocks-field">
+				<CoBlocksFieldLabel
+					required={ required }
+					label={ label }
+					setAttributes={ setAttributes }
+					isSelected={ isSelected }
+				/>
+				<TextControl />
+			</div>
+		</Fragment>
+	);
+}
+
+export default CoBlocksFieldTextControl;

--- a/src/blocks/form/fields/text/icon.js
+++ b/src/blocks/form/fields/text/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="m19 8h-14c-1.1 0-2 .9-2 2v4c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-4c0-1.1-.9-2-2-2zm0 6h-14v-4h14z" /></SVG>;

--- a/src/blocks/form/fields/text/index.js
+++ b/src/blocks/form/fields/text/index.js
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Block constants
+ */
+const metadata = {
+	name: 'coblocks/field-text',
+	category: 'layout',
+	attributes: {
+		label: {
+			type: 'string',
+			default: __( 'Custom response', 'coblocks' ),
+		},
+		required: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+};
+
+const { name, category, attributes } = metadata;
+
+const settings = {
+	/* translators: block name */
+	title: __( 'Text', 'coblocks' ),
+	/* translators: block description */
+	description: __( 'A text box for custom responses.', 'coblocks' ),
+	// icon,
+	keywords: [
+		'coblocks',
+		/* translators: block keyword */
+		__( 'text control', 'coblocks' ),
+		/* translators: block keyword */
+		__( 'text box', 'coblocks' ),
+		/* translators: block keyword */
+		__( 'input', 'coblocks' ),
+	],
+	parent: [ 'coblocks/form' ],
+	supports: {
+		reusable: false,
+		html: false,
+		customClassName: false,
+	},
+	attributes,
+	edit,
+	save: () => null,
+};
+
+export { name, category, metadata, settings };

--- a/src/blocks/form/fields/text/index.js
+++ b/src/blocks/form/fields/text/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 /**
  * WordPress dependencies
@@ -17,7 +18,7 @@ const metadata = {
 	attributes: {
 		label: {
 			type: 'string',
-			default: __( 'Custom response', 'coblocks' ),
+			default: __( 'Text', 'coblocks' ),
 		},
 		required: {
 			type: 'boolean',
@@ -33,7 +34,7 @@ const settings = {
 	title: __( 'Text', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A text box for custom responses.', 'coblocks' ),
-	// icon,
+	icon,
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/text/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/form/fields/text/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/field-text should render 1`] = `"<!-- wp:coblocks/field-text /-->"`;

--- a/src/blocks/form/fields/text/test/save.spec.js
+++ b/src/blocks/form/fields/text/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The form block allows for a number of custom inputs but lacks the basic text box input mechanism. This PR adds the capability to add a text field to a Form block allowing for custom responses/input from users.

### Screenshots
<!-- if applicable -->
![formTextField](https://user-images.githubusercontent.com/30462574/76321811-c7d26d00-629f-11ea-9958-4e07588da7df.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Add a new child block scoped for the Form block. Basic save test for new block save function. Still requires new icon.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Wrote a test for the new inner block. 
Tested and working with the Gutenberg Plugin.
Tested and working with WP 5.3.2 and WP 5.4RC.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
