### PR TITLE
Fix advanced spacing in the Layout Selector and Editor

### DIFF
--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -273,7 +273,6 @@ const addEditorBlockAttributes = createHigherOrderComponent( ( BlockListBlock ) 
 
 const handleEditorAdvancedMargin = ( ) => {
 	const handleChanges = ( targetedElem ) => {
-		// console.log( targetedElem );
 		if ( targetedElem.className.includes( 'wp-block' ) ) {
 			switch ( targetedElem.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
 				case true:
@@ -295,8 +294,9 @@ const handleEditorAdvancedMargin = ( ) => {
 		}
 	};
 
-	const targetNode = document;
-	const config = { attributes: true, childList: true, subtree: true };
+	const observationTargetNode = !! document.getElementsByClassName( 'coblocks-layout-selector' ).length
+		? document : document.getElementsByClassName( 'block-editor-block-list__layout' )[ 0 ];
+
 	const getClosest = ( elem, selector ) => {
 		for ( ; elem && elem !== document; elem = elem.parentNode ) {
 			if ( elem.matches( selector ) && !! elem.dataset.align ) {
@@ -328,7 +328,7 @@ const handleEditorAdvancedMargin = ( ) => {
 		}
 	};
 	const observer = new MutationObserver( callback );
-	observer.observe( targetNode, config );
+	observer.observe( observationTargetNode, { attributes: true, childList: true, subtree: true } );
 };
 
 addFilter(

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -273,6 +273,7 @@ const addEditorBlockAttributes = createHigherOrderComponent( ( BlockListBlock ) 
 
 const handleEditorAdvancedMargin = ( ) => {
 	const handleChanges = ( targetedElem ) => {
+		// console.log( targetedElem );
 		if ( targetedElem.className.includes( 'wp-block' ) ) {
 			switch ( targetedElem.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
 				case true:
@@ -294,19 +295,30 @@ const handleEditorAdvancedMargin = ( ) => {
 		}
 	};
 
-	const targetNode = document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' )[ 0 ];
+	const targetNode = document;
 	const config = { attributes: true, childList: true, subtree: true };
+	const getClosest = ( elem, selector ) => {
+		for ( ; elem && elem !== document; elem = elem.parentNode ) {
+			if ( elem.matches( selector ) && !! elem.dataset.align ) {
+				return elem;
+			}
+		}
+		return null;
+	};
+
 	const callback = function( mutationsList ) {
 		for ( const mutation of mutationsList ) {
 			if ( mutation.type === 'childList' ) {
-				if ( ! ( mutation.previousSibling instanceof HTMLElement ) ) {
+				if ( ! ( mutation.target instanceof HTMLElement ) ) {
 					continue;
 				}
-				if ( mutation.previousSibling.className.includes( 'wp-block' ) ) {
-					handleChanges( mutation.previousSibling );
+
+				const wpBlock = getClosest( mutation.target, '.wp-block' );
+				if ( !! wpBlock ) {
+					handleChanges( wpBlock );
 				}
 			}
-			if ( mutation.type === 'attributes' && 
+			if ( mutation.type === 'attributes' &&
 			( mutation.attributeName === 'data-coblocks-bottom-spacing' || mutation.attributeName === 'data-coblocks-top-spacing' ) ) {
 				if ( ! ( mutation.target.parentElement instanceof HTMLElement ) ) {
 					continue;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
A few blocks such as group and shape divider were not having spacing properly applied either in the editor or within the layout selector. Made some changes to the logic which applies the spacing in this PR.

There are two parts to the layouts. The exisitng layouts from Go require a minor tweak to attributes for the desired layouts. <del>Those tweaks will be coming in on the Go repository.</del> Looks like @richtabor made the changes here: https://github.com/godaddy-wordpress/go/pull/524/commits/29883ea6217d12673bc39a67e0ef6558a79a926c

### Screenshots
<!-- if applicable -->
![spacingInLayoutSelector](https://user-images.githubusercontent.com/30462574/83675881-a4f9e100-a58e-11ea-9d14-96acc1e54722.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor logic change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and with the layout selector.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
