### PR TITLE
Do not register if coblocksSettings is undefined

### DIFF
--- a/src/extensions/coblocks-settings/index.js
+++ b/src/extensions/coblocks-settings/index.js
@@ -21,11 +21,7 @@ import { registerPlugin, getPlugin, unregisterPlugin } from '@wordpress/plugins'
 import CoBlocksSettingsModal from './coblocks-settings-modal';
 import createCoBlocksStore from './coblocks-settings-store.js';
 
-if ( typeof coblocksSettings === 'undefined' ) {
-	coblocksSettings.coblocksSettingsEnabled = '0';
-}
-
-if ( coblocksSettings.coblocksSettingsEnabled ) {
+if ( typeof coblocksSettings !== 'undefined' && coblocksSettings.coblocksSettingsEnabled ) {
 	const CoBlocksSettingsMenuItem = () => {
 		const [
 			isOpen,


### PR DESCRIPTION
### Description
If the `coblocksSettings` var is undefined then we should not register the CoBlocks settings menu item at all. Such is the case when executing this extension directly, outside of PHP, where `wp_localize_script()` never runs.

### Screenshots
N/A

### Types of changes
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
