### PR TITLE
Fix import target for typography controls lodash

### DIFF
--- a/src/extensions/typography/apply-style.js
+++ b/src/extensions/typography/apply-style.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import pickBy from 'lodash/pickby';
+import { pickBy } from 'lodash';
 
 const styleAttributes = [ 'fontFamily', 'lineHeight', 'letterSpacing', 'fontWeight', 'textTransform' ];
 


### PR DESCRIPTION
### Description
Used incorrect import target. Minor change to use the correct import target for lodash.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
