### PR TITLE
Fix multi-selected layout issue

### DIFF
--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -4,6 +4,10 @@ $color-highlight: #00a4a6;
 // 	display: none;
 // }
 
+.block-editor-block-list__layout .block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) {
+	opacity: 1 !important;
+}
+
 .coblocks-layout-selector .coblocks-layout-selector__layout .block-editor-block-preview__container.editor-styles-wrapper {
 	--go--font-size: 0.5rem;
 	--go-button--font-size: 0.5rem;

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -1,10 +1,6 @@
 $color-highlight: #00a4a6;
 
-// .interface-interface-skeleton__sidebar {
-// 	display: none;
-// }
-
-.block-editor-block-list__layout .block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) {
+.coblocks-layout-selector .block-editor-block-list__layout .block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) {
 	opacity: 1 !important;
 }
 


### PR DESCRIPTION
### Description
I can't identify why exactly, but Gutenberg recently changed how multi-selected blocks display (with some opaque). 

### Screenshots
<img width="1557" alt="Screen Shot 2020-07-07 at 12 09 20 PM" src="https://user-images.githubusercontent.com/1813435/86819244-6061d980-c055-11ea-9db9-ac7474efce3c.png">
