### PR TITLE
Accordion block save function tests

### DIFF
--- a/src/blocks/accordion/accordion-item/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/accordion/accordion-item/test/__snapshots__/save.spec.js.snap
@@ -1,7 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`coblocks/accordion-item should render with background color 1`] = `
+"<!-- wp:coblocks/accordion-item {\\"backgroundColor\\":\\"#111111\\"} -->
+<div class=\\"wp-block-coblocks-accordion-item\\"></div>
+<!-- /wp:coblocks/accordion-item -->"
+`;
+
 exports[`coblocks/accordion-item should render with content 1`] = `
 "<!-- wp:coblocks/accordion-item {\\"title\\":\\"Accordion title\\"} -->
 <div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title\\">Accordion title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\"></div></details></div>
+<!-- /wp:coblocks/accordion-item -->"
+`;
+
+exports[`coblocks/accordion-item should render with custom background color 1`] = `
+"<!-- wp:coblocks/accordion-item {\\"title\\":\\"Accordion Item title\\",\\"customBackgroundColor\\":\\"#111111\\"} -->
+<div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title has-background\\" style=\\"background-color:#111111\\">Accordion Item title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\" style=\\"border-color:#111111\\"></div></details></div>
+<!-- /wp:coblocks/accordion-item -->"
+`;
+
+exports[`coblocks/accordion-item should render with text color 1`] = `
+"<!-- wp:coblocks/accordion-item {\\"textColor\\":\\"primary\\"} -->
+<div class=\\"wp-block-coblocks-accordion-item\\"></div>
 <!-- /wp:coblocks/accordion-item -->"
 `;

--- a/src/blocks/accordion/accordion-item/test/save.spec.js
+++ b/src/blocks/accordion/accordion-item/test/save.spec.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { JSDOM } from 'jsdom';
 import '@testing-library/jest-dom/extend-expect';
 import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
 
@@ -11,6 +12,7 @@ import { name, settings } from '../index';
 
 // Make variables accessible for all tests.
 let block;
+let blockDOM;
 let serializedBlock;
 
 describe( name, () => {
@@ -33,6 +35,77 @@ describe( name, () => {
 
 		expect( serializedBlock ).toBeDefined();
 		expect( serializedBlock ).toContain( 'Accordion title' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should render with text color', () => {
+		block.attributes.textColor = 'primary';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( '{"textColor":"primary"}' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should render with background color', () => {
+		block.attributes.backgroundColor = '#111111';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( '{"backgroundColor":"#111111"}' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should apply has-background class if any background color is selected', () => {
+		block.attributes.title = 'Accordion Item title';
+		block.attributes.customBackgroundColor = '#111111';
+		block.attributes.backgroundColor = undefined;
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-accordion-item__title' )
+		).toHaveClass( 'has-background' );
+
+		block.attributes.customBackgroundColor = undefined;
+		block.attributes.backgroundColor = 'primary';
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-accordion-item__title' )
+		).toHaveClass( 'has-background' );
+	} );
+
+	it( 'should apply has-primary-background-color class if selected from the color palette', () => {
+		block.attributes.title = 'Accordion Item title';
+		block.attributes.backgroundColor = 'primary';
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-accordion-item__title' )
+		).toHaveClass( `has-${ block.attributes.backgroundColor }-background-color` );
+	} );
+
+	it( 'should apply custom background color with inline css', () => {
+		block.attributes.title = 'Accordion Item title';
+		block.attributes.customBackgroundColor = '#123456';
+		serializedBlock = serialize( block );
+
+		blockDOM = new JSDOM( serializedBlock );
+		expect(
+			blockDOM.window.document.querySelector( '.wp-block-coblocks-accordion-item__title' )
+		).toHaveStyle( `background-color: ${ block.attributes.customBackgroundColor }` );
+	} );
+
+	it( 'should render with custom background color', () => {
+		block.attributes.title = 'Accordion Item title';
+		block.attributes.customBackgroundColor = '#111111';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( '"customBackgroundColor":"#111111"' );
 		expect( serializedBlock ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
### Description
Adds Jest unit tests to the Accordion block. These are the final tests to close our the [Jest Unit Test Coverage project](https://github.com/godaddy-wordpress/coblocks/projects/13).

Closes #853 

### How has this been tested?
Ran the suite, all tests passed and snapshots created.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
