### PR TITLE
Improve conditional loading of scripts and styles

### DIFF
--- a/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
@@ -172,6 +172,20 @@ class CoBlocks_Block_Assets_Tests extends WP_UnitTestCase {
 		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
 	}
 
+	public function test_block_assets_loaded_on_archive_pages() {
+		global $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		$this->go_to( "/?cat=1" );
+
+		$this->assertTrue( is_archive() );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
 	public function test_block_assets_loaded_with_core_image_block() {
 		global $post, $wp_styles;
 		unset( $GLOBALS['current_screen'] );

--- a/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
@@ -56,7 +56,6 @@ class CoBlocks_Block_Assets_Tests extends WP_UnitTestCase {
 			[ 'enqueue_block_assets', 'block_assets' ],
 			[ 'init', 'editor_assets' ],
 			[ 'wp_enqueue_scripts', 'frontend_scripts' ],
-			[ 'the_post', 'frontend_scripts' ],
 		];
 
 		foreach ( $actions as $action_data ) {

--- a/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
@@ -172,6 +172,174 @@ class CoBlocks_Block_Assets_Tests extends WP_UnitTestCase {
 		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
 	}
 
+	public function test_block_assets_loaded_with_core_image_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/image
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/image /-->',
+			'post_title'   => 'Core Image Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_button_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/button
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/button /-->',
+			'post_title'   => 'Core Button Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_cover_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/cover
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/cover /-->',
+			'post_title'   => 'Core Cover Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_heading_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/heading
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/heading /-->',
+			'post_title'   => 'Core Heading Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_list_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/list
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/list /-->',
+			'post_title'   => 'Core List Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_paragraph_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/paragraph
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/paragraph /-->',
+			'post_title'   => 'Core Paragraph Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_pullquote_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/pullquote
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/pullquote /-->',
+			'post_title'   => 'Core Pullquote Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
+	public function test_typography_styles_loaded_with_core_quote_block() {
+		global $post, $wp_styles;
+		unset( $GLOBALS['current_screen'] );
+
+		// core/quote
+		$post_id = wp_insert_post( [
+			'post_author'  => 1,
+			'post_content' => '<!-- wp:core/quote /-->',
+			'post_title'   => 'Core Quote Block',
+			'post_status'  => 'publish',
+		] );
+
+		$this->go_to( "/?p={$post_id}" );
+		$post = get_post( $post_id );
+
+		$this->coblocks_block_assets->block_assets();
+		do_action( 'enqueue_block_assets' );
+
+		$this->assertContains( 'coblocks-frontend', $wp_styles->queue );
+	}
+
 	/**
 	 * Test the frontend scripts masonry are enqueued correctly
 	 */

--- a/.dev/tests/phpunit/test-class-coblocks.php
+++ b/.dev/tests/phpunit/test-class-coblocks.php
@@ -176,19 +176,6 @@ class CoBlocks_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the block editor assets load correctly
-	 */
-	public function test_block_editor_assets() {
-
-		do_action( 'enqueue_block_editor_assets' );
-
-		global $wp_scripts;
-
-		$this->assertTrue( array_key_exists( 'coblocks-editor', $wp_scripts->registered ) );
-
-	}
-
-	/**
 	 * Test all expected final build assets exist
 	 */
 	public function test_final_build_assets_exist() {

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -280,7 +280,7 @@ class CoBlocks_Block_Assets {
 		$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
 
 		// Masonry block.
-		if ( has_block( 'coblocks/gallery-masonry' ) ) {
+		if ( has_block( 'coblocks/gallery-masonry' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
 				'coblocks-masonry',
 				$dir . 'coblocks-masonry.js',
@@ -291,7 +291,7 @@ class CoBlocks_Block_Assets {
 		}
 
 		// Carousel block.
-		if ( has_block( 'coblocks/gallery-carousel' ) ) {
+		if ( has_block( 'coblocks/gallery-carousel' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
 				'coblocks-flickity',
 				$vendors_dir . '/flickity.js',
@@ -300,7 +300,7 @@ class CoBlocks_Block_Assets {
 				true
 			);
 
-			if ( has_block( 'coblocks/accordion' ) ) {
+			if ( has_block( 'coblocks/accordion' ) || has_block( 'core/block' ) ) {
 				wp_enqueue_script(
 					'coblocks-accordion-carousel',
 					$dir . 'coblocks-accordion-carousel.js',
@@ -312,7 +312,7 @@ class CoBlocks_Block_Assets {
 		}
 
 		// Post Carousel block.
-		if ( has_block( 'coblocks/post-carousel' ) ) {
+		if ( has_block( 'coblocks/post-carousel' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
 				'coblocks-slick',
 				$vendors_dir . '/slick.js',
@@ -330,7 +330,7 @@ class CoBlocks_Block_Assets {
 		}
 
 		// Events block.
-		if ( has_block( 'coblocks/events' ) ) {
+		if ( has_block( 'coblocks/events' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
 				'coblocks-slick',
 				$vendors_dir . '/slick.js',
@@ -348,7 +348,7 @@ class CoBlocks_Block_Assets {
 		}
 
 		// Lightbox.
-		if ( has_block( 'coblocks/gallery-masonry' ) || has_block( 'coblocks/gallery-stacked' ) || has_block( 'coblocks/gallery-collage' ) || has_block( 'coblocks/gallery-carousel' ) || has_block( 'coblocks/gallery-offset' ) ) {
+		if ( has_block( 'coblocks/gallery-masonry' ) || has_block( 'coblocks/gallery-stacked' ) || has_block( 'coblocks/gallery-collage' ) || has_block( 'coblocks/gallery-carousel' ) || has_block( 'coblocks/gallery-offset' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
 				'coblocks-lightbox',
 				$dir . 'coblocks-lightbox.js',

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -79,12 +79,13 @@ class CoBlocks_Block_Assets {
 		// Only load the front end CSS if a Coblock is in use.
 		$has_coblock = ! is_singular();
 
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && is_singular() ) {
+			$wp_post = get_post( $post );
+
 			// This is similar to has_block() in core, but will match anything
 			// in the coblocks/* namespace.
-			$wp_post = get_post( $post );
 			if ( $wp_post instanceof WP_Post ) {
-				$has_coblock = false !== strpos( $wp_post->post_content, '<!-- wp:coblocks/' );
+				$has_coblock = false !== strpos( $wp_post->post_content, '<!-- wp:coblocks/' ) || has_block( 'core/block', $wp_post );
 			}
 		}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -84,7 +84,22 @@ class CoBlocks_Block_Assets {
 			// This is similar to has_block() in core, but will match anything
 			// in the coblocks/* namespace.
 			if ( $wp_post instanceof WP_Post ) {
-				$has_coblock = false !== strpos( $wp_post->post_content, '<!-- wp:coblocks/' ) || has_block( 'core/block', $wp_post );
+				$has_coblock = ! empty(
+					array_filter(
+						array(
+							false !== strpos( $wp_post->post_content, '<!-- wp:coblocks/' ),
+							has_block( 'core/block', $wp_post ),
+							has_block( 'core/button', $wp_post ),
+							has_block( 'core/cover', $wp_post ),
+							has_block( 'core/heading', $wp_post ),
+							has_block( 'core/image', $wp_post ),
+							has_block( 'core/list', $wp_post ),
+							has_block( 'core/paragraph', $wp_post ),
+							has_block( 'core/pullquote', $wp_post ),
+							has_block( 'core/quote', $wp_post ),
+						)
+					)
+				);
 			}
 		}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -46,7 +46,6 @@ class CoBlocks_Block_Assets {
 		add_action( 'init', array( $this, 'editor_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
-		add_action( 'the_post', array( $this, 'frontend_scripts' ) );
 	}
 
 	/**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -77,7 +77,7 @@ class CoBlocks_Block_Assets {
 		global $post;
 
 		// Only load the front end CSS if a Coblock is in use.
-		$has_coblock = false;
+		$has_coblock = ! is_singular();
 
 		if ( ! is_admin() ) {
 			// This is similar to has_block() in core, but will match anything

--- a/includes/class-coblocks-body-classes.php
+++ b/includes/class-coblocks-body-classes.php
@@ -65,7 +65,7 @@ class CoBlocks_Body_Classes {
 	 * @return string
 	 */
 	public function theme_slug() {
-		return esc_attr( wp_get_theme( get_template() )->get( 'TextDomain' ) );
+		return esc_attr( wp_get_theme( get_template() )->get_template() );
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR builds upon #1454 which attempted to conditionally load CoBlocks scripts and styles only when needed. This attempt was great but in the end broke some other conditions we didn't test for.

The `has_block` method in WordPress Core as well as the custom check for blocks in the `coblocks/` namespace only work on singular (`is_singular()`) pages. Two conditions we missed related to any non-singular page with CoBlocks rendered (#1490 & #1496) and CoBlocks used within a reusable block that is inserted into a page (#1491).

Currently it's impossible to easily determine if a specific block is loaded anywhere on the page (in any WP_Query loop) or if they exist in a reusable block (because it's saved as a `core/block` type). To solve those two problems will take some thought to take care of server-side performance, specifically around database lookups.

The behavior this PR presents is the following:
1. Editor scripts and styles are verified to only load in the block editor.
2. Frontend scripts and styles are verified to load only on the frontend and block editor.
3. Frontend scripts and styles are loaded by default on all non `is_singular()` pages.
3. Frontend scripts and styles are loaded by default on all all `is_singular()` pages that include a reusable block (`core/block`).
4. Frontend scripts are conditionally loaded based on the blocks that exists on an `is_singular()` pages.

**EDIT**
Because we apply typography controls to certain core blocks and style treatments to the `core/image` block, we need to add these supported blocks to our conditions. In the future we will need to split up our stylesheets to minimize the payload rather than loading the entire stylesheet.

These are the currently supported blocks: `core/block`, `core/button`, `core/cover`, `core/heading`, `core/image`, `core/list`, `core/paragraph`, `core/pullquote`, and `core/quote`.

Loading all frontend scripts and styles on non-`is_singular()` pages or pages with a reusable block (`core/block`) isn't ideal but I think it's an acceptable trade-off right now until we can better detect blocks on a full rendered page.

### Types of changes
- Resolves #1490 
- Resolves #1496 
- Resolves #1491 

### How has this been tested?
Unit tests have been provided for the new conditions.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
