### PR TITLE
Tweak display of + button in layout selector

### DIFF
--- a/src/layout-selector/index.js
+++ b/src/layout-selector/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import map from 'lodash/map';
 
 /**
  * WordPress dependencies
@@ -12,10 +13,9 @@ import { Component, Fragment } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { Button, Modal, Icon, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button, Modal, Icon, SVG, Path, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { BlockPreview } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import map from 'lodash/map';
 
 /**
  * Internal dependencies
@@ -209,7 +209,8 @@ class LayoutSelector extends Component {
 								closeTemplateSelector();
 							} }
 							isLink>
-							<span><Icon icon="plus" size={ 16 } /></span> { __( 'Add blank page', 'coblocks' ) }
+							<span><SVG width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><Path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z" ></Path></SVG></span>
+							{ __( 'Add blank page', 'coblocks' ) }
 						</Button>
 					</aside>
 

--- a/src/layout-selector/style.scss
+++ b/src/layout-selector/style.scss
@@ -158,21 +158,27 @@ $color-highlight: #00a4a6;
 		color: $dark-gray-800 !important;
 		text-decoration: none !important;
 		font-weight: 600;
+		min-width: 32px;
+		height: 32px;
 		display: inline-flex;
 		vertical-align: middle;
 		transition-duration: 0;
 		align-items: center;
 
 		> span {
-			display: inline-block;
 			position: relative;
 			background-color: $dark-gray-800;
 			color: $white;
-			padding: 7px 5px 0;
-			margin-right: 0.65em;
+			min-width: 32px;
+			height: 32px;
+			width: 32px;
+			margin-right: 8px;
 			border-radius: 2px;
 			vertical-align: middle;
 			transition: all 0.1s;
+			display: inline-flex;
+			justify-content: center;
+			align-items: center;
 		}
 
 		&:hover,


### PR DESCRIPTION
### Description
Tweaks the display of the + button by using the same + as used in Gutenberg.

### Screenshots
Before:
<img width="501" alt="Screen Shot 2020-05-27 at 1 55 30 PM" src="https://user-images.githubusercontent.com/1813435/83055373-c3595d00-a021-11ea-80a8-735eddaeb681.png">

With this PR:
<img width="506" alt="Screen Shot 2020-05-27 at 1 54 32 PM" src="https://user-images.githubusercontent.com/1813435/83055315-b3da1400-a021-11ea-9bfa-967d864b76eb.png">