### PR TITLE
Remove selected block outline from Shape Divider block

### DIFF
--- a/src/blocks/shape-divider/styles/editor.scss
+++ b/src/blocks/shape-divider/styles/editor.scss
@@ -121,3 +121,8 @@
 		}
 	}
 }
+
+// remove block outline.
+.block-editor-block-list__block[data-type="coblocks/shape-divider"]:not([contenteditable]):focus:after {
+	box-shadow: none;
+}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The Shape Divider block can be difficult to use when the block has an is-selected outline around the block. The outlines interfere with the resizable box handles and make the block harder to use. This PR removes the new outline added by the Gutenberg plugin.

### Screenshots
<!-- if applicable -->
![ShapeDividerGB](https://user-images.githubusercontent.com/30462574/84812600-800c6180-afc3-11ea-8afb-65b5a4cb80a3.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor CSS changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with and without the Gutenberg plugin active. The outline is only present and removed when the Gutenberg plugin is activated. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
