### PR TITLE
Fix unit tests by importing getCategories

### DIFF
--- a/src/utils/block-helpers.js
+++ b/src/utils/block-helpers.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockCollection } from '@wordpress/blocks';
+import { registerBlockCollection, getCategories } from '@wordpress/blocks';
 
 /**
  * Determine if the block attributes are empty.
@@ -46,6 +46,6 @@ export const supportsCollections = () => {
  *
  * @return {boolean} Value to indicate function support.
  */
-export const hasFormattingCategory = wp.blocks.getCategories().some( function( category ) {
+export const hasFormattingCategory = getCategories().some( function( category ) {
 	return category.slug === 'formatting';
 } );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Unit tests on master branch are failing due to use of `wp.blocks...` API as opposed to properly importing components `import { getCategories } from '@wordpress/blocks';`. This PR switches to import and resolves test failures.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally. Tests now pass.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
