### PR TITLE
Social profiles: Open links in new tab

### DIFF
--- a/src/blocks/social-profiles/block.json
+++ b/src/blocks/social-profiles/block.json
@@ -13,6 +13,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"opensInNewTab": {
+			"type": "boolean",
+			"default": false
+		},
 		"borderRadius": {
 			"type": "number",
 			"default": 40

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -103,7 +103,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	$markup = '';
 
 	// Set the social link target.
-	$link_target = $opens_in_new_tab ? 'target="_blank"' : '';
+	$link_target = $opens_in_new_tab ? 'target="_blank" rel="noopener noreferrer"' : '';
 
 	foreach ( $platforms as $id => $platform ) {
 

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -28,6 +28,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	$background_color_style = is_array( $attributes ) && isset( $attributes['customBlockBackgroundColor'] ) ? 'style=background-color:' . $attributes['customBlockBackgroundColor'] : '';
 	$border_radius          = is_array( $attributes ) && isset( $attributes['borderRadius'] ) ? "border-radius: {$attributes['borderRadius']}px;" : '';
 	$has_padding            = is_array( $attributes ) && isset( $attributes['padding'] ) ? 'has-padding' : '';
+	$opens_in_new_tab       = is_array( $attributes ) && isset( $attributes['opensInNewTab'] ) && $attributes['opensInNewTab'];
 
 	$has_background          = '';
 	$background_color_class  = '';
@@ -101,12 +102,15 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	// Start markup.
 	$markup = '';
 
+	// Set the social link target.
+	$link_target = $opens_in_new_tab ? 'target="_blank"' : '';
+
 	foreach ( $platforms as $id => $platform ) {
 
 		if ( isset( $attributes[ $id ] ) && $attributes[ $id ] ) {
 			$markup .= sprintf(
 				'<li>
-					<a href="%1$s" class="wp-block-button__link wp-block-coblocks-social__button wp-block-coblocks-social__button--%8$s %3$s %7$s %9$s %10$s %13$s" title="%2$s" style="%4$s%6$s%11$s%12$s">
+					<a href="%1$s" class="wp-block-button__link wp-block-coblocks-social__button wp-block-coblocks-social__button--%8$s %3$s %7$s %9$s %10$s %13$s" title="%2$s" style="%4$s%6$s%11$s%12$s" %14$s>
 						<span class="wp-block-coblocks-social__icon" style="%5$s"></span>
 						<span class="wp-block-coblocks-social__text">%2$s</span>
 					</a>
@@ -123,7 +127,8 @@ function coblocks_render_social_profiles_block( $attributes ) {
 				esc_attr( $text_color_class ),
 				esc_attr( $custom_text_color ),
 				esc_attr( $padding ),
-				esc_attr( $has_padding )
+				esc_attr( $has_padding ),
+				$link_target
 			);
 		}
 	}

--- a/src/blocks/social-profiles/inspector.js
+++ b/src/blocks/social-profiles/inspector.js
@@ -66,6 +66,7 @@ class Inspector extends Component {
 			youtube,
 			yelp,
 			houzz,
+			opensInNewTab,
 		} = attributes;
 
 		const isMaskStyle = includes( className, 'is-style-mask' );
@@ -155,6 +156,11 @@ class Inspector extends Component {
 								className="components-coblocks-inspector__social-button-size"
 							/>
 						) }
+						<ToggleControl
+							label={ __( 'Open links in new tab', 'coblocks' ) }
+							checked={ !! opensInNewTab }
+							onChange={ () => setAttributes( { opensInNewTab: ! opensInNewTab } ) }
+						/>
 					</PanelBody>
 					<PanelBody title={ __( 'Profiles', 'coblocks' ) } initialOpen={ false }>
 						<div className="components-social-links-list">

--- a/src/blocks/social-profiles/test/social-profiles.cypress.js
+++ b/src/blocks/social-profiles/test/social-profiles.cypress.js
@@ -71,7 +71,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		helpers.editPage();
 	} );
 
-		/**
+	/**
 	 * Test the coblocks social profiles block saves with opensInNewTab.
 	 */
 	it( 'Test the social profiles block allows links in new tabs.', function() {

--- a/src/blocks/social-profiles/test/social-profiles.cypress.js
+++ b/src/blocks/social-profiles/test/social-profiles.cypress.js
@@ -71,6 +71,35 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		helpers.editPage();
 	} );
 
+		/**
+	 * Test the coblocks social profiles block saves with opensInNewTab.
+	 */
+	it( 'Test the social profiles block allows links in new tabs.', function() {
+		helpers.addBlockToPost( 'coblocks/social-profiles', true );
+
+		cy.get( '.wp-block-coblocks-social-profiles button[aria-label="Add Facebook profile"]' ).click();
+		cy.get( '.block-editor-url-input' ).type( 'https://www.facebook.com/test' );
+
+		helpers.toggleSettingCheckbox( 'Open links in new tab' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/social-profiles' );
+
+		helpers.viewPage();
+
+		cy.get( '.wp-block-coblocks-social-profiles ul li' )
+			.its( 'length' )
+			.should( 'equal', 1 );
+
+		cy.get( 'a[title="Facebook"]' )
+			.should( 'have.attr', 'href', 'https://www.facebook.com/test' )
+			.should('have.attr', 'target', '_blank')
+			.should('have.attr', 'rel', 'noopener noreferrer');
+
+		helpers.editPage();
+	} );
+
 	/**
 	 * Test the coblocks social profiles block styles.
 	 */


### PR DESCRIPTION
### Description

Adding a general option for the social profiles block to open links in new tab. It should partially fix https://github.com/godaddy-wordpress/coblocks/issues/1360

I thought that experience wise, either you choose all links to open in a new tab, or not. That's why I took this approach. And because it doesn't lock "us" to implement on a link basis in the future.

*Note*: I'm building a new site using coblocks and I found it more useful this way.
*Note 2*: I want to add GitHub to this block. Maybe this is more a note to myself. I'll probably open a new issue.

### Screenshots

<img src="https://cldup.com/slAwErLNmV.png">

<img src="https://cldup.com/yKtMz4YfMc.png">

### Types of changes

I added a new block setting for the *Social Profiles* block. Used the same naming as WP does for this, to keep it consistent.

Finally, edited the block template to reflect the changes in the setting.

### How has this been tested?

- Added the social profiles block.
- Configured the "Open links in new tab" setting (ON/OFF).
- Tested the results in the FE.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
