### PR TITLE
Remove 100% height from gallery carousels on front of site

### DIFF
--- a/src/blocks/gallery-carousel/styles/editor.scss
+++ b/src/blocks/gallery-carousel/styles/editor.scss
@@ -9,6 +9,15 @@
 		height: 100%;
 	}
 
+	// Set the carousel to 100% height in the editor
+	.wp-block-coblocks-gallery-carousel {
+
+		&,
+		.coblocks-gallery {
+			height: 100%;
+		}
+	}
+
 	// Fixes issue with multiple dropzones displaying when dropping in an image.
 	.components-drop-zone.is-active {
 

--- a/src/blocks/gallery-carousel/styles/style.scss
+++ b/src/blocks/gallery-carousel/styles/style.scss
@@ -2,7 +2,6 @@
 
 	&,
 	.coblocks-gallery {
-		height: 100%;
 		position: relative;
 		overflow: hidden;
 	}


### PR DESCRIPTION
Resolves #1432 

### Description
I've removed the `height: 100%;` declaration from the `.coblocks-gallery` item on the front of site, as it is not needed.

I've added the height back inside of the editor, so things still render correctly.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/77702152-3e54b780-6f8e-11ea-843b-84b3f74de0f1.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually, visually. The end to end tests also passed, but not sure that tests for any issues like this.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
