### PR TITLE
Detect modified code in extensions when setting up test specs

### DIFF
--- a/.dev/bin/setup-test-specs.sh
+++ b/.dev/bin/setup-test-specs.sh
@@ -22,6 +22,22 @@ do
 			SPECS=( "${SPECS[@]}" "${testSpec}" )
 		fi
   fi
+  
+  # Changed file matches /src/extensions/*
+  if [[ $FILE == *"src/extensions/"* ]]; then
+    testSpec=$(echo $FILE | cut -d'/' -f3)
+		foundwords=$(echo ${SPECS[@]} | grep -o "${testSpec}" | wc -w)
+		# The test spec does not yet exist in the SPECS array
+		if [[ "${foundwords}" -eq 0 ]]; then
+			# Spec file string is empty, do not start string with a ,
+			if [[ ${#SPECSTRING} -eq 0 ]]; then
+				SPECSTRING="src/extensions/${testSpec}/**/*.cypress.js"
+			else
+				SPECSTRING="${SPECSTRING},src/extensions/${testSpec}/**/*.cypress.js"
+			fi
+			SPECS=( "${SPECS[@]}" "${testSpec}" )
+		fi
+  fi
 done
 
 # No spec files to run

--- a/src/extensions/coblocks-settings/test/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/test/coblocks-settings.cypress.js
@@ -1,7 +1,7 @@
 /*
  * Include our constants
  */
-import * as helpers from '../../../.dev/tests/cypress/helpers';
+import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Extension: CoBlocks Settings', function() {
 	let supportsGradients = false;

--- a/src/extensions/colors/test/apply-style.spec.js
+++ b/src/extensions/colors/test/apply-style.spec.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import applyStyle from './apply-style';
+import applyStyle from '../apply-style';
 
 describe( 'colors/applyStyle', () => {
 	it( 'returns style attributes for block', () => {

--- a/src/extensions/colors/test/classes.spec.js
+++ b/src/extensions/colors/test/classes.spec.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import ColorSettingsClasses from './classes';
+import ColorSettingsClasses from '../classes';
 
 describe( 'colors/classes', () => {
 	it( 'returns an empty array of classes if textColor or customTextColor is undefined', () => {

--- a/src/extensions/colors/test/transform.spec.js
+++ b/src/extensions/colors/test/transform.spec.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import ColorTransforms from './transform';
+import ColorTransforms from '../transform';
 
 describe( 'colors/ColorTransforms', () => {
 	it( 'returns color transform attributes', () => {

--- a/src/extensions/lightbox-controls/test/lightbox-controls.cypress.js
+++ b/src/extensions/lightbox-controls/test/lightbox-controls.cypress.js
@@ -1,7 +1,7 @@
 /*
  * Include our constants
  */
-import * as helpers from '../../../.dev/tests/cypress/helpers';
+import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Lightbox Controls extension', function() {
 	/**

--- a/src/extensions/padding-controls/test/padding-controls.cypress.js
+++ b/src/extensions/padding-controls/test/padding-controls.cypress.js
@@ -1,7 +1,7 @@
 /*
  * Include our constants
  */
-import * as helpers from '../../../.dev/tests/cypress/helpers';
+import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Extension: CoBlocks Padding Controls', function() {
 	beforeEach( function() {

--- a/src/extensions/replace-image/test/remove-image.cypress.js
+++ b/src/extensions/replace-image/test/remove-image.cypress.js
@@ -1,7 +1,7 @@
 /*
  * Include our constants
  */
-import * as helpers from '../../../.dev/tests/cypress/helpers';
+import * as helpers from '../../../../.dev/tests/cypress/helpers';
 
 describe( 'Test CoBlocks Replace Image extension', function() {
 	/**

--- a/src/extensions/replace-image/test/remove-image.cypress.js
+++ b/src/extensions/replace-image/test/remove-image.cypress.js
@@ -20,8 +20,6 @@ describe( 'Test CoBlocks Replace Image extension', function() {
 
 		cy.get( '.components-coblocks-replace-image button' ).click();
 
-		cy.get( '.media-modal-content' ).contains( /upload files/i );
-		cy.get( '.media-modal-content' ).contains( /media library/i );
-		cy.get( '.media-modal-content' ).find( '.attachments-browser' ).should( 'exist' );
+		cy.get( '.media-modal' ).should( 'exist' );
 	} );
 } );

--- a/src/extensions/typography/test/apply-style.spec.js
+++ b/src/extensions/typography/test/apply-style.spec.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import applyStyle from './apply-style';
+import applyStyle from '../apply-style';
 
 describe( 'typography/applyStyle', () => {
 	it( 'returns style attributes for block', () => {


### PR DESCRIPTION
This updates our `.dev/bin/setup-test-specs.sh` script to also check for modified files within the `src/extensions` directory when setting up specs for CI.