### PR TITLE
Fix primary/secondary buttons in custom components with Gutenberg active

### DIFF
--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -46,12 +46,12 @@ class ResponsiveTabsControl extends Component {
 						{
 							name: 'desk',
 							title: icons.desktopChrome,
-							className: 'components-coblocks-responsive__tabs-item components-coblocks-responsive__tabs-item--desktop components-button is-button is-default is-secondary',
+							className: 'components-coblocks-responsive__tabs-item components-coblocks-responsive__tabs-item--desktop components-button is-button is-default',
 						},
 						{
 							name: 'mobile',
 							title: icons.mobile,
-							className: 'components-coblocks-responsive__tabs-item components-coblocks-responsive__tabs-item--mobile components-button is-button is-default is-secondary',
+							className: 'components-coblocks-responsive__tabs-item components-coblocks-responsive__tabs-item--mobile components-button is-button is-default',
 						},
 					] }>
 					{

--- a/src/components/responsive-tabs-control/styles/editor.scss
+++ b/src/components/responsive-tabs-control/styles/editor.scss
@@ -16,16 +16,16 @@
 	&-item {
 		align-items: center;
 		appearance: none;
-		margin: 0;
-		border-radius: 2px;
-		height: auto !important;
-		padding: 8px !important;
-		box-shadow: none;
-		outline: 1px solid transparent;
-		white-space: nowrap;
-		color: theme(primary);
 		background: transparent;
+		border-radius: 2px;
 		border: 1px solid theme(primary);
+		box-shadow: none;
+		color: theme(primary);
+		height: auto !important;
+		margin: 0;
+		outline: 1px solid transparent;
+		padding: 8px !important;
+		white-space: nowrap;
 
 
 		&:first-of-type {

--- a/src/components/responsive-tabs-control/styles/editor.scss
+++ b/src/components/responsive-tabs-control/styles/editor.scss
@@ -17,6 +17,16 @@
 		align-items: center;
 		appearance: none;
 		margin: 0;
+		border-radius: 2px;
+		height: auto !important;
+		padding: 8px !important;
+		box-shadow: none;
+		outline: 1px solid transparent;
+		white-space: nowrap;
+		color: theme(primary);
+		background: transparent;
+		border: 1px solid theme(primary);
+
 
 		&:first-of-type {
 			border-bottom-right-radius: 0;

--- a/src/components/size-control/index.js
+++ b/src/components/size-control/index.js
@@ -168,7 +168,7 @@ class SizeControl extends Component {
 							<Button
 								key={ size }
 								isLarge
-								isSecondary
+								isSecondary={ value !== size }
 								isPrimary={ value === size }
 								aria-pressed={ value === size }
 								onClick={ () => onChange( size ) }


### PR DESCRIPTION
Before:
<img width="489" alt="Screen Shot 2020-06-11 at 2 07 30 PM" src="https://user-images.githubusercontent.com/1813435/84423760-f6d4e380-abec-11ea-9e88-dac8de8f4087.png">

After: 
<img width="477" alt="Screen Shot 2020-06-11 at 2 05 24 PM" src="https://user-images.githubusercontent.com/1813435/84423762-f8061080-abec-11ea-94ae-7726b54e73c0.png">
