### PR TITLE
Try removing masonry transition

### DIFF
--- a/src/js/coblocks-masonry.js
+++ b/src/js/coblocks-masonry.js
@@ -9,7 +9,7 @@ import jQuery from 'jquery';
 		container.imagesLoaded( function() {
 			container.masonry( {
 				itemSelector: '.coblocks-gallery--item',
-				transitionDuration: '0.2s',
+				transitionDuration: '0',
 				percentPosition: true,
 			} );
 		} );


### PR DESCRIPTION
### Description
Removes the `transitionDuration` for the Masonry block. May resolve #1370 as well.
