### PR TITLE
Fix editor performance relating to advanced margins

### DIFF
--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -2,12 +2,12 @@
  * External Dependencies
  */
 import classnames from 'classnames';
+import { lifecycle } from 'recompose';
 
 /**
  * WordPress Dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lifecycle } from 'recompose';
 import { addFilter } from '@wordpress/hooks';
 import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
+import { withProps, lifecycle } from 'recompose';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { ToggleControl } from '@wordpress/components';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
@@ -215,6 +216,41 @@ const enhance = compose(
 			selected: select( 'core/block-editor' ).getSelectedBlock(),
 			select,
 		};
+	} ),
+
+	/**
+	 * Using recompose lifecycle as an escape hatch to access component lifecycle methods.
+	 * Method will perform document mutations related to advanced editor margins.
+	 *
+	 * @return {Function} Enhanced component with modified lifecycle method.
+	 */
+	lifecycle( {
+		componentDidUpdate() {
+			// Check if alignment wrapper has been applied - Gutenberg 8.2.1
+			if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
+				const targetElems = document.querySelectorAll( '.block-editor-block-list__layout .wp-block[data-align]' );
+				targetElems.forEach( ( elem ) => {
+					const wrapper = elem.closest( '.wp-block' );
+					switch ( wrapper.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
+						case true:
+							wrapper.style.marginBottom = 0;
+							break;
+						case false:
+							wrapper.style.marginBottom = null;
+							break;
+					}
+
+					switch ( wrapper.innerHTML.includes( 'data-coblocks-top-spacing' ) ) {
+						case true:
+							wrapper.style.marginTop = 0;
+							break;
+						case false:
+							wrapper.style.marginTop = null;
+							break;
+					}
+				} );
+			}
+		},
 	} )
 );
 
@@ -262,74 +298,9 @@ const addEditorBlockAttributes = createHigherOrderComponent( ( BlockListBlock ) 
 			};
 		}
 
-		// Check if alignment wrapper has been applied - Gutenberg 8.2.1
-		if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
-			handleEditorAdvancedMargin();
-		}
-
 		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 	} );
 }, 'addEditorBlockAttributes' );
-
-const handleEditorAdvancedMargin = ( ) => {
-	const handleChanges = ( targetedElem ) => {
-		if ( targetedElem.className.includes( 'wp-block' ) ) {
-			switch ( targetedElem.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
-				case true:
-					targetedElem.style.marginBottom = 0;
-					break;
-				case false:
-					targetedElem.style.marginBottom = null;
-					break;
-			}
-
-			switch ( targetedElem.innerHTML.includes( 'data-coblocks-top-spacing' ) ) {
-				case true:
-					targetedElem.style.marginTop = 0;
-					break;
-				case false:
-					targetedElem.style.marginTop = null;
-					break;
-			}
-		}
-	};
-
-	const observationTargetNode = !! document.getElementsByClassName( 'coblocks-layout-selector' ).length
-		? document : document.getElementsByClassName( 'block-editor-block-list__layout' )[ 0 ];
-
-	const getClosest = ( elem, selector ) => {
-		for ( ; elem && elem !== document; elem = elem.parentNode ) {
-			if ( elem.matches( selector ) && !! elem.dataset.align ) {
-				return elem;
-			}
-		}
-		return null;
-	};
-
-	const callback = function( mutationsList ) {
-		for ( const mutation of mutationsList ) {
-			if ( mutation.type === 'childList' ) {
-				if ( ! ( mutation.target instanceof HTMLElement ) ) {
-					continue;
-				}
-
-				const wpBlock = getClosest( mutation.target, '.wp-block' );
-				if ( !! wpBlock ) {
-					handleChanges( wpBlock );
-				}
-			}
-			if ( mutation.type === 'attributes' &&
-			( mutation.attributeName === 'data-coblocks-bottom-spacing' || mutation.attributeName === 'data-coblocks-top-spacing' ) ) {
-				if ( ! ( mutation.target.parentElement instanceof HTMLElement ) ) {
-					continue;
-				}
-				handleChanges( mutation.target.parentElement );
-			}
-		}
-	};
-	const observer = new MutationObserver( callback );
-	observer.observe( observationTargetNode, { attributes: true, childList: true, subtree: true } );
-};
 
 addFilter(
 	'blocks.registerBlockType',

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -7,10 +7,10 @@ import classnames from 'classnames';
  * WordPress Dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { lifecycle } from 'recompose';
 import { addFilter } from '@wordpress/hooks';
 import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import { withProps, lifecycle } from 'recompose';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { ToggleControl } from '@wordpress/components';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
PR https://github.com/godaddy-wordpress/coblocks/pull/1521 introduced a mutation observer to handle document changes needed to properly apply advanced margins. This PR is using lifecycle methods instead of mutation observers with significant performance benefits.

### Screenshots
<!-- if applicable -->
This screenshot shows the layout selector in use with markedly enhanced performance. 
![editorPerformance](https://user-images.githubusercontent.com/30462574/84932240-de4f4800-b088-11ea-8311-59d9ee9915c5.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Using simple document methods to watch the document and apply advanced margins where applicable. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with and without the Gutenberg plugin active.
### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
