### PR TITLE
Allow HTML formatted text within Lightbox captions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,3 +40,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @westonruter      | @westonruter           |
 | @xpurichan        |                        |
 | @zrgisa           |                        |
+| @jchwenger        |                        |

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -100,7 +100,7 @@
 			// If not, jump to the next sibling and continue the loop
 			while ( sibling ) {
 				if ( sibling.matches( selector ) ) {
-					return sibling.innerHTML;
+					return sibling.textContent;
 				}
 				sibling = sibling.nextElementSibling;
 			}

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -100,7 +100,7 @@
 			// If not, jump to the next sibling and continue the loop
 			while ( sibling ) {
 				if ( sibling.matches( selector ) ) {
-					return sibling.textContent;
+					return sibling.innerHTML;
 				}
 				sibling = sibling.nextElementSibling;
 			}
@@ -130,7 +130,7 @@
 			wrapper.style.display = 'flex';
 			wrapperBackground.style.backgroundImage = `url(${ imagePreloader[ `img-${ index }` ].src })`;
 			image.src = imagePreloader[ `img-${ index }` ].src;
-			caption.textContent = imagePreloader[ `img-${ index }` ][ 'data-caption' ];
+			caption.innerHTML = imagePreloader[ `img-${ index }` ][ 'data-caption' ];
 			counter.textContent = `${ ( index + 1 ) } / ${ images.length }`;
 		}
 


### PR DESCRIPTION
### Description
Only extracts plain text and converts html code (e.g. &amp;) into text before injecting it into lightbox captions.

### Types of changes
Only `textContent` instead of `rawHTML` [here](https://github.com/godaddy-wordpress/coblocks/blob/master/src/js/coblocks-lightbox.js#L103).

However, that means that no html code can be used in said captions, e.g. bold, italics. I have been looking for a way to achieve that, maybe that could be implemented in the future.

### How has this been tested?
Implemented it on the website I'm currently working on.

### Checklist:
- [x ] My code is tested

Closes #1558 