### PR TITLE
Add form block e2e test to confirm emails are being sent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,9 @@ jobs:
       - run:
           name: "Install Mailhog"
           command: bash .dev/bin/install-mailhog.sh
+      - run:
+          name: "Start Mailhog"
+          command: "MailHog"
           background: true
       - run:
           name: "Start WPCLI Server"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
       - run:
           name: "Setup Environment Variables"
           command: |
-            echo "export PATH=$HOME/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
+            echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
             source /home/circleci/.bashrc
       - run:
           name: Setup spec files to run based on git diff-tree
@@ -269,7 +269,7 @@ jobs:
       - run:
           name: "Setup Environment Variables"
           command: |
-            echo "export PATH=$HOME/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
+            echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
             source /home/circleci/.bashrc
       - run:
           name: Setup spec files to run based on git diff-tree

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
     docker:
       - image: circleci/php:latest-node-browsers-legacy
       - image: circleci/mysql:5.7
-    parallelism: 1
+    parallelism: 4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,13 @@ jobs:
             ./vendor/bin/wp post generate --count=5 --path=/tmp/wordpress
             ./vendor/bin/wp plugin activate coblocks --path=/tmp/wordpress
       - run:
+          name: "Install Mailhog"
+          command: bash .dev/bin/install-mailhog.sh
+      - run:
+          name: "Start Mailhog"
+          command: "MailHog"
+          background: true
+      - run:
           name: "Start WPCLI Server"
           command: sudo ./vendor/bin/wp server --host=0.0.0.0 --port=80 --allow-root  --path=/tmp/wordpress
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo "export PATH=$HOME/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
+      - run:
           name: Setup spec files to run based on git diff-tree
           command: bash .dev/bin/setup-test-specs.sh
       - run:
@@ -261,6 +266,11 @@ jobs:
     parallelism: 4
     steps:
       - checkout
+      - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo "export PATH=$HOME/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
       - run:
           name: Setup spec files to run based on git diff-tree
           command: bash .dev/bin/setup-test-specs.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
     docker:
       - image: circleci/php:latest-node-browsers-legacy
       - image: circleci/mysql:5.7
-    parallelism: 4
+    parallelism: 1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,10 @@ jobs:
             ./vendor/bin/wp post generate --count=5 --path=/tmp/wordpress
             ./vendor/bin/wp plugin activate coblocks --path=/tmp/wordpress
       - run:
+          name: "Install Mailhog"
+          command: bash .dev/bin/install-mailhog.sh
+          background: true
+      - run:
           name: "Start WPCLI Server"
           command: sudo ./vendor/bin/wp server --host=0.0.0.0 --port=80 --allow-root  --path=/tmp/wordpress
           background: true

--- a/.dev/bin/install-mailhog.sh
+++ b/.dev/bin/install-mailhog.sh
@@ -7,8 +7,6 @@ echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
 
 brew install mailhog
 
-MailHog
-
 mkdir /tmp/wordpress/wp-content/mu-plugins
 
 # Setup the Mailhog MU plugin

--- a/.dev/bin/install-mailhog.sh
+++ b/.dev/bin/install-mailhog.sh
@@ -5,8 +5,6 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
 echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
 
-export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
-
 brew install mailhog
 
 mkdir /tmp/wordpress/wp-content/mu-plugins

--- a/.dev/bin/install-mailhog.sh
+++ b/.dev/bin/install-mailhog.sh
@@ -10,4 +10,4 @@ brew install mailhog
 mkdir /tmp/wordpress/wp-content/mu-plugins
 
 # Setup the Mailhog MU plugin
-cp ../mailhog.php /tmp/wordpress/wp-content/mu-plugins/mailhog.php
+cp /home/circleci/project/.dev/mailhog.php /tmp/wordpress/wp-content/mu-plugins/mailhog.php

--- a/.dev/bin/install-mailhog.sh
+++ b/.dev/bin/install-mailhog.sh
@@ -1,0 +1,15 @@
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+
+test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
+test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
+echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
+
+brew install mailhog
+
+MailHog
+
+mkdir /tmp/wordpress/wp-content/mu-plugins
+
+# Setup the Mailhog MU plugin
+cp ../mailhog.php /tmp/wordpress/wp-content/mu-plugins/mailhog.php

--- a/.dev/bin/install-mailhog.sh
+++ b/.dev/bin/install-mailhog.sh
@@ -5,6 +5,8 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
 echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
 
+export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
+
 brew install mailhog
 
 mkdir /tmp/wordpress/wp-content/mu-plugins

--- a/.dev/mailhog.php
+++ b/.dev/mailhog.php
@@ -1,28 +1,13 @@
 <?php
 
 add_action( 'phpmailer_init', function( $phpmailer ) {
-	// Define that we are sending with SMTP
+	// Define that we are sending with SMTP.
 	$phpmailer->isSMTP();
 
-	// The hostname of the mail server
-	$phpmailer->Host = 'localhost';
-
-	// Use SMTP authentication (true|false)
+	// Set options.
+	$phpmailer->Host     = 'localhost';
 	$phpmailer->SMTPAuth = false;
-
-	// SMTP port number
-	// Mailhog normally run on port 1025
-	$phpmailer->Port = '1025';
-
-	// Username to use for SMTP authentication
-	// $phpmailer->Username = 'yourusername';
-
-	// Password to use for SMTP authentication
-	// $phpmailer->Password = 'yourpassword';
-
-	// The encryption system to use - ssl (deprecated) or tls
-	// $phpmailer->SMTPSecure = 'tls';
-
-	$phpmailer->From = 'admin@wp.dev';
+	$phpmailer->Port     = '1025';
+	$phpmailer->From     = 'admin@wp.dev';
 	$phpmailer->FromName = 'WP DEV';
 }, 10, 1 );

--- a/.dev/mailhog.php
+++ b/.dev/mailhog.php
@@ -1,0 +1,28 @@
+<?php
+
+add_action( 'phpmailer_init', function( $phpmailer ) {
+	// Define that we are sending with SMTP
+	$phpmailer->isSMTP();
+
+	// The hostname of the mail server
+	$phpmailer->Host = 'localhost';
+
+	// Use SMTP authentication (true|false)
+	$phpmailer->SMTPAuth = false;
+
+	// SMTP port number
+	// Mailhog normally run on port 1025
+	$phpmailer->Port = '1025';
+
+	// Username to use for SMTP authentication
+	// $phpmailer->Username = 'yourusername';
+
+	// Password to use for SMTP authentication
+	// $phpmailer->Password = 'yourpassword';
+
+	// The encryption system to use - ssl (deprecated) or tls
+	// $phpmailer->SMTPSecure = 'tls';
+
+	$phpmailer->From = 'admin@wp.dev';
+	$phpmailer->FromName = 'WP DEV';
+}, 10, 1 );

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -61,15 +61,6 @@ class CoBlocks_Form {
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'form_recaptcha_assets' ) );
 
-		// define the wp_mail_failed callback
-
-
-// add the action
-add_action('wp_mail_failed', function($wp_error)
-{
-		wp_die( print_r( $wp_error ) );
-}, 10, 1);
-
 
 	}
 
@@ -208,11 +199,6 @@ add_action('wp_mail_failed', function($wp_error)
 		<div class="coblocks-form" id="<?php echo esc_attr( $this->form_hash ); ?>">
 
 			<?php
-
-			echo 'Submitted Hash: ' . $submitted_hash . ' <br />';
-			echo '$this->form_hash: ' . $this->form_hash;
-
-			echo '<hr />';
 
 			if ( $submitted_hash === $this->form_hash ) {
 
@@ -835,8 +821,6 @@ add_action('wp_mail_failed', function($wp_error)
 
 		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission ) {
 
-			wp_die( 'Error 1' );
-
 			return;
 
 		}
@@ -844,8 +828,6 @@ add_action('wp_mail_failed', function($wp_error)
 		$nonce = filter_input( INPUT_POST, 'form-submit', FILTER_SANITIZE_STRING );
 
 		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'coblocks-form-submit' ) ) {
-
-			wp_die( 'Error 2' );
 
 			return;
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -199,6 +199,11 @@ class CoBlocks_Form {
 
 			<?php
 
+			echo 'Submitted Hash: ' . $submitted_hash . ' <br />';
+			echo '$this->form_hash: ' . $this->form_hash;
+
+			echo '<hr />';
+
 			if ( $submitted_hash === $this->form_hash ) {
 
 				$submit_form = $this->process_form_submission( $atts );
@@ -212,10 +217,6 @@ class CoBlocks_Form {
 					return ob_get_clean();
 
 				}
-			} else {
-
-				wp_die( 'Form hashes do not match... Submitted: ' . $submitted_hash . ' || Form Hash: ' . $this->form_hash );
-
 			}
 
 			?>

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -61,6 +61,16 @@ class CoBlocks_Form {
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'form_recaptcha_assets' ) );
 
+		// define the wp_mail_failed callback
+
+
+// add the action
+add_action('wp_mail_failed', function($wp_error)
+{
+		wp_die( print_r( $wp_error ) );
+}, 10, 1);
+
+
 	}
 
 	/**

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -212,6 +212,10 @@ class CoBlocks_Form {
 					return ob_get_clean();
 
 				}
+			} else {
+
+				wp_die( 'Form hashes do not match... Submitted: ' . $submitted_hash . ' || Form Hash: ' . $this->form_hash );
+
 			}
 
 			?>
@@ -820,6 +824,8 @@ class CoBlocks_Form {
 
 		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission ) {
 
+			wp_die( 'Error 1' );
+
 			return;
 
 		}
@@ -827,6 +833,8 @@ class CoBlocks_Form {
 		$nonce = filter_input( INPUT_POST, 'form-submit', FILTER_SANITIZE_STRING );
 
 		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'coblocks-form-submit' ) ) {
+
+			wp_die( 'Error 2' );
 
 			return;
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -61,7 +61,6 @@ class CoBlocks_Form {
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'form_recaptcha_assets' ) );
 
-
 	}
 
 	/**

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -325,5 +325,6 @@ describe( 'Test CoBlocks Form Block', function() {
 			.should( 'contain', 'Email: email@example.com' )
 			.should( 'contain', 'Message: My message for you.' );
 
+		helpers.editPage();
 	} );
 } );

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -4,276 +4,276 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Form Block', function() {
-	// /**
-	//  * Test the coblock contact template.
-	//  */
-	// it( 'Test the form block contact template.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:first-child' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-name"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	helpers.savePage();
-	//
-	// 	helpers.checkForBlockErrors( 'coblocks/form' );
-	//
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	// Check labels
-	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-	// 		switch ( $index ) {
-	// 			case 0:
-	// 				cy.get( $element ).contains( 'Name' );
-	// 				break;
-	//
-	// 			case 1:
-	// 				cy.get( $element ).contains( 'Email' );
-	// 				break;
-	//
-	// 			case 2:
-	// 				cy.get( $element ).contains( 'Message' );
-	// 				break;
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'input[name="field-name[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'textarea[name="field-message[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.contains( 'Contact Us' );
-	//
-	// 	helpers.editPage();
-	// } );
-	//
-	// /**
-	//  * Test the coblock RSVP template.
-	//  */
-	// it( 'Test the form block RSVP template.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( '.coblocks-field--name' )
-	// 		.its( 'length' )
-	// 		.should( 'equal', 2 );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	helpers.savePage();
-	//
-	// 	helpers.checkForBlockErrors( 'coblocks/form' );
-	//
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	// Check labels
-	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-	// 		switch ( $index ) {
-	// 			case 0:
-	// 				cy.get( $element ).contains( 'Name' );
-	// 				break;
-	//
-	// 			case 1:
-	// 				cy.get( $element ).contains( 'Plus one' );
-	// 				break;
-	//
-	// 			case 2:
-	// 				cy.get( $element ).contains( 'Email' );
-	// 				break;
-	//
-	// 			case 3:
-	// 				cy.get( $element ).contains( 'Will you be attending?' );
-	// 				break;
-	//
-	// 			case 4:
-	// 				cy.get( $element ).contains( 'Notes?' );
-	// 				break;
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-will-you-be-attending[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'textarea[name="field-notes[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.contains( 'RSVP' );
-	//
-	// 	helpers.editPage();
-	// } );
-	//
-	// /**
-	//  * Test the coblock appointment template.
-	//  */
-	// it( 'Test the form block appointment template.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( '.coblocks-field--name' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-phone"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-date"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	helpers.savePage();
-	//
-	// 	helpers.checkForBlockErrors( 'coblocks/form' );
-	//
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	// Check labels
-	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-	// 		switch ( $index ) {
-	// 			case 0:
-	// 				cy.get( $element ).contains( 'Name' );
-	// 				break;
-	//
-	// 			case 1:
-	// 				cy.get( $element ).contains( 'Phone' );
-	// 				break;
-	//
-	// 			case 2:
-	// 				cy.get( $element ).contains( 'Email' );
-	// 				break;
-	//
-	// 			case 3:
-	// 				cy.get( $element ).contains( 'Date' );
-	// 				break;
-	//
-	// 			case 4:
-	// 				cy.get( $element ).contains( 'Time' );
-	// 				break;
-	//
-	// 			case 5:
-	// 				cy.get( $element ).contains( 'Special Notes' );
-	// 				break;
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-phone[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-date[value]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-time[value]"]' )
-	// 		.its( 'length' )
-	// 		.should( 'equal', 2 );
-	//
-	// 	cy.get( 'textarea[name="field-special-notes[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.contains( 'Book Appointment' );
-	//
-	// 	helpers.editPage();
-	// } );
+	/**
+	 * Test the coblock contact template.
+	 */
+	it( 'Test the form block contact template.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:first-child' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( 'div[data-type="coblocks/field-name"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-email"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/form' );
+
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		// Check labels
+		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+			switch ( $index ) {
+				case 0:
+					cy.get( $element ).contains( 'Name' );
+					break;
+
+				case 1:
+					cy.get( $element ).contains( 'Email' );
+					break;
+
+				case 2:
+					cy.get( $element ).contains( 'Message' );
+					break;
+			}
+		} );
+
+		cy.get( 'input[name="field-name[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'textarea[name="field-message[value]"]' )
+			.should( 'exist' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.contains( 'Contact Us' );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test the coblock RSVP template.
+	 */
+	it( 'Test the form block RSVP template.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( '.coblocks-field--name' )
+			.its( 'length' )
+			.should( 'equal', 2 );
+
+		cy.get( 'div[data-type="coblocks/field-email"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-radio"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/form' );
+
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		// Check labels
+		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+			switch ( $index ) {
+				case 0:
+					cy.get( $element ).contains( 'Name' );
+					break;
+
+				case 1:
+					cy.get( $element ).contains( 'Plus one' );
+					break;
+
+				case 2:
+					cy.get( $element ).contains( 'Email' );
+					break;
+
+				case 3:
+					cy.get( $element ).contains( 'Will you be attending?' );
+					break;
+
+				case 4:
+					cy.get( $element ).contains( 'Notes?' );
+					break;
+			}
+		} );
+
+		cy.get( 'input[name="field-name[value][first-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value][last-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-will-you-be-attending[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'textarea[name="field-notes[value]"]' )
+			.should( 'exist' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.contains( 'RSVP' );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test the coblock appointment template.
+	 */
+	it( 'Test the form block appointment template.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( '.coblocks-field--name' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-phone"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-email"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-date"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-radio"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/form' );
+
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		// Check labels
+		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+			switch ( $index ) {
+				case 0:
+					cy.get( $element ).contains( 'Name' );
+					break;
+
+				case 1:
+					cy.get( $element ).contains( 'Phone' );
+					break;
+
+				case 2:
+					cy.get( $element ).contains( 'Email' );
+					break;
+
+				case 3:
+					cy.get( $element ).contains( 'Date' );
+					break;
+
+				case 4:
+					cy.get( $element ).contains( 'Time' );
+					break;
+
+				case 5:
+					cy.get( $element ).contains( 'Special Notes' );
+					break;
+			}
+		} );
+
+		cy.get( 'input[name="field-name[value][first-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value][last-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-phone[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-date[value]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-time[value]"]' )
+			.its( 'length' )
+			.should( 'equal', 2 );
+
+		cy.get( 'textarea[name="field-special-notes[value]"]' )
+			.should( 'exist' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.contains( 'Book Appointment' );
+
+		helpers.editPage();
+	} );
 
 	/**
 	 * Test the coblock contact template.

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -4,6 +4,277 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Form Block', function() {
+	// /**
+	//  * Test the coblock contact template.
+	//  */
+	// it( 'Test the form block contact template.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:first-child' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-name"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	helpers.savePage();
+	//
+	// 	helpers.checkForBlockErrors( 'coblocks/form' );
+	//
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	// Check labels
+	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+	// 		switch ( $index ) {
+	// 			case 0:
+	// 				cy.get( $element ).contains( 'Name' );
+	// 				break;
+	//
+	// 			case 1:
+	// 				cy.get( $element ).contains( 'Email' );
+	// 				break;
+	//
+	// 			case 2:
+	// 				cy.get( $element ).contains( 'Message' );
+	// 				break;
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'input[name="field-name[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'textarea[name="field-message[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.contains( 'Contact Us' );
+	//
+	// 	helpers.editPage();
+	// } );
+	//
+	// /**
+	//  * Test the coblock RSVP template.
+	//  */
+	// it( 'Test the form block RSVP template.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( '.coblocks-field--name' )
+	// 		.its( 'length' )
+	// 		.should( 'equal', 2 );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	helpers.savePage();
+	//
+	// 	helpers.checkForBlockErrors( 'coblocks/form' );
+	//
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	// Check labels
+	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+	// 		switch ( $index ) {
+	// 			case 0:
+	// 				cy.get( $element ).contains( 'Name' );
+	// 				break;
+	//
+	// 			case 1:
+	// 				cy.get( $element ).contains( 'Plus one' );
+	// 				break;
+	//
+	// 			case 2:
+	// 				cy.get( $element ).contains( 'Email' );
+	// 				break;
+	//
+	// 			case 3:
+	// 				cy.get( $element ).contains( 'Will you be attending?' );
+	// 				break;
+	//
+	// 			case 4:
+	// 				cy.get( $element ).contains( 'Notes?' );
+	// 				break;
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-will-you-be-attending[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'textarea[name="field-notes[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.contains( 'RSVP' );
+	//
+	// 	helpers.editPage();
+	// } );
+	//
+	// /**
+	//  * Test the coblock appointment template.
+	//  */
+	// it( 'Test the form block appointment template.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( '.coblocks-field--name' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-phone"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-date"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	helpers.savePage();
+	//
+	// 	helpers.checkForBlockErrors( 'coblocks/form' );
+	//
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	// Check labels
+	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+	// 		switch ( $index ) {
+	// 			case 0:
+	// 				cy.get( $element ).contains( 'Name' );
+	// 				break;
+	//
+	// 			case 1:
+	// 				cy.get( $element ).contains( 'Phone' );
+	// 				break;
+	//
+	// 			case 2:
+	// 				cy.get( $element ).contains( 'Email' );
+	// 				break;
+	//
+	// 			case 3:
+	// 				cy.get( $element ).contains( 'Date' );
+	// 				break;
+	//
+	// 			case 4:
+	// 				cy.get( $element ).contains( 'Time' );
+	// 				break;
+	//
+	// 			case 5:
+	// 				cy.get( $element ).contains( 'Special Notes' );
+	// 				break;
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-phone[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-date[value]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-time[value]"]' )
+	// 		.its( 'length' )
+	// 		.should( 'equal', 2 );
+	//
+	// 	cy.get( 'textarea[name="field-special-notes[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.contains( 'Book Appointment' );
+	//
+	// 	helpers.editPage();
+	// } );
+
 	/**
 	 * Test the coblock contact template.
 	 */
@@ -24,254 +295,35 @@ describe( 'Test CoBlocks Form Block', function() {
 			}
 		} );
 
-		cy.get( 'div[data-type="coblocks/field-name"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-email"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
 		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/form' );
-
 		helpers.viewPage();
 
 		cy.get( '.coblocks-form' )
 			.should( 'exist' );
-
-		// Check labels
-		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-			switch ( $index ) {
-				case 0:
-					cy.get( $element ).contains( 'Name' );
-					break;
-
-				case 1:
-					cy.get( $element ).contains( 'Email' );
-					break;
-
-				case 2:
-					cy.get( $element ).contains( 'Message' );
-					break;
-			}
-		} );
 
 		cy.get( 'input[name="field-name[value]"]' )
-			.should( 'exist' );
+			.type( 'Name' );
 
 		cy.get( 'input[name="field-email[value]"]' )
-			.should( 'exist' );
+			.type( 'email@example.com' );
 
 		cy.get( 'textarea[name="field-message[value]"]' )
-			.should( 'exist' );
+			.type( 'My message for you.' );
 
 		cy.get( '.coblocks-form__submit button' )
-			.contains( 'Contact Us' );
+			.click();
 
-		helpers.editPage();
-	} );
+		cy.get( '.coblocks-form__submitted' ).contains( 'Your message was sent:' );
 
-	/**
-	 * Test the coblock RSVP template.
-	 */
-	it( 'Test the form block RSVP template.', function() {
-		helpers.addBlockToPost( 'coblocks/form', true );
+		cy.get( '.coblocks-form__submitted ul li:first-child' ).contains( 'Name: Name' );
+		cy.get( '.coblocks-form__submitted ul li:nth-child(2)' ).contains( 'Email: email@example.com' );
+		cy.get( '.coblocks-form__submitted ul li:last-child' ).contains( 'Message: My message for you.' );
 
-		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-				cy.get( placeholder )
-					.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
-					.find( 'button' ).click( { force: true } );
-			} else {
-				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
-					.click();
+		cy.exec( 'curl http://127.0.0.1:8025/api/v2/messages' )
+			.its( 'stdout' )
+			.should( 'contain', 'Name: Name' )
+			.should( 'contain', 'Email: email@example.com' )
+			.should( 'contain', 'Message: My message for you.' );
 
-				cy.get( '.block-editor-inner-blocks__template-picker-options' )
-					.should( 'not.exist' );
-			}
-		} );
-
-		cy.get( '.coblocks-field--name' )
-			.its( 'length' )
-			.should( 'equal', 2 );
-
-		cy.get( 'div[data-type="coblocks/field-email"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-radio"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/form' );
-
-		helpers.viewPage();
-
-		cy.get( '.coblocks-form' )
-			.should( 'exist' );
-
-		// Check labels
-		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-			switch ( $index ) {
-				case 0:
-					cy.get( $element ).contains( 'Name' );
-					break;
-
-				case 1:
-					cy.get( $element ).contains( 'Plus one' );
-					break;
-
-				case 2:
-					cy.get( $element ).contains( 'Email' );
-					break;
-
-				case 3:
-					cy.get( $element ).contains( 'Will you be attending?' );
-					break;
-
-				case 4:
-					cy.get( $element ).contains( 'Notes?' );
-					break;
-			}
-		} );
-
-		cy.get( 'input[name="field-name[value][first-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-name[value][last-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-email[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-will-you-be-attending[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'textarea[name="field-notes[value]"]' )
-			.should( 'exist' );
-
-		cy.get( '.coblocks-form__submit button' )
-			.contains( 'RSVP' );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test the coblock appointment template.
-	 */
-	it( 'Test the form block appointment template.', function() {
-		helpers.addBlockToPost( 'coblocks/form', true );
-
-		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-				cy.get( placeholder )
-					.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
-					.find( 'button' ).click( { force: true } );
-			} else {
-				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
-					.click();
-
-				cy.get( '.block-editor-inner-blocks__template-picker-options' )
-					.should( 'not.exist' );
-			}
-		} );
-
-		cy.get( '.coblocks-field--name' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-phone"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-email"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-date"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-radio"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/form' );
-
-		helpers.viewPage();
-
-		cy.get( '.coblocks-form' )
-			.should( 'exist' );
-
-		// Check labels
-		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-			switch ( $index ) {
-				case 0:
-					cy.get( $element ).contains( 'Name' );
-					break;
-
-				case 1:
-					cy.get( $element ).contains( 'Phone' );
-					break;
-
-				case 2:
-					cy.get( $element ).contains( 'Email' );
-					break;
-
-				case 3:
-					cy.get( $element ).contains( 'Date' );
-					break;
-
-				case 4:
-					cy.get( $element ).contains( 'Time' );
-					break;
-
-				case 5:
-					cy.get( $element ).contains( 'Special Notes' );
-					break;
-			}
-		} );
-
-		cy.get( 'input[name="field-name[value][first-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-name[value][last-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-phone[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-email[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-date[value]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-time[value]"]' )
-			.its( 'length' )
-			.should( 'equal', 2 );
-
-		cy.get( 'textarea[name="field-special-notes[value]"]' )
-			.should( 'exist' );
-
-		cy.get( '.coblocks-form__submit button' )
-			.contains( 'Book Appointment' );
-
-		helpers.editPage();
 	} );
 } );

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -278,7 +278,7 @@ describe( 'Test CoBlocks Form Block', function() {
 	/**
 	 * Test the coblock contact template.
 	 */
-	it( 'Test the form block contact template.', function() {
+	it( 'Test the form block email is sent and received.', function() {
 		helpers.addBlockToPost( 'coblocks/form', true );
 
 		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -4,329 +4,329 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Form Block', function() {
-	/**
-	 * Test the coblock contact template.
-	 */
-	it( 'Test the form block contact template.', function() {
-		helpers.addBlockToPost( 'coblocks/form', true );
-
-		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-				cy.get( placeholder )
-					.find( '.block-editor-block-variation-picker__variations li:first-child' )
-					.find( 'button' ).click( { force: true } );
-			} else {
-				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
-					.click();
-
-				cy.get( '.block-editor-inner-blocks__template-picker-options' )
-					.should( 'not.exist' );
-			}
-		} );
-
-		cy.get( 'div[data-type="coblocks/field-name"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-email"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/form' );
-
-		helpers.viewPage();
-
-		cy.get( '.coblocks-form' )
-			.should( 'exist' );
-
-		// Check labels
-		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-			switch ( $index ) {
-				case 0:
-					cy.get( $element ).contains( 'Name' );
-					break;
-
-				case 1:
-					cy.get( $element ).contains( 'Email' );
-					break;
-
-				case 2:
-					cy.get( $element ).contains( 'Message' );
-					break;
-			}
-		} );
-
-		cy.get( 'input[name="field-name[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-email[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'textarea[name="field-message[value]"]' )
-			.should( 'exist' );
-
-		cy.get( '.coblocks-form__submit button' )
-			.contains( 'Contact Us' );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test the coblock RSVP template.
-	 */
-	it( 'Test the form block RSVP template.', function() {
-		helpers.addBlockToPost( 'coblocks/form', true );
-
-		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-				cy.get( placeholder )
-					.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
-					.find( 'button' ).click( { force: true } );
-			} else {
-				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
-					.click();
-
-				cy.get( '.block-editor-inner-blocks__template-picker-options' )
-					.should( 'not.exist' );
-			}
-		} );
-
-		cy.get( '.coblocks-field--name' )
-			.its( 'length' )
-			.should( 'equal', 2 );
-
-		cy.get( 'div[data-type="coblocks/field-email"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-radio"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/form' );
-
-		helpers.viewPage();
-
-		cy.get( '.coblocks-form' )
-			.should( 'exist' );
-
-		// Check labels
-		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-			switch ( $index ) {
-				case 0:
-					cy.get( $element ).contains( 'Name' );
-					break;
-
-				case 1:
-					cy.get( $element ).contains( 'Plus one' );
-					break;
-
-				case 2:
-					cy.get( $element ).contains( 'Email' );
-					break;
-
-				case 3:
-					cy.get( $element ).contains( 'Will you be attending?' );
-					break;
-
-				case 4:
-					cy.get( $element ).contains( 'Notes?' );
-					break;
-			}
-		} );
-
-		cy.get( 'input[name="field-name[value][first-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-name[value][last-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-email[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-will-you-be-attending[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'textarea[name="field-notes[value]"]' )
-			.should( 'exist' );
-
-		cy.get( '.coblocks-form__submit button' )
-			.contains( 'RSVP' );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test the coblock appointment template.
-	 */
-	it( 'Test the form block appointment template.', function() {
-		helpers.addBlockToPost( 'coblocks/form', true );
-
-		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-				cy.get( placeholder )
-					.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
-					.find( 'button' ).click( { force: true } );
-			} else {
-				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
-					.click();
-
-				cy.get( '.block-editor-inner-blocks__template-picker-options' )
-					.should( 'not.exist' );
-			}
-		} );
-
-		cy.get( '.coblocks-field--name' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-phone"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-email"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-date"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-radio"]' )
-			.should( 'exist' );
-
-		cy.get( 'div[data-type="coblocks/field-textarea"]' )
-			.should( 'exist' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/form' );
-
-		helpers.viewPage();
-
-		cy.get( '.coblocks-form' )
-			.should( 'exist' );
-
-		// Check labels
-		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-			switch ( $index ) {
-				case 0:
-					cy.get( $element ).contains( 'Name' );
-					break;
-
-				case 1:
-					cy.get( $element ).contains( 'Phone' );
-					break;
-
-				case 2:
-					cy.get( $element ).contains( 'Email' );
-					break;
-
-				case 3:
-					cy.get( $element ).contains( 'Date' );
-					break;
-
-				case 4:
-					cy.get( $element ).contains( 'Time' );
-					break;
-
-				case 5:
-					cy.get( $element ).contains( 'Special notes' );
-					break;
-			}
-		} );
-
-		cy.get( 'input[name="field-name[value][first-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-name[value][last-name]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-phone[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-email[value]"]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-date[value]' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-time[value]"]' )
-			.its( 'length' )
-			.should( 'equal', 2 );
-
-		cy.get( 'textarea[name="field-special-notes[value]"]' )
-			.should( 'exist' );
-
-		cy.get( '.coblocks-form__submit button' )
-			.contains( 'Book Appointment' );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test the coblock contact template.
-	 */
-	it( 'Test the form block email is sent and received.', function() {
-		helpers.addBlockToPost( 'coblocks/form', true );
-
-		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-				cy.get( placeholder )
-					.find( '.block-editor-block-variation-picker__variations li:first-child' )
-					.find( 'button' ).click( { force: true } );
-			} else {
-				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
-					.click();
-
-				cy.get( '.block-editor-inner-blocks__template-picker-options' )
-					.should( 'not.exist' );
-			}
-		} );
-
-		helpers.savePage();
-		helpers.viewPage();
-
-		cy.get( '.coblocks-form' )
-			.should( 'exist' );
-
-		cy.get( 'input[name="field-name[value]"]' )
-			.type( 'Name' );
-
-		cy.get( 'input[name="field-email[value]"]' )
-			.type( 'email@example.com' );
-
-		cy.get( 'textarea[name="field-message[value]"]' )
-			.type( 'My message for you.' );
-
-		cy.get( '.coblocks-form__submit button' )
-			.click();
-
-		cy.get( '.coblocks-form__submitted' ).contains( 'Your message was sent:' );
-
-		cy.get( '.coblocks-form__submitted ul li:first-child' ).contains( 'Name: Name' );
-		cy.get( '.coblocks-form__submitted ul li:nth-child(2)' ).contains( 'Email: email@example.com' );
-		cy.get( '.coblocks-form__submitted ul li:last-child' ).contains( 'Message: My message for you.' );
-
-		cy.exec( 'curl http://127.0.0.1:8025/api/v2/messages' )
-			.its( 'stdout' )
-			.should( 'contain', 'Name: Name' )
-			.should( 'contain', 'Email: email@example.com' )
-			.should( 'contain', 'Message: My message for you.' );
-
-		helpers.editPage();
-	} );
+	// /**
+	//  * Test the coblock contact template.
+	//  */
+	// it( 'Test the form block contact template.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:first-child' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-name"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	helpers.savePage();
+	//
+	// 	helpers.checkForBlockErrors( 'coblocks/form' );
+	//
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	// Check labels
+	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+	// 		switch ( $index ) {
+	// 			case 0:
+	// 				cy.get( $element ).contains( 'Name' );
+	// 				break;
+	//
+	// 			case 1:
+	// 				cy.get( $element ).contains( 'Email' );
+	// 				break;
+	//
+	// 			case 2:
+	// 				cy.get( $element ).contains( 'Message' );
+	// 				break;
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'input[name="field-name[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'textarea[name="field-message[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.contains( 'Contact Us' );
+	//
+	// 	helpers.editPage();
+	// } );
+	//
+	// /**
+	//  * Test the coblock RSVP template.
+	//  */
+	// it( 'Test the form block RSVP template.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( '.coblocks-field--name' )
+	// 		.its( 'length' )
+	// 		.should( 'equal', 2 );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	helpers.savePage();
+	//
+	// 	helpers.checkForBlockErrors( 'coblocks/form' );
+	//
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	// Check labels
+	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+	// 		switch ( $index ) {
+	// 			case 0:
+	// 				cy.get( $element ).contains( 'Name' );
+	// 				break;
+	//
+	// 			case 1:
+	// 				cy.get( $element ).contains( 'Plus one' );
+	// 				break;
+	//
+	// 			case 2:
+	// 				cy.get( $element ).contains( 'Email' );
+	// 				break;
+	//
+	// 			case 3:
+	// 				cy.get( $element ).contains( 'Will you be attending?' );
+	// 				break;
+	//
+	// 			case 4:
+	// 				cy.get( $element ).contains( 'Notes?' );
+	// 				break;
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-will-you-be-attending[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'textarea[name="field-notes[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.contains( 'RSVP' );
+	//
+	// 	helpers.editPage();
+	// } );
+	//
+	// /**
+	//  * Test the coblock appointment template.
+	//  */
+	// it( 'Test the form block appointment template.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( '.coblocks-field--name' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-phone"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-date"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
+	// 		.should( 'exist' );
+	//
+	// 	helpers.savePage();
+	//
+	// 	helpers.checkForBlockErrors( 'coblocks/form' );
+	//
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	// Check labels
+	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+	// 		switch ( $index ) {
+	// 			case 0:
+	// 				cy.get( $element ).contains( 'Name' );
+	// 				break;
+	//
+	// 			case 1:
+	// 				cy.get( $element ).contains( 'Phone' );
+	// 				break;
+	//
+	// 			case 2:
+	// 				cy.get( $element ).contains( 'Email' );
+	// 				break;
+	//
+	// 			case 3:
+	// 				cy.get( $element ).contains( 'Date' );
+	// 				break;
+	//
+	// 			case 4:
+	// 				cy.get( $element ).contains( 'Time' );
+	// 				break;
+	//
+	// 			case 5:
+	// 				cy.get( $element ).contains( 'Special notes' );
+	// 				break;
+	// 		}
+	// 	} );
+	//
+	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-phone[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-date[value]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-time[value]"]' )
+	// 		.its( 'length' )
+	// 		.should( 'equal', 2 );
+	//
+	// 	cy.get( 'textarea[name="field-special-notes[value]"]' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.contains( 'Book Appointment' );
+	//
+	// 	helpers.editPage();
+	// } );
+	//
+	// /**
+	//  * Test the coblock contact template.
+	//  */
+	// it( 'Test the form block email is sent and received.', function() {
+	// 	helpers.addBlockToPost( 'coblocks/form', true );
+	//
+	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+	// 			cy.get( placeholder )
+	// 				.find( '.block-editor-block-variation-picker__variations li:first-child' )
+	// 				.find( 'button' ).click( { force: true } );
+	// 		} else {
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+	// 				.click();
+	//
+	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
+	// 				.should( 'not.exist' );
+	// 		}
+	// 	} );
+	//
+	// 	helpers.savePage();
+	// 	helpers.viewPage();
+	//
+	// 	cy.get( '.coblocks-form' )
+	// 		.should( 'exist' );
+	//
+	// 	cy.get( 'input[name="field-name[value]"]' )
+	// 		.type( 'Name' );
+	//
+	// 	cy.get( 'input[name="field-email[value]"]' )
+	// 		.type( 'email@example.com' );
+	//
+	// 	cy.get( 'textarea[name="field-message[value]"]' )
+	// 		.type( 'My message for you.' );
+	//
+	// 	cy.get( '.coblocks-form__submit button' )
+	// 		.click();
+	//
+	// 	cy.get( '.coblocks-form__submitted' ).contains( 'Your message was sent:' );
+	//
+	// 	cy.get( '.coblocks-form__submitted ul li:first-child' ).contains( 'Name: Name' );
+	// 	cy.get( '.coblocks-form__submitted ul li:nth-child(2)' ).contains( 'Email: email@example.com' );
+	// 	cy.get( '.coblocks-form__submitted ul li:last-child' ).contains( 'Message: My message for you.' );
+	//
+	// 	cy.exec( 'curl http://127.0.0.1:8025/api/v2/messages' )
+	// 		.its( 'stdout' )
+	// 		.should( 'contain', 'Name: Name' )
+	// 		.should( 'contain', 'Email: email@example.com' )
+	// 		.should( 'contain', 'Message: My message for you.' );
+	//
+	// 	helpers.editPage();
+	// } );
 
 	/**
 	 * Test the coblock contact template.
@@ -358,7 +358,21 @@ describe( 'Test CoBlocks Form Block', function() {
 					cy.get( $inputElem ).invoke( 'val' ).then( ( val ) => {
 						cy.get( $inputElem )
 							.clear()
-							.type( 'Custom Subject Line: Email From [email] - [name]' );
+							.type( 'Custom Subject Line: Email From ' );
+
+						cy.get( 'button.components-button' )
+							.contains( '[email]' )
+							.click();
+
+						cy.get( $inputElem ).type( ' - ' );
+
+						cy.get( 'button.components-button' )
+							.contains( '[name]' )
+							.click();
+
+						cy.get( $inputElem ).invoke( 'val' ).then( ( val ) => {
+							cy.expect( val ).to.equal( 'Custom Subject Line: Email From [email] - [name]' );
+						} );
 					} );
 				} );
 

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -242,7 +242,7 @@ describe( 'Test CoBlocks Form Block', function() {
 					break;
 
 				case 5:
-					cy.get( $element ).contains( 'Special Notes' );
+					cy.get( $element ).contains( 'Special notes' );
 					break;
 			}
 		} );

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -327,4 +327,65 @@ describe( 'Test CoBlocks Form Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test the coblock contact template.
+	 */
+	it( 'Test the form block custom subject line sends as intended.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:first-child' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( '.wp-block[data-type="coblocks/form"]' )
+			.click( { force: true } );
+
+			cy.get( 'div.edit-post-sidebar' )
+				.contains( /Subject/i )
+				.next( 'input' )
+				.then( ( $inputElem ) => {
+					cy.get( $inputElem ).invoke( 'val' ).then( ( val ) => {
+						cy.get( $inputElem )
+							.clear()
+							.type( 'Custom Subject Line: Email From [email] - [name]' );
+					} );
+				} );
+
+		helpers.savePage();
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value]"]' )
+			.type( 'Name' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.type( 'email@example.com' );
+
+		cy.get( 'textarea[name="field-message[value]"]' )
+			.type( 'My message for you.' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.click();
+
+		cy.get( '.coblocks-form__submitted' ).contains( 'Your message was sent:' );
+
+		cy.exec( 'curl http://127.0.0.1:8025/api/v2/messages' )
+			.its( 'stdout' )
+			.should( 'contain', 'Custom Subject Line: Email From email@example.com - Name' );
+
+		helpers.editPage();
+	} );
 } );

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -329,7 +329,7 @@ describe( 'Test CoBlocks Form Block', function() {
 	} );
 
 	/**
-	 * Test the coblock contact template.
+	 * Test the [email] and [name] links work and that the custom subject line field is used in the email.
 	 */
 	it( 'Test the form block custom subject line sends as intended.', function() {
 		helpers.addBlockToPost( 'coblocks/form', true );

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -4,329 +4,329 @@
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Form Block', function() {
-	// /**
-	//  * Test the coblock contact template.
-	//  */
-	// it( 'Test the form block contact template.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:first-child' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-name"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	helpers.savePage();
-	//
-	// 	helpers.checkForBlockErrors( 'coblocks/form' );
-	//
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	// Check labels
-	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-	// 		switch ( $index ) {
-	// 			case 0:
-	// 				cy.get( $element ).contains( 'Name' );
-	// 				break;
-	//
-	// 			case 1:
-	// 				cy.get( $element ).contains( 'Email' );
-	// 				break;
-	//
-	// 			case 2:
-	// 				cy.get( $element ).contains( 'Message' );
-	// 				break;
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'input[name="field-name[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'textarea[name="field-message[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.contains( 'Contact Us' );
-	//
-	// 	helpers.editPage();
-	// } );
-	//
-	// /**
-	//  * Test the coblock RSVP template.
-	//  */
-	// it( 'Test the form block RSVP template.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( '.coblocks-field--name' )
-	// 		.its( 'length' )
-	// 		.should( 'equal', 2 );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	helpers.savePage();
-	//
-	// 	helpers.checkForBlockErrors( 'coblocks/form' );
-	//
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	// Check labels
-	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-	// 		switch ( $index ) {
-	// 			case 0:
-	// 				cy.get( $element ).contains( 'Name' );
-	// 				break;
-	//
-	// 			case 1:
-	// 				cy.get( $element ).contains( 'Plus one' );
-	// 				break;
-	//
-	// 			case 2:
-	// 				cy.get( $element ).contains( 'Email' );
-	// 				break;
-	//
-	// 			case 3:
-	// 				cy.get( $element ).contains( 'Will you be attending?' );
-	// 				break;
-	//
-	// 			case 4:
-	// 				cy.get( $element ).contains( 'Notes?' );
-	// 				break;
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-will-you-be-attending[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'textarea[name="field-notes[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.contains( 'RSVP' );
-	//
-	// 	helpers.editPage();
-	// } );
-	//
-	// /**
-	//  * Test the coblock appointment template.
-	//  */
-	// it( 'Test the form block appointment template.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( '.coblocks-field--name' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-phone"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-email"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-date"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-radio"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'div[data-type="coblocks/field-textarea"]' )
-	// 		.should( 'exist' );
-	//
-	// 	helpers.savePage();
-	//
-	// 	helpers.checkForBlockErrors( 'coblocks/form' );
-	//
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	// Check labels
-	// 	cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
-	// 		switch ( $index ) {
-	// 			case 0:
-	// 				cy.get( $element ).contains( 'Name' );
-	// 				break;
-	//
-	// 			case 1:
-	// 				cy.get( $element ).contains( 'Phone' );
-	// 				break;
-	//
-	// 			case 2:
-	// 				cy.get( $element ).contains( 'Email' );
-	// 				break;
-	//
-	// 			case 3:
-	// 				cy.get( $element ).contains( 'Date' );
-	// 				break;
-	//
-	// 			case 4:
-	// 				cy.get( $element ).contains( 'Time' );
-	// 				break;
-	//
-	// 			case 5:
-	// 				cy.get( $element ).contains( 'Special notes' );
-	// 				break;
-	// 		}
-	// 	} );
-	//
-	// 	cy.get( 'input[name="field-name[value][first-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-name[value][last-name]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-phone[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-date[value]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-time[value]"]' )
-	// 		.its( 'length' )
-	// 		.should( 'equal', 2 );
-	//
-	// 	cy.get( 'textarea[name="field-special-notes[value]"]' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.contains( 'Book Appointment' );
-	//
-	// 	helpers.editPage();
-	// } );
-	//
-	// /**
-	//  * Test the coblock contact template.
-	//  */
-	// it( 'Test the form block email is sent and received.', function() {
-	// 	helpers.addBlockToPost( 'coblocks/form', true );
-	//
-	// 	cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
-	// 		if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
-	// 			cy.get( placeholder )
-	// 				.find( '.block-editor-block-variation-picker__variations li:first-child' )
-	// 				.find( 'button' ).click( { force: true } );
-	// 		} else {
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
-	// 				.click();
-	//
-	// 			cy.get( '.block-editor-inner-blocks__template-picker-options' )
-	// 				.should( 'not.exist' );
-	// 		}
-	// 	} );
-	//
-	// 	helpers.savePage();
-	// 	helpers.viewPage();
-	//
-	// 	cy.get( '.coblocks-form' )
-	// 		.should( 'exist' );
-	//
-	// 	cy.get( 'input[name="field-name[value]"]' )
-	// 		.type( 'Name' );
-	//
-	// 	cy.get( 'input[name="field-email[value]"]' )
-	// 		.type( 'email@example.com' );
-	//
-	// 	cy.get( 'textarea[name="field-message[value]"]' )
-	// 		.type( 'My message for you.' );
-	//
-	// 	cy.get( '.coblocks-form__submit button' )
-	// 		.click();
-	//
-	// 	cy.get( '.coblocks-form__submitted' ).contains( 'Your message was sent:' );
-	//
-	// 	cy.get( '.coblocks-form__submitted ul li:first-child' ).contains( 'Name: Name' );
-	// 	cy.get( '.coblocks-form__submitted ul li:nth-child(2)' ).contains( 'Email: email@example.com' );
-	// 	cy.get( '.coblocks-form__submitted ul li:last-child' ).contains( 'Message: My message for you.' );
-	//
-	// 	cy.exec( 'curl http://127.0.0.1:8025/api/v2/messages' )
-	// 		.its( 'stdout' )
-	// 		.should( 'contain', 'Name: Name' )
-	// 		.should( 'contain', 'Email: email@example.com' )
-	// 		.should( 'contain', 'Message: My message for you.' );
-	//
-	// 	helpers.editPage();
-	// } );
+	/**
+	 * Test the coblock contact template.
+	 */
+	it( 'Test the form block contact template.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:first-child' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( 'div[data-type="coblocks/field-name"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-email"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/form' );
+
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		// Check labels
+		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+			switch ( $index ) {
+				case 0:
+					cy.get( $element ).contains( 'Name' );
+					break;
+
+				case 1:
+					cy.get( $element ).contains( 'Email' );
+					break;
+
+				case 2:
+					cy.get( $element ).contains( 'Message' );
+					break;
+			}
+		} );
+
+		cy.get( 'input[name="field-name[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'textarea[name="field-message[value]"]' )
+			.should( 'exist' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.contains( 'Contact Us' );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test the coblock RSVP template.
+	 */
+	it( 'Test the form block RSVP template.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:nth-child(2)' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(2)' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( '.coblocks-field--name' )
+			.its( 'length' )
+			.should( 'equal', 2 );
+
+		cy.get( 'div[data-type="coblocks/field-email"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-radio"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/form' );
+
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		// Check labels
+		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+			switch ( $index ) {
+				case 0:
+					cy.get( $element ).contains( 'Name' );
+					break;
+
+				case 1:
+					cy.get( $element ).contains( 'Plus one' );
+					break;
+
+				case 2:
+					cy.get( $element ).contains( 'Email' );
+					break;
+
+				case 3:
+					cy.get( $element ).contains( 'Will you be attending?' );
+					break;
+
+				case 4:
+					cy.get( $element ).contains( 'Notes?' );
+					break;
+			}
+		} );
+
+		cy.get( 'input[name="field-name[value][first-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value][last-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-plus-one-2[value][first-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-plus-one-2[value][last-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-will-you-be-attending[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'textarea[name="field-notes[value]"]' )
+			.should( 'exist' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.contains( 'RSVP' );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test the coblock appointment template.
+	 */
+	it( 'Test the form block appointment template.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:nth-child(3)' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:nth-child(3)' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( '.coblocks-field--name' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-phone"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-email"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-date"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-radio"]' )
+			.should( 'exist' );
+
+		cy.get( 'div[data-type="coblocks/field-textarea"]' )
+			.should( 'exist' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/form' );
+
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		// Check labels
+		cy.get( '.coblocks-label' ).each( ( $element, $index ) => {
+			switch ( $index ) {
+				case 0:
+					cy.get( $element ).contains( 'Name' );
+					break;
+
+				case 1:
+					cy.get( $element ).contains( 'Phone' );
+					break;
+
+				case 2:
+					cy.get( $element ).contains( 'Email' );
+					break;
+
+				case 3:
+					cy.get( $element ).contains( 'Date' );
+					break;
+
+				case 4:
+					cy.get( $element ).contains( 'Time' );
+					break;
+
+				case 5:
+					cy.get( $element ).contains( 'Special notes' );
+					break;
+			}
+		} );
+
+		cy.get( 'input[name="field-name[value][first-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value][last-name]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-phone[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-date[value]' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-time[value]"]' )
+			.its( 'length' )
+			.should( 'equal', 2 );
+
+		cy.get( 'textarea[name="field-special-notes[value]"]' )
+			.should( 'exist' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.contains( 'Book Appointment' );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test the coblock contact template.
+	 */
+	it( 'Test the form block email is sent and received.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( 'div.wp-block[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:first-child' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		helpers.savePage();
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value]"]' )
+			.type( 'Name' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.type( 'email@example.com' );
+
+		cy.get( 'textarea[name="field-message[value]"]' )
+			.type( 'My message for you.' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.click();
+
+		cy.get( '.coblocks-form__submitted' ).contains( 'Your message was sent:' );
+
+		cy.get( '.coblocks-form__submitted ul li:first-child' ).contains( 'Name: Name' );
+		cy.get( '.coblocks-form__submitted ul li:nth-child(2)' ).contains( 'Email: email@example.com' );
+		cy.get( '.coblocks-form__submitted ul li:last-child' ).contains( 'Message: My message for you.' );
+
+		cy.exec( 'curl http://127.0.0.1:8025/api/v2/messages' )
+			.its( 'stdout' )
+			.should( 'contain', 'Name: Name' )
+			.should( 'contain', 'Email: email@example.com' )
+			.should( 'contain', 'Message: My message for you.' );
+
+		helpers.editPage();
+	} );
 
 	/**
 	 * Test the coblock contact template.


### PR DESCRIPTION
### Description
This PR introduces a Cypress e2e test which submits the form and confirms that an email was sent and received.

It also adds a test to test that custom subject line is set when `wp_mail()` fires and tests that the `[email]` and `[name]` link keywords are added to the subject line in the block editor and then replaced in the subject line when sent.

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
I have run the tests a number of times locally and on CircleCI.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
