### PR TITLE
Fix gallery block image selector UI

### DIFF
--- a/src/components/block-gallery/styles/editor/_gallery-item-menus.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item-menus.scss
@@ -44,4 +44,5 @@
 	height: 24px;
 	padding: 2px;
 	width: 24px;
+	min-width: 24px !important;
 }


### PR DESCRIPTION
Closes #1506. 

Result:
<img width="624" alt="Screen Shot 2020-05-27 at 12 55 13 PM" src="https://user-images.githubusercontent.com/1813435/83051345-e8e36800-a01b-11ea-8454-2dc9d635972a.png">
