### PR TITLE
Improve consistency of advanced margin propagation

### DIFF
--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -225,34 +225,40 @@ const enhance = compose(
 	 * @return {Function} Enhanced component with modified lifecycle method.
 	 */
 	lifecycle( {
+		componentDidMount() {
+			handleMargins();
+		},
 		componentDidUpdate() {
-			// Check if alignment wrapper has been applied - Gutenberg 8.2.1
-			if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
-				const targetElems = document.querySelectorAll( '.block-editor-block-list__layout .wp-block[data-align]' );
-				targetElems.forEach( ( elem ) => {
-					const wrapper = elem.closest( '.wp-block' );
-					switch ( wrapper.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
-						case true:
-							wrapper.style.marginBottom = 0;
-							break;
-						case false:
-							wrapper.style.marginBottom = null;
-							break;
-					}
-
-					switch ( wrapper.innerHTML.includes( 'data-coblocks-top-spacing' ) ) {
-						case true:
-							wrapper.style.marginTop = 0;
-							break;
-						case false:
-							wrapper.style.marginTop = null;
-							break;
-					}
-				} );
-			}
+			handleMargins();
 		},
 	} )
 );
+
+const handleMargins = () => {
+	// Check if alignment wrapper has been applied - Gutenberg 8.2.1
+	if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
+		const targetElems = document.querySelectorAll( '.block-editor-block-list__layout .wp-block[data-align]' );
+		targetElems.forEach( ( elem ) => {
+			const wrapper = elem.closest( '.wp-block' );
+			switch ( wrapper.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
+				case true:
+					wrapper.style.marginBottom = 0;
+					break;
+				case false:
+					wrapper.style.marginBottom = null;
+					break;
+			}
+			switch ( wrapper.innerHTML.includes( 'data-coblocks-top-spacing' ) ) {
+				case true:
+					wrapper.style.marginTop = 0;
+					break;
+				case false:
+					wrapper.style.marginTop = null;
+					break;
+			}
+		} );
+	}
+};
 
 const addEditorBlockAttributes = createHigherOrderComponent( ( BlockListBlock ) => {
 	return enhance( ( { select, ...props } ) => {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Recent PR #1543 introduced methods to attach to component lifecycle methods. While the PR 1543 was perfectly acceptable for use with the Layout Selector, it did not solve the issue for when the editor first loads, and before components update. 

This PR includes logic to use both `componentDidMount` and `componentDidUpdate` lifecycle methods to more consistently apply advanced margins within the editor.

### Screenshots
<!-- if applicable -->
**Bugged**
![advancedMarginsBugged](https://user-images.githubusercontent.com/30462574/85160739-990b5180-b213-11ea-9e8c-1819a92b4f98.gif)


**Fixed**
![advancedMarginsFixed](https://user-images.githubusercontent.com/30462574/85160754-9c064200-b213-11ea-8deb-2311a8d81706.gif)



### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in the browser with and without the Gutenberg plugin active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
