### PR TITLE
Remove .prettierrc.js file from repository

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,0 @@
-const defaultConfig = require( '@wordpress/eslint-plugin/recommended-with-formatting' );
-
-module.exports = {
-	...defaultConfig,
-};


### PR DESCRIPTION
### Description
The `.prettierrc.js` file is not needed as the configuration is already defined in the project `.eslintrc.js` file. PR to remove this file which is a regression and unintended.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Remove file to revert a regression on the master branch. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. `.eslintrc.js` file is properly extending `plugin:@wordpress/eslint-plugin/recommended-with-formatting`.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
