### PR TITLE
Fix Icon block spacing when using custom links

### DIFF
--- a/src/blocks/icon/styles/style.scss
+++ b/src/blocks/icon/styles/style.scss
@@ -11,7 +11,6 @@
 			box-shadow: none !important;
 			height: 100%;
 			outline: none;
-			position: absolute;
 			text-shadow: none;
 			width: 100%;
 		}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1428.

### Screenshots
<!-- if applicable -->
**Before**
![image](https://user-images.githubusercontent.com/30462574/77184267-ce759700-6a8c-11ea-9b63-a8dceac93c31.png)

**After**
![image](https://user-images.githubusercontent.com/30462574/77184211-bc93f400-6a8c-11ea-8386-3bb0dab61885.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor CSS change. This properly sets icon spacing when using links with your icons.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Chrome and Firefox.
5.5beta with and without GB.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
