### PR TITLE
Remove Rich from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @richtabor @jrtashjian @EvanHerman @AnthonyLedesma
+* @jrtashjian @EvanHerman @AnthonyLedesma


### PR DESCRIPTION
Going forward, @richtabor will be added as a review for PR's that only require his attention.