### PR TITLE
Settings: Return instance on register

### DIFF
--- a/includes/class-coblocks-accordion-ie-support.php
+++ b/includes/class-coblocks-accordion-ie-support.php
@@ -27,11 +27,15 @@ class CoBlocks_Accordion_IE_Support {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Accordion_IE_Support
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Accordion_IE_Support();
 		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -27,11 +27,15 @@ class CoBlocks_Block_Assets {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Block_Assets
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Block_Assets();
 		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-font-loader.php
+++ b/includes/class-coblocks-font-loader.php
@@ -27,11 +27,15 @@ class CoBlocks_Font_Loader {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Font_Loader
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Font_Loader();
 		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-generated-styles.php
+++ b/includes/class-coblocks-generated-styles.php
@@ -27,11 +27,15 @@ class CoBlocks_Generated_Styles {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Generated_Styles
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Generated_Styles();
 		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-google-map-block.php
+++ b/includes/class-coblocks-google-map-block.php
@@ -27,11 +27,15 @@ class CoBlocks_Google_Map_Block {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Google_Map_Block
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Google_Map_Block();
 		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-register-blocks.php
+++ b/includes/class-coblocks-register-blocks.php
@@ -27,11 +27,15 @@ class CoBlocks_Register_Blocks {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Register_Blocks
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Register_Blocks();
 		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-settings.php
+++ b/includes/class-coblocks-settings.php
@@ -28,11 +28,15 @@ class CoBlocks_Settings {
 
 	/**
 	 * Registers the plugin.
+	 *
+	 * @return CoBlocks_Settings
 	 */
 	public static function register() {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Settings();
 		}
+		
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-coblocks-settings.php
+++ b/includes/class-coblocks-settings.php
@@ -35,7 +35,7 @@ class CoBlocks_Settings {
 		if ( null === self::$instance ) {
 			self::$instance = new CoBlocks_Settings();
 		}
-		
+
 		return self::$instance;
 	}
 


### PR DESCRIPTION
Enables plugins to remove the action added in `__contstruct()`.

### Description
Returns the instance of `CoBlocks_Settings` after it was registered.


### Types of changes
Enhancement

### How has this been tested?
Tested locally.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
