### PR TITLE
Propagate alignment to Hero block inner buttons

### DIFF
--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -19,6 +19,7 @@ import { compose } from '@wordpress/compose';
 import { Component, Fragment } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { ResizableBox, Spinner } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { isBlobURL } from '@wordpress/blob';
  
 /**
@@ -29,7 +30,7 @@ import { isBlobURL } from '@wordpress/blob';
  *
  * @constant
  * @type {string[]}
-*/
+ */
 const ALLOWED_BLOCKS = [ 'core/heading', 'core/paragraph', 'core/spacer', 'core/button', 'core/buttons', 'core/list', 'core/image', 'coblocks/alert', 'coblocks/gif', 'coblocks/social', 'coblocks/row', 'coblocks/column', 'coblocks/buttons' ];
 const TEMPLATE = [
 	[
@@ -112,8 +113,9 @@ export class Edit extends Component {
 	}
 
 	saveMeta( type ) {
-		const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
-		const block = wp.data.select( 'core/block-editor' ).getBlock( this.props.clientId );
+		const { getEditedPostAttribute, getBlock, editPost } = this.props; 
+		const meta = getEditedPostAttribute( 'meta' );
+		const block = getBlock( this.props.clientId );
 		let dimensions = {};
 
 		if ( typeof this.props.attributes.coblocks !== 'undefined' && typeof this.props.attributes.coblocks.id !== 'undefined' ) {
@@ -140,7 +142,7 @@ export class Edit extends Component {
 			dimensions[ id ][ type ] = height;
 
 			// Save values to metadata.
-			wp.data.dispatch( 'core/editor' ).editPost( {
+			editPost( {
 				meta: {
 					_coblocks_responsive_height: JSON.stringify( dimensions ),
 				},
@@ -399,4 +401,25 @@ export class Edit extends Component {
 
 export default compose( [
 	applyWithColors,
+
+	withDispatch( ( dispatch ) => {
+		const { updateBlockAttributes, editPost } = dispatch( 'core/block-editor' );
+
+		return {
+			updateBlockAttributes,
+			editPost,
+		};
+	} ),
+
+	withSelect( ( select, props ) => {
+		const { getBlocks,  } = select( 'core/block-editor' );
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const innerBlocks = getBlocks( props.clientId );
+	
+		return {
+			innerBlocks,
+			getEditedPostAttribute,
+			getBlocks,
+		};
+	} )
 ] )( Edit );

--- a/src/js/deprecations/deprecate-coblocks-buttons.js
+++ b/src/js/deprecations/deprecate-coblocks-buttons.js
@@ -4,28 +4,43 @@
 import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 
+
+
 /**
  * Prevents the CoBlocks Buttons block from being insertable.
  */
 function deprecateCoBlocksButtonsSettings() {
 	const coreButtons = getBlockType( 'core/buttons' );
+	const coBlocksButtons = getBlockType( 'coblocks/buttons' );	
+	if ( buttonsBlockDeprecated(coreButtons, coBlocksButtons) ) {
+		unregisterBlockType( 'coblocks/buttons' );
+		registerBlockType( 'coblocks/buttons', {
+			...coBlocksButtons,
+			supports: {
+				...coBlocksButtons.supports,
+				inserter: false,
+			},
+		} );
+	}
+}
+
+/**
+ * Check whether or not core/buttons is available for use.
+ *
+ * @param {Object} coreButtons The results of getBlockType.
+ * @param {Object} coBlocksButtons The results of getBlockType.
+ * 
+ * @return {boolean} True or false if block is deprecated.
+ */
+export function buttonsBlockDeprecated(coreButtons = getBlockType( 'core/buttons' ), coBlocksButtons = getBlockType( 'coblocks/buttons' )) {
 	if ( ! coreButtons ) {
-		return;
+		return false;
 	}
 
-	const coBlocksButtons = getBlockType( 'coblocks/buttons' );
 	if ( ! coBlocksButtons ) {
-		return;
+		return false;
 	}
-
-	unregisterBlockType( 'coblocks/buttons' );
-	registerBlockType( 'coblocks/buttons', {
-		...coBlocksButtons,
-		supports: {
-			...coBlocksButtons.supports,
-			inserter: false,
-		},
-	} );
+	return true;
 }
 
 domReady( deprecateCoBlocksButtonsSettings );


### PR DESCRIPTION
### Description
PR to set inner block button alignment with Hero block. 
Closes #1460.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Add Select and Dispatch HOC to Grid component to allow setting of inner block attributes. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in 5.4 with and without the Gutenberg plugin.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
