### PR TITLE
Enable gallery caption editing when using custom links

### DIFF
--- a/src/blocks/gallery-collage/styles/editor.scss
+++ b/src/blocks/gallery-collage/styles/editor.scss
@@ -31,7 +31,7 @@
 	}
 }
 
-.wp-block[data-type="coblocks/gallery-collage"] {
+[data-type="coblocks/gallery-collage"] {
 
 	ul {
 		list-style-type: none;
@@ -141,6 +141,10 @@
 	.block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]) {
 		overflow: hidden;
 		position: relative !important;
+	}
+
+	.components-coblocks-gallery-item__image-link ~ .coblocks-gallery--caption {
+		bottom: 3em;
 	}
 }
 

--- a/src/blocks/gallery-stacked/styles/editor.scss
+++ b/src/blocks/gallery-stacked/styles/editor.scss
@@ -1,4 +1,4 @@
-.wp-block[data-type="coblocks/gallery-stacked"] {
+[data-type="coblocks/gallery-stacked"] {
 
 	&[data-align="left"],
 	&[data-align="right"] {
@@ -11,6 +11,8 @@
 	// Fix issue where selected images are not wider than the viewport.
 	.coblocks-gallery--item:not(.is-appender) .coblocks-gallery--figure {
 		display: inline-block;
+		margin-left: 0;
+		margin-right: 0;
 	}
 
 	.has-fullwidth-images .coblocks-gallery--figure {
@@ -22,8 +24,11 @@
 		margin-bottom: 35px;
 	}
 
-	li:nth-last-of-type(1) figure {
-		margin-bottom: 0 !important;
+	.components-coblocks-gallery-item__image-link ~ .coblocks-gallery--caption {
+		bottom: 3em;
+		position: absolute;
+		width: 100%;
+		justify-content: center;
 	}
 }
 

--- a/src/components/block-gallery/styles/editor/_gallery-item-link.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item-link.scss
@@ -17,8 +17,8 @@
 	}
 
 	.dashicons-admin-links {
-		margin-left: 11px;
-		margin-right: 9px;
+		margin-left: 14px;
+		margin-right: 12px;
 		width: 16px;
 	}
 

--- a/src/components/block-gallery/styles/editor/_gallery-item-link.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item-link.scss
@@ -50,10 +50,15 @@
 	}
 
 	.block-editor-url-input {
-		flex-grow: 1;
+		flex: 1 2;
 		padding: 2px;
 		position: relative;
 		width: calc(100% - 73px);
+
+		.components-base-control__field {
+			margin-top: 4px;
+			margin-bottom: 4px;
+		}
 
 		input[type="text"] {
 			border-radius: 3px;

--- a/src/components/block-gallery/styles/editor/_gallery-item-menus.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item-menus.scss
@@ -40,9 +40,9 @@
 
 .coblocks-gallery-item__button {
 	box-shadow: none !important;
-	color: $white;
+	color: $white !important;
 	height: 24px;
-	padding: 2px;
+	padding: 2px !important;
 	width: 24px;
 	min-width: 24px !important;
 }

--- a/src/components/block-gallery/styles/editor/_gallery-item.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item.scss
@@ -37,6 +37,11 @@
 	.block-editor-rich-text {
 		z-index: 2;
 	}
+
+	.components-coblocks-gallery-item__image-link ~ .coblocks-gallery--caption {
+		bottom: 3em;
+	}
+
 }
 
 .has-caption-color .coblocks-gallery--caption a {


### PR DESCRIPTION
### Description
Closes #1503 
Gallery blocks use overlapping DOM elements when rendering the user interface. Certain conditions may be met which essentially results in a hidden caption input box. Utilizing conditional CSS selectors we may move the caption box within view when necessary to do so.

This fix works for both core WordPress 5.4.1 as well as with Gutenberg plugin active 8.2.1. This PR also fixes the display of the custom URL input box when Gutenberg is active. 
![image](https://user-images.githubusercontent.com/30462574/84170262-55a02e80-aa2e-11ea-8c8c-c6f71cdc57d6.png)

### Screenshots
<!-- if applicable -->
![galleryBlocksCaptionCustonLink](https://user-images.githubusercontent.com/30462574/84171039-3229b380-aa2f-11ea-9303-c496ff406768.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor CSS changes to gallery components.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with and without the Gutenberg plugin active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
