### PR TITLE
[Fix] Add custom classes for Map block within the editor.

### DIFF
--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -115,6 +115,7 @@ class Edit extends Component {
 			attributes,
 			setAttributes,
 			isSelected,
+			className,
 		} = this.props;
 
 		const {
@@ -183,7 +184,7 @@ class Edit extends Component {
 							height,
 							width: '100%',
 						} }
-						className={ classnames( { 'is-selected': isSelected } ) }
+						className={ classnames( className, { 'is-selected': isSelected } ) }
 						minHeight="200"
 						enable={ {
 							bottom: true,

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -70,7 +70,10 @@ class Edit extends Component {
 			this.state.address &&
 			Object.keys( this.state.address ).length
 		) {
-			this.props.setAttributes( { address: this.state.address, pinned: true } );
+			this.props.setAttributes( {
+				address: this.state.address,
+				pinned: true,
+			} );
 		}
 	}
 
@@ -111,12 +114,7 @@ class Edit extends Component {
 	}
 
 	render() {
-		const {
-			attributes,
-			setAttributes,
-			isSelected,
-			className,
-		} = this.props;
+		const { attributes, setAttributes, isSelected, className } = this.props;
 
 		const {
 			address,
@@ -133,11 +131,11 @@ class Edit extends Component {
 
 		const locale = document.documentElement.lang;
 
-		const renderMap = (event) => {
+		const renderMap = ( event ) => {
 			if ( event ) {
 				event.preventDefault();
 			}
-			
+
 			setAttributes( { address: this.state.address, pinned: true } );
 		};
 
@@ -150,19 +148,26 @@ class Edit extends Component {
 		};
 
 		const marker = {
-			url: '/wp-content/plugins/coblocks/dist/images/markers/' + skin + '.svg',
+			url:
+				'/wp-content/plugins/coblocks/dist/images/markers/' +
+				skin +
+				'.svg',
 			scaledSize: { width: iconSize, height: iconSize },
 		};
 
 		const GoogleMapIframeRender = (
 			<Fragment>
-				<div style={ { width: '100%', height, position: 'absolute' } } />
+				<div
+					style={ { width: '100%', height, position: 'absolute' } }
+				/>
 				<div className="iframe__overflow-wrapper">
 					<iframe
 						title={ __( 'Google Map', 'coblocks' ) }
 						frameBorder="0"
 						style={ { width: '100%', minHeight: height + 'px' } }
-						src={ `https://www.google.com/maps?q=${ encodeURIComponent( address ) }&output=embed&hl=${ locale }&z=${ zoom }` }
+						src={ `https://www.google.com/maps?q=${ encodeURIComponent(
+							address
+						) }&output=embed&hl=${ locale }&z=${ zoom }` }
 					/>
 				</div>
 			</Fragment>
@@ -177,14 +182,18 @@ class Edit extends Component {
 						updateApiKeyCallBack={ this.updateApiKey }
 					/>
 				) }
-				{ isSelected && <Controls { ...this.props } apiKey={ this.state.apiKey } /> }
+				{ isSelected && (
+					<Controls { ...this.props } apiKey={ this.state.apiKey } />
+				) }
 				{ pinned ? (
 					<ResizableBox
 						size={ {
 							height,
 							width: '100%',
 						} }
-						className={ classnames( className, { 'is-selected': isSelected } ) }
+						className={ classnames( className, {
+							'is-selected': isSelected,
+						} ) }
 						minHeight="200"
 						enable={ {
 							bottom: true,
@@ -202,86 +211,125 @@ class Edit extends Component {
 							} );
 						} }
 					>
-						{ !! this.state.apiKey ?
-							compose(
-								withProps( {
-									googleMapURL:
-												`https://maps.googleapis.com/maps/api/js?key=${ this.state.apiKey }` +
-												`&language=${ locale }` +
-												'&v=3.exp&libraries=geometry,drawing,places',
-									loadingElement: <div style={ { height: '100%' } } />,
-									containerElement: <div style={ { height: '100%' } } />,
-									mapElement: <div style={ { height: '100%' } } />,
-									coords: null,
-									props: this.props,
-								} ),
-								withScriptjs,
-								withGoogleMap,
-								lifecycle( {
-									componentDidMount() {
-										const geocoder = new window.google.maps.Geocoder();
-										geocoder.geocode(
-											{ address },
-											function( results, status ) {
-												if ( status !== 'OK' ) {
-													this.props.props.setAttributes( {
-														pinned: false,
-														hasError: __( 'Invalid API key, or too many requests', 'coblocks' ),
+						{ !! this.state.apiKey
+							? compose(
+									withProps( {
+										googleMapURL:
+											`https://maps.googleapis.com/maps/api/js?key=${ this.state.apiKey }` +
+											`&language=${ locale }` +
+											'&v=3.exp&libraries=geometry,drawing,places',
+										loadingElement: (
+											<div style={ { height: '100%' } } />
+										),
+										containerElement: (
+											<div style={ { height: '100%' } } />
+										),
+										mapElement: (
+											<div style={ { height: '100%' } } />
+										),
+										coords: null,
+										props: this.props,
+									} ),
+									withScriptjs,
+									withGoogleMap,
+									lifecycle( {
+										componentDidMount() {
+											const geocoder = new window.google.maps.Geocoder();
+											geocoder.geocode(
+												{ address },
+												function( results, status ) {
+													if ( status !== 'OK' ) {
+														this.props.props.setAttributes(
+															{
+																pinned: false,
+																hasError: __(
+																	'Invalid API key, or too many requests',
+																	'coblocks'
+																),
+															}
+														);
+														return;
+													}
+
+													this.setState( {
+														coords: results[ 0 ].geometry.location.toJSON(),
 													} );
-													return;
+
+													this.props.props.setAttributes(
+														{
+															lat: results[ 0 ].geometry.location
+																.toJSON()
+																.lat.toString(),
+															lng: results[ 0 ].geometry.location
+																.toJSON()
+																.lng.toString(),
+															hasError: '',
+														}
+													);
+												}.bind( this )
+											);
+										},
+									} )
+							  )( ( props ) => [
+									props.coords ? (
+										<GoogleMap
+											isMarkerShown={ true }
+											defaultZoom={
+												props.props.attributes.zoom
+											}
+											defaultCenter={
+												new window.google.maps.LatLng(
+													props.coords
+												)
+											}
+											defaultOptions={ {
+												styles: GMapStyles[ skin ],
+												draggable: false,
+												mapTypeControl,
+												zoomControl,
+												streetViewControl,
+												fullscreenControl,
+											} }
+										>
+											<Marker
+												position={
+													new window.google.maps.LatLng(
+														props.coords
+													)
 												}
-
-												this.setState( {
-													coords: results[ 0 ].geometry.location.toJSON(),
-												} );
-
-												this.props.props.setAttributes( {
-													lat: results[ 0 ].geometry.location.toJSON().lat.toString(),
-													lng: results[ 0 ].geometry.location.toJSON().lng.toString(),
-													hasError: '',
-												} );
-											}.bind( this )
-										);
-									},
-								} )
-							)( ( props ) => [
-								props.coords ? (
-									<GoogleMap
-										isMarkerShown={ true }
-										defaultZoom={ props.props.attributes.zoom }
-										defaultCenter={ new window.google.maps.LatLng( props.coords ) }
-										defaultOptions={ {
-											styles: GMapStyles[ skin ],
-											draggable: false,
-											mapTypeControl,
-											zoomControl,
-											streetViewControl,
-											fullscreenControl,
-										} }
-									>
-										<Marker
-											position={ new window.google.maps.LatLng( props.coords ) }
-											icon={ marker }
-										/>
-									</GoogleMap>
-								) : null,
-							] ) :
-							( GoogleMapIframeRender ) }
+												icon={ marker }
+											/>
+										</GoogleMap>
+									) : null,
+							  ] )
+							: GoogleMapIframeRender }
 					</ResizableBox>
 				) : (
 					<Placeholder
 						icon={ <BlockIcon icon={ icon } /> }
 						label={ __( 'Google map', 'coblocks' ) }
-						instructions={ __( 'Enter a location or address to drop a pin on a Google map.', 'coblocks' ) }
+						instructions={ __(
+							'Enter a location or address to drop a pin on a Google map.',
+							'coblocks'
+						) }
 					>
 						<form onSubmit={ renderMap }>
 							<input
 								type="text"
 								value={ this.state.address || '' }
 								className="components-placeholder__input"
-								placeholder={ __( 'Search for a place or address…', 'coblocks' ) }
-								onChange={ ( nextAddress ) => this.setState( { address: nextAddress.target.value } ) }
-								onKeyDown={ ( { keyCode } ) => handleKeyDown( keyCode ) }
+								placeholder={ __(
+									'Search for a place or address…',
+									'coblocks'
+								) }
+								onChange={ ( nextAddress ) =>
+									this.setState( {
+										address: nextAddress.target.value,
+									} )
+								}
+								onKeyDown={ ( { keyCode } ) =>
+									handleKeyDown( keyCode )
+								}
 							/>
 							<Button
 								isLarge
@@ -305,7 +353,10 @@ class Edit extends Component {
 									isLink
 									onClick={ () => {
 										setAttributes( { pinned: ! pinned } );
-										this.setState( { address: this.props.attributes.address } );
+										this.setState( {
+											address: this.props.attributes
+												.address,
+										} );
 									} }
 									disabled={ ! address }
 								>

--- a/src/blocks/map/test/map.cypress.js
+++ b/src/blocks/map/test/map.cypress.js
@@ -11,7 +11,7 @@ describe( 'Test CoBlocks Map Block', function() {
 	 * Test that we can add a map block to the content, not add any text or
 	 * alter any settings, and are able to successfully save the block without errors.
 	 */
-	it( 'Test map block saves without content values set.', function() {
+	it( 'can save without content values set.', function() {
 		helpers.addBlockToPost( 'coblocks/map', true );
 
 		helpers.savePage();
@@ -29,7 +29,7 @@ describe( 'Test CoBlocks Map Block', function() {
 	 * Test that we can add a map block to the content, add a map
 	 * URL and save without any errors.
 	 */
-	it( 'Test map block saves with address.', function() {
+	it( 'can save with address.', function() {
 		helpers.addBlockToPost( 'coblocks/map', true );
 
 		cy.get( 'input[placeholder="Search for a place or address…"]' )
@@ -51,7 +51,7 @@ describe( 'Test CoBlocks Map Block', function() {
 	/**
 	 * Test the map block saves height set
 	 */
-	it( 'Test the map block height controls.', function() {
+	it( 'can use block height controls.', function() {
 		helpers.addBlockToPost( 'coblocks/map', true );
 
 		cy.get( 'input[placeholder="Search for a place or address…"]' )
@@ -70,6 +70,32 @@ describe( 'Test CoBlocks Map Block', function() {
 		helpers.viewPage();
 
 		cy.get( '.wp-block-coblocks-map' ).should( 'have.css', 'min-height', '800px' );
+
+		helpers.editPage();
+	} );
+
+	/**
+	 * Test the map block custom classes
+	 */
+	it( 'can have custom classes', () => {
+		helpers.addBlockToPost( 'coblocks/map', true );
+
+		cy.get( 'input[placeholder="Search for a place or address…"]' )
+		.type( mapAddress )
+		.parents( '.components-placeholder__fieldset' )
+		.find( 'button' ).contains( /apply/i ).click();
+
+		helpers.addCustomBlockClass( 'my-custom-class', 'map' );
+
+		cy.get( '.wp-block-coblocks-map' ).should( 'have.class', 'my-custom-class' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/map' );
+
+		helpers.viewPage();
+
+		cy.get( '.wp-block-coblocks-map' ).should( 'have.class', 'my-custom-class' );
 
 		helpers.editPage();
 	} );


### PR DESCRIPTION
### Description

Adding custom classes for the map block with in the editor. Resolves: https://github.com/godaddy-wordpress/coblocks/issues/1332

### Screenshots

<img src="https://cldup.com/j3-eQJqc01.png" />

### Types of changes

I've added the className from props to the render. Using the `classnames` method.

### How has this been tested?

- While in the editor, I selected the map block and went to the "Advanced" settings on the sidebar. - Then added `my-own-class`. 
- Finally, confirmed using the dev tools that the class is in place.

I set the class on the same places as other blocks do.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
