### PR TITLE
Fix resizablebox handles

### DIFF
--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -161,6 +161,7 @@ class Edit extends Component {
 						onResizeStart={ () => {
 							setAttributes( { iconSize: 'advanced' } );
 						} }
+						showHandle={ isSelected }
 					>
 						{ selectedIcon ? selectedIcon.icon : null }
 					</ResizableBox>

--- a/src/blocks/icon/styles/editor.scss
+++ b/src/blocks/icon/styles/editor.scss
@@ -111,7 +111,7 @@
 }
 
 //Add styling for resizableBox handles when a parent div is positioning the icon.
-.has-center-content .wp-block-coblocks-icon__inner.is-selected {
+.has-center-content .wp-block-coblocks-icon__inner.has-show-handle {
 
 	.components-resizable-box__handle-left,
 	.components-resizable-box__handle-right {
@@ -119,7 +119,7 @@
 	}
 }
 
-.has-right-content .wp-block-coblocks-icon__inner.is-selected {
+.has-right-content .wp-block-coblocks-icon__inner.has-show-handle {
 
 	.components-resizable-box__handle-left {
 		display: block !important;
@@ -129,6 +129,14 @@
 		display: none !important;
 	}
 }
+
+.wp-block[data-type="coblocks/icon"] {
+
+	&.block-editor-block-list__block:not([contenteditable]):focus::after {
+		display: none !important;
+	}
+}
+
 
 // Editor style preview.
 .editor-block-preview,

--- a/src/blocks/icon/styles/editor.scss
+++ b/src/blocks/icon/styles/editor.scss
@@ -97,21 +97,10 @@
 				}
 			}
 		}
-
-		// &.is-selected {
-		// 	.components-button {
-		// 		&,
-		// 		&:focus {
-		// 			background: transparent;
-		// 			box-shadow: 0 0 0 2px $white, 0 0 0 4px $dark-gray-500;
-		// 		}
-		// 	}
-		// }
 	}
 }
 
-//Add styling for resizableBox handles when a parent div is positioning the icon.
-.has-center-content .wp-block-coblocks-icon__inner.has-show-handle {
+.has-center-content .wp-block-coblocks-icon__inner.is-selected {
 
 	.components-resizable-box__handle-left,
 	.components-resizable-box__handle-right {
@@ -119,7 +108,7 @@
 	}
 }
 
-.has-right-content .wp-block-coblocks-icon__inner.has-show-handle {
+.has-right-content .wp-block-coblocks-icon__inner.is-selected {
 
 	.components-resizable-box__handle-left {
 		display: block !important;
@@ -168,6 +157,7 @@
 	}
 }
 
+// Hide screen reader label for Gutenberg < 6.4
 .components-coblocks-icon-size__controls {
 	align-items: center;
 	display: flex;
@@ -182,10 +172,6 @@
 	.components-base-control__field {
 		margin-bottom: 0 !important;
 	}
-}
-
-// Hide screen reader label for Gutenberg < 6.4
-.components-coblocks-icon-size__controls {
 
 	.components-base-control .components-base-control__label {
 		border: 0;


### PR DESCRIPTION
### Description
Closes #1514 for when Gutenberg is activated. Properly disables resiablebox handles when they're supposed to be.