### PR TITLE
Fix overwriting existing line height style when none has been set in CoBlocks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,7 +30,7 @@ This list is manually curated to include valuable contributions by volunteers th
 | @mahdiyazdani     | @mahdiyazdani          |
 | @nicolad          | @vadimnicolai          |
 | @obenland         | @obenland              |
-| @p-jackson        |                        |
+| @p-jackson        | @philipmjackson        |
 | @passatgt         | @passatgt              |
 | @ramiy            | @ramiy                 |
 | @Reinpal          |                        |

--- a/src/extensions/typography/apply-style.js
+++ b/src/extensions/typography/apply-style.js
@@ -1,19 +1,12 @@
-function applyStyle( attributes, name ) {
-	const {
-		fontFamily,
-		lineHeight,
-		letterSpacing,
-		fontWeight,
-		textTransform,
-	} = attributes;
+/**
+ * External dependencies
+ */
+import pickBy from 'lodash/pickby';
 
-	const style = {
-		lineHeight: lineHeight || null,
-		fontFamily: fontFamily || null,
-		fontWeight: fontWeight || null,
-		textTransform: textTransform || null,
-		letterSpacing: letterSpacing || null,
-	};
+const styleAttributes = [ 'fontFamily', 'lineHeight', 'letterSpacing', 'fontWeight', 'textTransform' ];
+
+function applyStyle( attributes, name ) {
+	const style = pickBy( attributes, ( value, key ) => !! value && styleAttributes.includes( key ) );
 
 	if ( typeof attributes.customFontSize !== 'undefined' ) {
 		style.fontSize = attributes.customFontSize + 'px';


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

The latest version of Gutenberg includes typography settings which already exist in CoBlocks. This PR doesn't fully harmonise those settings, but it stops CoBlock from disabling the core settings.

Using `line-height` as an example: if the line height was unset in CoBlocks, then `applyStyle()` would set the inline style to `null`. This means that if core Gutenberg had set it's own line height then it would get nulled out. As shown in #1500 this caused the line height to be removed on the front end and could cause invalid block errors.

This PR only sets an inline typography style if one has been set in CoBlocks, otherwise it leaves it alone. This means the CoBlocks setting takes precedent over the core Gutenberg setting on the front end. Maybe it should be the other way round, but this at least fixes the invalid block errors.

It's possible to do this without the `_.pickBy` function but it's more verbose and I saw this function was already used elsewhere in the plugin. From a code size point of view.

Fixes #1500 

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Enable latest Gutenberg and disable CoBlocks
- Add a paragraph block to a post
- Set a custom line height in the block settings
- Enable CoBlocks
- Open post, should have no block errors
- Preview post, line height should be applied

And checked the other way round just to be sure
- Enable CoBlocks and disable latest Gutenberg
- Add a paragraph block to a post
- Set a custom line height using the CoBlocks settings in the toolbar
- Enable latest Gutenberg
- Open post, should have no block errors
- Add a different line height using core block settings
- Preview post, line height from CoBlocks settings should be applied

Also tried the above using [the other blocks that have custom typograph settings](https://github.com/godaddy-wordpress/coblocks/blob/5b28202bc0bbe6235d7906314146006a2c829acf/src/extensions/typography/index.js#L21).

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
