### PR TITLE
Fix Accordion children block appender

### DIFF
--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -56,6 +56,43 @@ class AccordionEdit extends Component {
 
 		const items = this.props.getBlocksByClientId( clientId );
 
+		const handleEvent = ( ) => {
+			if ( items[ 0 ].innerBlocks ) {
+				const lastId = items[ 0 ].innerBlocks[ items[ 0 ].innerBlocks.length - 1 ].clientId;
+				let copyAttributes = {};
+
+				if ( lastId ) {
+					const lastBlockClient = this.props.getBlockAttributes( lastId );
+					if ( lastBlockClient.backgroundColor ) {
+						copyAttributes = Object.assign( copyAttributes, {
+							backgroundColor: lastBlockClient.backgroundColor,
+						} );
+					}
+
+					if ( lastBlockClient.borderColor ) {
+						copyAttributes = Object.assign( copyAttributes, {
+							borderColor: lastBlockClient.borderColor,
+						} );
+					}
+
+					if ( lastBlockClient.textColor ) {
+						copyAttributes = Object.assign( copyAttributes, {
+							textColor: lastBlockClient.textColor,
+						} );
+					}
+
+					if ( lastBlockClient.customTextColor ) {
+						copyAttributes = Object.assign( copyAttributes, {
+							customTextColor: lastBlockClient.customTextColor,
+						} );
+					}
+				}
+
+				const created = createBlock( 'coblocks/accordion-item', copyAttributes );
+				this.props.insertBlock( created, undefined, clientId );
+			}
+		};
+
 		return (
 			<Fragment>
 				{ isSelected && (
@@ -76,42 +113,8 @@ class AccordionEdit extends Component {
 								/* translators: Add a child element for the Accordion block */
 								label={ __( 'Add accordion item', 'coblocks' ) }
 								icon="insert"
-								onClick={ () => {
-									if ( items[ 0 ].innerBlocks ) {
-										const lastId = items[ 0 ].innerBlocks[ items[ 0 ].innerBlocks.length - 1 ].clientId;
-										let copyAttributes = {};
-
-										if ( lastId ) {
-											const lastBlockClient = this.props.getBlockAttributes( lastId );
-											if ( lastBlockClient.backgroundColor ) {
-												copyAttributes = Object.assign( copyAttributes, {
-													backgroundColor: lastBlockClient.backgroundColor,
-												} );
-											}
-
-											if ( lastBlockClient.borderColor ) {
-												copyAttributes = Object.assign( copyAttributes, {
-													borderColor: lastBlockClient.borderColor,
-												} );
-											}
-
-											if ( lastBlockClient.textColor ) {
-												copyAttributes = Object.assign( copyAttributes, {
-													textColor: lastBlockClient.textColor,
-												} );
-											}
-
-											if ( lastBlockClient.customTextColor ) {
-												copyAttributes = Object.assign( copyAttributes, {
-													customTextColor: lastBlockClient.customTextColor,
-												} );
-											}
-										}
-
-										const created = createBlock( 'coblocks/accordion-item', copyAttributes );
-										this.props.insertBlock( created, undefined, clientId );
-									}
-								} } >
+								onMouseUp={ handleEvent }
+							>
 							</IconButton>
 						</div>
 					) }

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -46,7 +46,8 @@ describe( 'Block: Accordion', () => {
 	 * Test that multiple accordion items display as expected
 	 */
 	it( 'can add multiple accordion item blocks', () => {
-		cy.get( '[data-type="coblocks/accordion"]' ).click( { force: true } ).find( '.components-coblocks-add-accordion-item__button' ).click( );
+		cy.get( '[data-type="coblocks/accordion"]' ).click( 'top', { force: true } );
+		cy.get('.components-coblocks-add-accordion-item__button' ).click( );
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
 		helpers.checkForBlockErrors( 'coblocks/accordion' );

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -33,7 +33,7 @@ describe( 'Block: Accordion', () => {
 		cy.get( '.editor-post-title__input' ).click();
 		cy.get( '[data-type="coblocks/accordion"] .wp-block-coblocks-accordion-item__content' ).should( 'not.exist' );
 
-		cy.get( '[data-type="coblocks/accordion"]' ).click();
+		cy.get( '[data-type="coblocks/accordion-item"]' ).click();
 		helpers.toggleSettingCheckbox( 'Display as open' );
 
 		cy.get( '.editor-post-title__input' ).click();

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -47,7 +47,10 @@ describe( 'Block: Accordion', () => {
 	 */
 	it( 'can add multiple accordion item blocks', () => {
 		cy.get( '[data-type="coblocks/accordion"]' ).click( 'top', { force: true } );
-		cy.get('.components-coblocks-add-accordion-item__button' ).click( );
+		
+		cy.get('.components-coblocks-add-accordion-item__button' ).trigger( 'mouseup' ); 
+		// Using trigger here instead of click to more accurately represent behavior of event bubbling from user interaction within the editor.
+
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 
 		helpers.checkForBlockErrors( 'coblocks/accordion' );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Accordion block appender had been using `onClick` listener to handle the creation of new children. I found that changes within the DOM upon `mouseDown` event were causing the `onClick` event to cease bubbling thus resulting in a failure to execute the callback. 

By using `onMouseUp` listener we can circumvent the bubbling issue and react to user interaction.   

### Screenshots
<!-- if applicable -->
![accordionAddButton](https://user-images.githubusercontent.com/30462574/84941475-51ab8680-b096-11ea-8ed2-9cbc2b6791db.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor changes to event listener attached to the block appender.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with and without the Gutenberg plugin active. Tested with Go and Twenty Twenty. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
