### PR TITLE
Fix errors in hero block resize

### DIFF
--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -113,9 +113,10 @@ export class Edit extends Component {
 	}
 
 	saveMeta( type ) {
-		const { getEditedPostAttribute, getBlock, editPost } = this.props;
+		const { getEditedPostAttribute } = this.props;
 		const meta = getEditedPostAttribute( 'meta' );
-		const block = getBlock( this.props.clientId );
+		const block = wp.data.select( 'core/editor' ).getBlock( this.props.clientId );
+		console.log( block );
 		let dimensions = {};
 
 		if ( typeof this.props.attributes.coblocks !== 'undefined' && typeof this.props.attributes.coblocks.id !== 'undefined' ) {
@@ -142,7 +143,7 @@ export class Edit extends Component {
 			dimensions[ id ][ type ] = height;
 
 			// Save values to metadata.
-			editPost( {
+			wp.data.dispatch( 'core/editor' ).editPost( {
 				meta: {
 					_coblocks_responsive_height: JSON.stringify( dimensions ),
 				},

--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -116,7 +116,6 @@ export class Edit extends Component {
 		const { getEditedPostAttribute } = this.props;
 		const meta = getEditedPostAttribute( 'meta' );
 		const block = wp.data.select( 'core/editor' ).getBlock( this.props.clientId );
-		console.log( block );
 		let dimensions = {};
 
 		if ( typeof this.props.attributes.coblocks !== 'undefined' && typeof this.props.attributes.coblocks.id !== 'undefined' ) {

--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -113,9 +113,9 @@ export class Edit extends Component {
 	}
 
 	saveMeta( type ) {
-		const { getEditedPostAttribute } = this.props;
+		const { getEditedPostAttribute, getBlock, editPost } = this.props;
 		const meta = getEditedPostAttribute( 'meta' );
-		const block = wp.data.select( 'core/editor' ).getBlock( this.props.clientId );
+		const block = getBlock( this.props.clientId );
 		let dimensions = {};
 
 		if ( typeof this.props.attributes.coblocks !== 'undefined' && typeof this.props.attributes.coblocks.id !== 'undefined' ) {
@@ -142,7 +142,7 @@ export class Edit extends Component {
 			dimensions[ id ][ type ] = height;
 
 			// Save values to metadata.
-			wp.data.dispatch( 'core/editor' ).editPost( {
+			editPost( {
 				meta: {
 					_coblocks_responsive_height: JSON.stringify( dimensions ),
 				},
@@ -406,7 +406,8 @@ export default compose( [
 	applyWithColors,
 
 	withDispatch( ( dispatch ) => {
-		const { updateBlockAttributes, editPost } = dispatch( 'core/block-editor' );
+		const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+		const { editPost } = dispatch( 'core/editor' );
 
 		return {
 			updateBlockAttributes,
@@ -414,15 +415,13 @@ export default compose( [
 		};
 	} ),
 
-	withSelect( ( select, props ) => {
-		const { getBlocks } = select( 'core/block-editor' );
+	withSelect( ( select ) => {
+		const { getBlock } = select( 'core/block-editor' );
 		const { getEditedPostAttribute } = select( 'core/editor' );
-		const innerBlocks = getBlocks( props.clientId );
 
 		return {
-			innerBlocks,
 			getEditedPostAttribute,
-			getBlocks,
+			getBlock,
 		};
 	} ),
 ] )( Edit );


### PR DESCRIPTION
### Description
Resolves #1550 

### Screenshots
![hero-resize-fix](https://user-images.githubusercontent.com/5321364/87337328-4458af00-c511-11ea-8589-f7d971ffc98b.gif)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested the changes.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
