### PR TITLE
Use React hooks to improve Advanced Margins feature

### DIFF
--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -93,28 +93,44 @@ const withAdvancedControls = createHigherOrderComponent( ( BlockEdit ) => {
 		const hasStackedControl = hasBlockSupport( name, 'stackedOnMobile' );
 		const withBlockSpacing = hasBlockSupport( name, 'coBlocksSpacing' );
 
+		const handleMargins = ( target ) => {
+			const innerAlignmentBlock = target.querySelector( '.wp-block[data-align]' );
+			const setInnerAlignmentBlock = ( margin, val ) => {
+				if ( !! innerAlignmentBlock ) {
+					innerAlignmentBlock.style[ margin ] = val;
+				}
+			};
+			switch ( target.outerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
+				case true:
+					target.style.marginBottom = 0;
+					setInnerAlignmentBlock( 'marginBottom', 0 );
+					break;
+				case false:
+					target.style.marginBottom = null;
+					setInnerAlignmentBlock( 'marginBottom', null );
+					break;
+			}
+			switch ( target.outerHTML.includes( 'data-coblocks-top-spacing' ) ) {
+				case true:
+					target.style.marginTop = 0;
+					setInnerAlignmentBlock( 'marginTop', 0 );
+					break;
+				case false:
+					target.style.marginTop = null;
+					setInnerAlignmentBlock( 'marginTop', null );
+
+					break;
+			}
+		};
+
 		useEffect( ( ) => {
 			// Check if alignment wrapper has been applied - Gutenberg 8.2.1
 			if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
-				const targetElems = document.querySelectorAll( '.block-editor-block-list__layout .wp-block[data-align]' );
+				const targetElems = document.querySelectorAll( '.block-editor-block-list__layout' );
 				targetElems.forEach( ( elem ) => {
-					const wrapper = elem.closest( '.wp-block' );
-					switch ( wrapper.innerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
-						case true:
-							wrapper.style.marginBottom = 0;
-							break;
-						case false:
-							wrapper.style.marginBottom = null;
-							break;
-					}
-					switch ( wrapper.innerHTML.includes( 'data-coblocks-top-spacing' ) ) {
-						case true:
-							wrapper.style.marginTop = 0;
-							break;
-						case false:
-							wrapper.style.marginTop = null;
-							break;
-					}
+					elem.childNodes.forEach( ( child ) => {
+						handleMargins( child );
+					} );
 				} );
 			}
 		}, [ noBottomMargin, noTopMargin ] );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Recent PRs  #1518 #1548 and #1543 made changes to the advanced margin controls. These methods worked but rely on an outdated method of hooking into React lifecycle that has now been replaced with integrated methods.

This PR makes the change of using newer React Hooks. In this case, we are using useEffect to hook into `componentDidMount` and `componnetDidUpdate` and are passing in the props `[ noBottomMargin, noTopMargin ]` which cause `useEffect` to execute when argument props update.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Major JavaScript non-breaking changes. This is an improvement in code quality, readability, and performance.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally with and without the Gutenberg plugin active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
