### PR TITLE
Add tests for the `alert` block save.

### DIFF
--- a/src/blocks/alert/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/alert/test/__snapshots__/save.spec.js.snap
@@ -1,7 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`coblocks/alert should render with background color 1`] = `
+"<!-- wp:coblocks/alert {\\"backgroundColor\\":\\"#111111\\"} -->
+<div class=\\"wp-block-coblocks-alert has-background has-111111-background-color\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
 exports[`coblocks/alert should render with content 1`] = `
 "<!-- wp:coblocks/alert -->
 <div class=\\"wp-block-coblocks-alert\\"><p class=\\"wp-block-coblocks-alert__title\\">Alert title</p><p class=\\"wp-block-coblocks-alert__text\\">Alert description</p></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with custom background color 1`] = `
+"<!-- wp:coblocks/alert {\\"customBackgroundColor\\":\\"#111111\\"} -->
+<div class=\\"wp-block-coblocks-alert has-background\\" style=\\"background-color:#111111\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with custom classes for styles 1`] = `
+"<!-- wp:coblocks/alert {\\"className\\":\\"is-style-info\\"} -->
+<div class=\\"wp-block-coblocks-alert is-style-info\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with custom classes for styles 2`] = `
+"<!-- wp:coblocks/alert {\\"className\\":\\"is-style-success\\"} -->
+<div class=\\"wp-block-coblocks-alert is-style-success\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with custom classes for styles 3`] = `
+"<!-- wp:coblocks/alert {\\"className\\":\\"is-style-warning\\"} -->
+<div class=\\"wp-block-coblocks-alert is-style-warning\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with custom classes for styles 4`] = `
+"<!-- wp:coblocks/alert {\\"className\\":\\"is-style-error\\"} -->
+<div class=\\"wp-block-coblocks-alert is-style-error\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with text align 1`] = `
+"<!-- wp:coblocks/alert {\\"textAlign\\":\\"left\\"} -->
+<div class=\\"wp-block-coblocks-alert has-text-align-left\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with text align 2`] = `
+"<!-- wp:coblocks/alert {\\"textAlign\\":\\"center\\"} -->
+<div class=\\"wp-block-coblocks-alert has-text-align-center\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with text align 3`] = `
+"<!-- wp:coblocks/alert {\\"textAlign\\":\\"right\\"} -->
+<div class=\\"wp-block-coblocks-alert has-text-align-right\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;
+
+exports[`coblocks/alert should render with text color 1`] = `
+"<!-- wp:coblocks/alert {\\"textColor\\":\\"primary\\"} -->
+<div class=\\"wp-block-coblocks-alert has-text-color has-primary-color\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;

--- a/src/blocks/alert/test/save.spec.js
+++ b/src/blocks/alert/test/save.spec.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { JSDOM } from 'jsdom';
 import '@testing-library/jest-dom/extend-expect';
 import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
 
@@ -11,6 +12,7 @@ import { name, settings } from '../index';
 
 // Make variables accessible for all tests.
 let block;
+let blockDOM;
 let serializedBlock;
 
 describe( name, () => {
@@ -37,4 +39,102 @@ describe( name, () => {
 		expect( serializedBlock ).toContain( 'Alert description' );
 		expect( serializedBlock ).toMatchSnapshot();
 	} );
+
+	it( 'should render with text color', () => {
+		block.attributes.textColor = 'primary';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( '{"textColor":"primary"}' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should render with background color', () => {
+		block.attributes.backgroundColor = '#111111';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( '{"backgroundColor":"#111111"}' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should apply has-background class if any background color is selected', () => {
+		block.attributes.customBackgroundColor = '#111111';
+		block.attributes.backgroundColor = undefined;
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-alert' )
+		).toHaveClass( 'has-background' );
+
+		block.attributes.customBackgroundColor = undefined;
+		block.attributes.backgroundColor = 'primary';
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-alert' )
+		).toHaveClass( 'has-background' );
+	} );
+
+	it( 'should apply has-primary-background-color class if selected from the color palette', () => {
+		block.attributes.backgroundColor = 'primary';
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-alert' )
+		).toHaveClass( `has-${ block.attributes.backgroundColor }-background-color` );
+	} );
+
+	it( 'should apply custom background color with inline css', () => {
+		block.attributes.customBackgroundColor = '#123456';
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-alert' )
+		).toHaveStyle( `background-color: ${ block.attributes.customBackgroundColor }` );
+	} );
+
+	it( 'should render with custom background color', () => {
+		block.attributes.customBackgroundColor = '#111111';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( '{"customBackgroundColor":"#111111"}' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should render with text align', () => {
+		[ 'left', 'center', 'right' ].forEach( ( alignment ) => {
+			block.attributes.textAlign = alignment;
+			serializedBlock = serialize( block );
+			expect( serializedBlock ).toBeDefined();
+			expect( serializedBlock ).toContain( `"textAlign":"${ alignment }"` );
+			expect( serializedBlock ).toMatchSnapshot();
+
+			blockDOM = new JSDOM( serializedBlock );
+			expect(
+				blockDOM.window.document.querySelector( '.wp-block-coblocks-alert' )
+			).toHaveClass( `has-text-align-${ alignment }` );
+		} );
+	} );
+
+	it( 'should render with custom classes for styles', () => {
+		[ 'is-style-info', 'is-style-success', 'is-style-warning', 'is-style-error' ].forEach( ( className ) => {
+			block.attributes.className = className;
+			serializedBlock = serialize( block );
+			expect( serializedBlock ).toBeDefined();
+			expect( serializedBlock ).toContain( `"className":"${ className }"` );
+			expect( serializedBlock ).toMatchSnapshot();
+
+			blockDOM = new JSDOM( serializedBlock );
+			expect(
+				blockDOM.window.document.querySelector( '.wp-block-coblocks-alert' )
+			).toHaveClass( `${ className }` );
+		} );
+	} );
+
 } );


### PR DESCRIPTION
### Description
Adding tests for the alert block, on save. 

Closes #854

### Types of changes

- No changes besides the tests. Just being sure that on save, the block saves correctly the different attributes.

### How has this been tested?

- Running tests locally for this block.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
