### PR TITLE
Fix advanced block spacing with Gutenberg plugin

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+const defaultConfig = require( '@wordpress/eslint-plugin/recommended-with-formatting' );
+
+module.exports = {
+	...defaultConfig,
+};

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -106,9 +106,9 @@ const withAdvancedControls = createHigherOrderComponent( ( BlockEdit ) => {
 									setAttributes( { isStackedOnMobile: ! isStackedOnMobile } )
 								}
 								help={
-									!! isStackedOnMobile ?
-										__( 'Responsiveness is enabled.', 'coblocks' ) :
-										__(
+									!! isStackedOnMobile
+										? __( 'Responsiveness is enabled.', 'coblocks' )
+										: __(
 											'Toggle to stack elements on top of each other on smaller viewports.', 'coblocks'
 										)
 								}
@@ -262,9 +262,62 @@ const addEditorBlockAttributes = createHigherOrderComponent( ( BlockListBlock ) 
 			};
 		}
 
+		// Check if alignment wrapper has been applied - Gutenberg 8.2.1
+		if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
+			handleEditorAdvancedMargin();
+		}
+
 		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 	} );
 }, 'addEditorBlockAttributes' );
+
+const handleEditorAdvancedMargin = ( ) => {
+	const handleChanges = ( targetedElem ) => {
+		if ( targetedElem.className.includes( 'wp-block' ) ) {
+			switch ( targetedElem.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
+				case true:
+					targetedElem.style.marginBottom = 0;
+					break;
+				case false:
+					targetedElem.style.marginBottom = null;
+					break;
+			}
+
+			switch ( targetedElem.innerHTML.includes( 'data-coblocks-top-spacing' ) ) {
+				case true:
+					targetedElem.style.marginTop = 0;
+					break;
+				case false:
+					targetedElem.style.marginTop = null;
+					break;
+			}
+		}
+	};
+
+	const targetNode = document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' )[ 0 ];
+	const config = { attributes: true, childList: true, subtree: true };
+	const callback = function( mutationsList ) {
+		for ( const mutation of mutationsList ) {
+			if ( mutation.type === 'childList' ) {
+				if ( ! ( mutation.previousSibling instanceof HTMLElement ) ) {
+					continue;
+				}
+				if ( mutation.previousSibling.className.includes( 'wp-block' ) ) {
+					handleChanges( mutation.previousSibling );
+				}
+			}
+			if ( mutation.type === 'attributes' && 
+			( mutation.attributeName === 'data-coblocks-bottom-spacing' || mutation.attributeName === 'data-coblocks-top-spacing' ) ) {
+				if ( ! ( mutation.target.parentElement instanceof HTMLElement ) ) {
+					continue;
+				}
+				handleChanges( mutation.target.parentElement );
+			}
+		}
+	};
+	const observer = new MutationObserver( callback );
+	observer.observe( targetNode, config );
+};
 
 addFilter(
 	'blocks.registerBlockType',

--- a/src/extensions/advanced-controls/styles/editor.scss
+++ b/src/extensions/advanced-controls/styles/editor.scss
@@ -13,7 +13,7 @@
 	}
 
 	.wp-block[data-coblocks-top-spacing="1"]:not(:first-child),
-	.wp-block [data-coblocks-top-spacing="1"]:not(:first-child) {
+	.wp-block:not(:first-child) [data-coblocks-top-spacing="1"] {
 		margin-top: 0 !important;
 
 		// Ensure that blocks with custom margin settings using our dimensions control
@@ -36,7 +36,7 @@
 	}
 
 	.wp-block[data-coblocks-bottom-spacing="1"]:not(:last-child),
-	.wp-block [data-coblocks-bottom-spacing="1"]:not(:last-child)  {
+	.wp-block:not(:last-child) [data-coblocks-bottom-spacing="1"] {
 		margin-bottom: 0 !important;
 
 		// Ensure that blocks with custom margin settings using our dimensions control

--- a/src/extensions/advanced-controls/styles/editor.scss
+++ b/src/extensions/advanced-controls/styles/editor.scss
@@ -1,6 +1,7 @@
 .editor-styles-wrapper {
 
-	.wp-block[data-coblocks-bottom-spacing="1"][data-type="core/image"] {
+	.wp-block[data-coblocks-bottom-spacing="1"][data-type="core/image"],
+	.wp-block [data-coblocks-bottom-spacing="1"][data-type="core/image"] {
 
 		.block-editor-rich-text {
 			display: none;
@@ -11,7 +12,8 @@
 		}
 	}
 
-	.wp-block[data-coblocks-top-spacing="1"]:not(:first-child) {
+	.wp-block[data-coblocks-top-spacing="1"]:not(:first-child),
+	.wp-block [data-coblocks-top-spacing="1"]:not(:first-child) {
 		margin-top: 0 !important;
 
 		// Ensure that blocks with custom margin settings using our dimensions control
@@ -33,7 +35,8 @@
 		}
 	}
 
-	.wp-block[data-coblocks-bottom-spacing="1"]:not(:last-child) {
+	.wp-block[data-coblocks-bottom-spacing="1"]:not(:last-child),
+	.wp-block [data-coblocks-bottom-spacing="1"]:not(:last-child)  {
 		margin-bottom: 0 !important;
 
 		// Ensure that blocks with custom margin settings using our dimensions control
@@ -59,7 +62,8 @@
 		// that does not have margin bottom applied.
 		&[data-type="coblocks/map"] {
 
-			+ .wp-block[data-coblocks-bottom-spacing="1"] {
+			+ .wp-block[data-coblocks-bottom-spacing="1"],
+			.wp-block [data-coblocks-bottom-spacing="1"] {
 
 				> .block-editor-block-list__insertion-point {
 					display: none;
@@ -69,11 +73,13 @@
 	}
 
 	// Remove top and bottom margin from Gutenberg 5.8+ [data-block] margin
-	.wp-block[data-coblocks-top-spacing="1"] .block-editor-block-list__block-edit > [data-block] {
+	.wp-block[data-coblocks-top-spacing="1"] .block-editor-block-list__block-edit > [data-block],
+	.wp-block [data-coblocks-top-spacing="1"] .block-editor-block-list__block-edit > [data-block] {
 		margin-top: 0;
 	}
 
-	.wp-block[data-coblocks-bottom-spacing="1"] .block-editor-block-list__block-edit > [data-block] {
+	.wp-block[data-coblocks-bottom-spacing="1"] .block-editor-block-list__block-edit > [data-block],
+	.wp-block [data-coblocks-bottom-spacing="1"] .block-editor-block-list__block-edit > [data-block] {
 		margin-bottom: 0;
 	}
 
@@ -81,6 +87,14 @@
 	.wp-block {
 
 		&.is-selected {
+
+			&[data-coblocks-top-spacing="1"],
+			&[data-coblocks-bottom-spacing="1"] {
+				z-index: 29;
+			}
+		}
+
+		.is-selected {
 
 			&[data-coblocks-top-spacing="1"],
 			&[data-coblocks-bottom-spacing="1"] {


### PR DESCRIPTION
### Description
Closes #1513
Gutenberg has made [changes](https://github.com/WordPress/gutenberg/pull/21822) with V8.2.1 that add an alignment wrapper to blocks that allow alignment. This has negatively impacted the advanced spacing controls extension from CoBlocks.

This PR uses a mutation observer to watch the editor and update margins using inline styles where appropriate. Styles are properly applied to the Front-end as is.

### Screenshots
<!-- if applicable -->
![advancedSpacingFixed](https://user-images.githubusercontent.com/30462574/83556707-3bfa6680-a4c5-11ea-8921-a32b7dd3470c.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Changes to the `addEditorBlockAttributes` HOC.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with and without Gutenberg running. Tested in Go, and TwentyTwenty.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
