### PR TITLE
Update typography hooks docs.

### DIFF
--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -2,7 +2,7 @@
 
 ## Customize labels
 
-The following JavaScript filter will customize the text used for the menu item
+The following `JavaScript` filter will customize the text used for the menu item
 label and panel titles: 
 
 ```javascript

--- a/docs/hooks/typography-controls.md
+++ b/docs/hooks/typography-controls.md
@@ -4,8 +4,7 @@
 
 The following `JavaScript` filter can be used to add Google fonts to the list of available fonts with Typography Controls.  
 
-
-```php
+```JavaScript
 /**
  * Make additional custom Google fonts available
  *
@@ -35,6 +34,9 @@ wp.hooks.addFilter( 'coblocks.google_fonts', 'coblocks/coblocks.google_fonts', f
 ```
 
 ## Disable Typography Controls
+
+The following `PHP` filters allow for disabling of typography controls by post or user role.
+
 **Post Limits (Only shows on post ID 1)**
 ```php
 add_filter( 'coblocks_disable_typography_controls', function( $bool, $post_id ) {

--- a/docs/hooks/typography-controls.md
+++ b/docs/hooks/typography-controls.md
@@ -2,7 +2,7 @@
 
 ## Add Additional Google Fonts
 
-The following `PHP` filter can be used to add Google fonts to the list of available fonts with Typography Controls.  
+The following `JavaScript` filter can be used to add Google fonts to the list of available fonts with Typography Controls.  
 
 
 ```php


### PR DESCRIPTION
The description was saying `PHP` when it is actually a `JavaScript` filter, and can be misleading.

### Description
Only a small change in the docs.