### PR TITLE
Fix Map block placeholder styles

### DIFF
--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -8,7 +8,7 @@
 /**
  * Renders the `events` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param array  $attributes The block attributes.
  * @param string $content   The post content.
  *
  * @return string Returns the events content.

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -26,7 +26,6 @@ import { compose } from '@wordpress/compose';
 import {
 	Placeholder,
 	Button,
-	TextControl,
 	ResizableBox,
 	withNotices,
 } from '@wordpress/components';
@@ -283,13 +282,6 @@ class Edit extends Component {
 								onChange={ ( nextAddress ) => this.setState( { address: nextAddress.target.value } ) }
 								onKeyDown={ ( { keyCode } ) => handleKeyDown( keyCode ) }
 							/>
-							{ /* <TextControl
-								className="components-placeholder__input"
-								value={ this.state.address }
-								placeholder={ __( 'Search for a place or address…', 'coblocks' ) }
-								onChange={  }
-								
-							/> */ }
 							<Button
 								isLarge
 								isSecondary
@@ -298,8 +290,6 @@ class Edit extends Component {
 							>
 								{ __( 'Apply', 'coblocks' ) }
 							</Button>
-
-							
 						</form>
 						{ attributes.lng && attributes.hasError && (
 							<span className="invalid-google-maps-api-key">

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -133,7 +133,11 @@ class Edit extends Component {
 
 		const locale = document.documentElement.lang;
 
-		const renderMap = () => {
+		const renderMap = (event) => {
+			if ( event ) {
+				event.preventDefault();
+			}
+			
 			setAttributes( { address: this.state.address, pinned: true } );
 		};
 
@@ -270,42 +274,54 @@ class Edit extends Component {
 						label={ __( 'Google map', 'coblocks' ) }
 						instructions={ __( 'Enter a location or address to drop a pin on a Google map.', 'coblocks' ) }
 					>
-						<TextControl
-							className="components-placeholder__input"
-							value={ this.state.address }
-							placeholder={ __( 'Search for a place or address…', 'coblocks' ) }
-							onChange={ ( nextAddress ) => this.setState( { address: nextAddress } ) }
-							onKeyDown={ ( { keyCode } ) => handleKeyDown( keyCode ) }
-						/>
-						<Button
-							isLarge
-							isSecondary
-							type="button"
-							onClick={ renderMap }
-							disabled={ ! this.state.address }
-						>
-							{ __( 'Apply', 'coblocks' ) }
-						</Button>
-
-						{ address && (
+						<form onSubmit={ renderMap }>
+							<input
+								type="text"
+								value={ this.state.address || '' }
+								className="components-placeholder__input"
+								placeholder={ __( 'Search for a place or address…', 'coblocks' ) }
+								onChange={ ( nextAddress ) => this.setState( { address: nextAddress.target.value } ) }
+								onKeyDown={ ( { keyCode } ) => handleKeyDown( keyCode ) }
+							/>
+							{ /* <TextControl
+								className="components-placeholder__input"
+								value={ this.state.address }
+								placeholder={ __( 'Search for a place or address…', 'coblocks' ) }
+								onChange={  }
+								
+							/> */ }
 							<Button
-								className="components-placeholder__cancel-button"
-								title={ __( 'Cancel', 'coblocks' ) }
-								isLink
-								onClick={ () => {
-									setAttributes( { pinned: ! pinned } );
-									this.setState( { address: this.props.attributes.address } );
-								} }
-								disabled={ ! address }
+								isLarge
+								isSecondary
+								type="submit"
+								disabled={ ! this.state.address }
 							>
-								{ __( 'Cancel', 'coblocks' ) }
+								{ __( 'Apply', 'coblocks' ) }
 							</Button>
-						) }
+
+							
+						</form>
 						{ attributes.lng && attributes.hasError && (
 							<span className="invalid-google-maps-api-key">
 								{ attributes.hasError }
 							</span>
 						) }
+						<div className="components-placeholder__learn-more">
+							{ address && (
+								<Button
+									className="components-placeholder__cancel-button"
+									title={ __( 'Cancel', 'coblocks' ) }
+									isLink
+									onClick={ () => {
+										setAttributes( { pinned: ! pinned } );
+										this.setState( { address: this.props.attributes.address } );
+									} }
+									disabled={ ! address }
+								>
+									{ __( 'Cancel', 'coblocks' ) }
+								</Button>
+							) }
+						</div>
 					</Placeholder>
 				) }
 			</Fragment>

--- a/src/blocks/map/styles/editor.scss
+++ b/src/blocks/map/styles/editor.scss
@@ -13,10 +13,10 @@
 				position: relative;
 				top: 1px;
 			}
-		}
 
-		.components-base-control__field {
-			margin-bottom: 12px;
+			form {
+				margin-bottom: 12px;
+			}
 		}
 
 		.components-placeholder__label {
@@ -48,8 +48,6 @@
 
 	.components-placeholder__cancel-button.is-link {
 		display: block;
-		margin-left: 33%;
-		margin-right: 33%;
 	}
 }
 


### PR DESCRIPTION
### Description
Closes #1439 
PR changes the markup used for the placeholder for the Map block in the edit.js file. Using a form and a general input element similar to the markup used for the core Embed block.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/78797438-8bf8f900-796c-11ea-8dde-e79dfd45e790.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor change adjusts layout of Map block placeholder. No deprecation needed.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested with and without Gutenberg.
Tested with 5.5beta.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
