### PR TITLE
Unify gutterOption values and remove duplicate code

### DIFF
--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -8,8 +8,8 @@
 /**
  * Renders the `events` block on server.
  *
- * @param array $attributes The block attributes.
- * @param string $content   The post content.
+ * @param array  $attributes The block attributes.
+ * @param string $content    The post content.
  *
  * @return string Returns the events content.
  */

--- a/src/blocks/features/inspector.js
+++ b/src/blocks/features/inspector.js
@@ -5,6 +5,7 @@ import applyWithColors from './colors';
 import { BackgroundPanel } from '../../components/background';
 import DimensionsControl from '../../components/dimensions-control/';
 import OptionSelectorControl from '../../components/option-selector-control';
+import gutterOptions from '../../utils/gutter-options';
 
 /**
  * WordPress dependencies
@@ -82,38 +83,6 @@ class Inspector extends Component {
 			paddingTopTablet,
 			paddingUnit,
 		} = attributes;
-
-		const gutterOptions = [
-			{
-				value: 'no',
-				label: __( 'None', 'coblocks' ),
-				shortName: __( 'None', 'coblocks' ),
-			},
-			{
-				value: 'small',
-				/* translators: abbreviation for small size */
-				label: __( 'S', 'coblocks' ),
-				tooltip: __( 'Small', 'coblocks' ),
-			},
-			{
-				value: 'medium',
-				/* translators: abbreviation for medium size */
-				label: __( 'M', 'coblocks' ),
-				tooltip: __( 'Medium', 'coblocks' ),
-			},
-			{
-				value: 'large',
-				/* translators: abbreviation for large size */
-				label: __( 'L', 'coblocks' ),
-				tooltip: __( 'Large', 'coblocks' ),
-			},
-			{
-				value: 'huge',
-				/* translators: abbreviation for largest size */
-				label: __( 'XL', 'coblocks' ),
-				tooltip: __( 'Huge', 'coblocks' ),
-			},
-		];
 
 		return (
 			<Fragment>

--- a/src/blocks/gallery-collage/inspector.js
+++ b/src/blocks/gallery-collage/inspector.js
@@ -4,6 +4,7 @@
 import captionOptions from '../../components/block-gallery/options/caption-options';
 import GalleryLinkSettings from '../../components/block-gallery/gallery-link-settings';
 import OptionSelectorControl from '../../components/option-selector-control';
+import gutterOptions from '../../utils/gutter-options';
 
 /**
  * WordPress dependencies
@@ -54,38 +55,6 @@ class Inspector extends Component {
 			captionStyle,
 			lightbox,
 		} = attributes;
-
-		const gutterOptions = [
-			{
-				value: 'no',
-				label: __( 'None', 'coblocks' ),
-				shortName: __( 'None', 'coblocks' ),
-			},
-			{
-				value: 'small',
-				/* translators: abbreviation for small size */
-				label: __( 'S', 'coblocks' ),
-				tooltip: __( 'Small', 'coblocks' ),
-			},
-			{
-				value: 'medium',
-				/* translators: abbreviation for medium size */
-				label: __( 'M', 'coblocks' ),
-				tooltip: __( 'Medium', 'coblocks' ),
-			},
-			{
-				value: 'large',
-				/* translators: abbreviation for large size */
-				label: __( 'L', 'coblocks' ),
-				tooltip: __( 'Large', 'coblocks' ),
-			},
-			{
-				value: 'huge',
-				/* translators: abbreviation for largest size */
-				label: __( 'XL', 'coblocks' ),
-				tooltip: __( 'Huge', 'coblocks' ),
-			},
-		];
 
 		const shadowOptions = [
 			{

--- a/src/blocks/gallery-offset/inspector.js
+++ b/src/blocks/gallery-offset/inspector.js
@@ -5,6 +5,7 @@ import GalleryLinkSettings from '../../components/block-gallery/gallery-link-set
 import captionOptions from '../../components/block-gallery/options/caption-options';
 import SizeControl from '../../components/size-control';
 import OptionSelectorControl from '../../components/option-selector-control';
+import gutterOptions from '../../utils/gutter-options';
 
 /**
  * WordPress dependencies
@@ -74,38 +75,6 @@ class Inspector extends Component {
 			captions,
 			captionStyle,
 		} = attributes;
-
-		const gutterOptions = [
-			{
-				value: 'no',
-				label: __( 'None', 'coblocks' ),
-				shortName: __( 'None', 'coblocks' ),
-			},
-			{
-				value: 'small',
-				/* translators: abbreviation for small size */
-				label: __( 'S', 'coblocks' ),
-				tooltip: __( 'Small', 'coblocks' ),
-			},
-			{
-				value: 'medium',
-				/* translators: abbreviation for medium size */
-				label: __( 'M', 'coblocks' ),
-				tooltip: __( 'Medium', 'coblocks' ),
-			},
-			{
-				value: 'large',
-				/* translators: abbreviation for large size */
-				label: __( 'L', 'coblocks' ),
-				tooltip: __( 'Large', 'coblocks' ),
-			},
-			{
-				value: 'huge',
-				/* translators: abbreviation for largest size */
-				label: __( 'XL', 'coblocks' ),
-				tooltip: __( 'Huge', 'coblocks' ),
-			},
-		];
 
 		return (
 			<InspectorControls>

--- a/src/blocks/posts/inspector.js
+++ b/src/blocks/posts/inspector.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import OptionSelectorControl from '../../components/option-selector-control';
+import gutterOptions from '../../utils/gutter-options';
 
 /**
  * WordPress dependencies
@@ -132,33 +133,6 @@ const Inspector = ( props ) => {
 	if ( isHorizontalStyle && columns > 2 ) {
 		columnsCountOnChange( 2 );
 	}
-
-	const gutterOptions = [
-		{
-			value: 'small',
-			/* translators: abbreviation for small size */
-			label: __( 'S', 'coblocks' ),
-			tooltip: __( 'Small', 'coblocks' ),
-		},
-		{
-			value: 'medium',
-			/* translators: abbreviation for medium size */
-			label: __( 'M', 'coblocks' ),
-			tooltip: __( 'Medium', 'coblocks' ),
-		},
-		{
-			value: 'large',
-			/* translators: abbreviation for large size */
-			label: __( 'L', 'coblocks' ),
-			tooltip: __( 'Large', 'coblocks' ),
-		},
-		{
-			value: 'huge',
-			/* translators: abbreviation for largest size */
-			label: __( 'XL', 'coblocks' ),
-			tooltip: __( 'Huge', 'coblocks' ),
-		},
-	];
 
 	const settings = (
 		<PanelBody title={ __( 'Posts settings', 'coblocks' ) }>

--- a/src/blocks/row/inspector.js
+++ b/src/blocks/row/inspector.js
@@ -12,6 +12,7 @@ import applyWithColors from './colors';
 import { BackgroundPanel } from '../../components/background';
 import DimensionsControl from '../../components/dimensions-control';
 import OptionSelectorControl from '../../components/option-selector-control';
+import gutterOptions from '../../utils/gutter-options';
 
 /**
  * WordPress dependencies
@@ -97,33 +98,6 @@ class Inspector extends Component {
 			paddingUnit,
 			hasMarginControl,
 		} = attributes;
-
-		const gutterOptions = [
-			{
-				value: 'small',
-				/* translators: abbreviation for small size */
-				label: __( 'S', 'coblocks' ),
-				tooltip: __( 'Small', 'coblocks' ),
-			},
-			{
-				value: 'medium',
-				/* translators: abbreviation for medium size */
-				label: __( 'M', 'coblocks' ),
-				tooltip: __( 'Medium', 'coblocks' ),
-			},
-			{
-				value: 'large',
-				/* translators: abbreviation for large size */
-				label: __( 'L', 'coblocks' ),
-				tooltip: __( 'Large', 'coblocks' ),
-			},
-			{
-				value: 'huge',
-				/* translators: abbreviation for largest size */
-				label: __( 'XL', 'coblocks' ),
-				tooltip: __( 'Huge', 'coblocks' ),
-			},
-		];
 
 		let selectedRows = 1;
 

--- a/src/blocks/services/inspector.js
+++ b/src/blocks/services/inspector.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import HeadingToolbar from '../../components/heading-toolbar';
 import OptionSelectorControl from '../../components/option-selector-control';
+import gutterOptions from '../../utils/gutter-options';
 
 /**
  * WordPress dependencies.
@@ -27,33 +28,6 @@ const Inspector = ( props ) => {
 		onToggleCtas,
 		onUpdateStyle,
 	} = props;
-
-	const gutterOptions = [
-		{
-			value: 'small',
-			/* translators: abbreviation for small size */
-			label: __( 'S', 'coblocks' ),
-			tooltip: __( 'Small', 'coblocks' ),
-		},
-		{
-			value: 'medium',
-			/* translators: abbreviation for medium size */
-			label: __( 'M', 'coblocks' ),
-			tooltip: __( 'Medium', 'coblocks' ),
-		},
-		{
-			value: 'large',
-			/* translators: abbreviation for large size */
-			label: __( 'L', 'coblocks' ),
-			tooltip: __( 'Large', 'coblocks' ),
-		},
-		{
-			value: 'huge',
-			/* translators: abbreviation for largest size */
-			label: __( 'XL', 'coblocks' ),
-			tooltip: __( 'Huge', 'coblocks' ),
-		},
-	];
 
 	return (
 		<InspectorControls>

--- a/src/utils/gutter-options.js
+++ b/src/utils/gutter-options.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const gutterOptions = [
+	{
+		value: 'no',
+		label: __( 'None', 'coblocks' ),
+		shortName: __( 'None', 'coblocks' ),
+	},
+	{
+		value: 'small',
+		/* translators: abbreviation for small size */
+		label: __( 'S', 'coblocks' ),
+		tooltip: __( 'Small', 'coblocks' ),
+	},
+	{
+		value: 'medium',
+		/* translators: abbreviation for medium size */
+		label: __( 'M', 'coblocks' ),
+		tooltip: __( 'Medium', 'coblocks' ),
+	},
+	{
+		value: 'large',
+		/* translators: abbreviation for large size */
+		label: __( 'L', 'coblocks' ),
+		tooltip: __( 'Large', 'coblocks' ),
+	},
+	{
+		value: 'huge',
+		/* translators: abbreviation for largest size */
+		label: __( 'XL', 'coblocks' ),
+		tooltip: __( 'Huge', 'coblocks' ),
+	},
+];
+
+export default gutterOptions;


### PR DESCRIPTION
### Description
Remove duplicate `gutterOptions` throughout the blocks, and add a `gutter-options.js` utility.

### Screenshots
<img src="https://user-images.githubusercontent.com/5321364/78925581-af559e00-7a69-11ea-8514-00a76d6c0c9c.png" width="300" />

### Types of changes
Refactor existing code base - non-breaking change

### How has this been tested?
Manual checks.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
