### PR TITLE
Remove a condition where a variable may not be defined

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -84,11 +84,7 @@ class CoBlocks_Block_Assets {
 			// in the coblocks/* namespace.
 			$wp_post = get_post( $post );
 			if ( $wp_post instanceof WP_Post ) {
-				$post_content = $wp_post->post_content;
-			}
-
-			if ( false !== strpos( $post_content, '<!-- wp:coblocks/' ) ) {
-				$has_coblock = true;
+				$has_coblock = false !== strpos( $wp_post->post_content, '<!-- wp:coblocks/' );
 			}
 		}
 


### PR DESCRIPTION
### Description
Resolves a bug that was introduced in 1.26.0 where the variable $post_content may not be defined.

### Types of changes
Simplifying the conditional prevents the possibility of the notice.

Resolves #1474 
Resolves #1475 

### How has this been tested?
Manual tests and our unit tests pass.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
