### PR TITLE
Conditionally show the layout selector settings

### DIFF
--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -9,6 +9,7 @@ import Section from './section';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
+import { getPlugin } from '@wordpress/plugins';
 import {
 	CheckboxControl,
 	Modal,
@@ -114,7 +115,7 @@ class CoBlocksSettingsModal extends Component {
 
 		const supportsGradients = getSettings().gradients !== undefined;
 		const colorPanelEnabled = !! colorPanel;
-		const showLayoutSelectorControl = applyFilters( 'coblocks-show-layout-selector', true );
+		const showLayoutSelectorControl = applyFilters( 'coblocks-show-layout-selector', true ) && !! getPlugin( 'coblocks-layout-selector' );
 
 		return (
 			<Modal
@@ -123,7 +124,7 @@ class CoBlocksSettingsModal extends Component {
 			>
 				<div className="coblocks-modal__content">
 					<Section title={ __( 'General' ) }>
-						{ showLayoutSelectorControl && 
+						{ showLayoutSelectorControl &&
 						<>
 							<HorizontalRule />
 							<CheckboxControl


### PR DESCRIPTION
### Description
CoBlocks Settings panel features controls for the layout selector. These controls are only available to users if the display conditions for the layout selector have been met. 


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor change to the logic used to hide the layout selector controls.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with and without Gutenberg active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
