### PR TITLE
Enable extensibility of Settings panel using SlotFill component

### DIFF
--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -2,7 +2,7 @@
 
 ## Add Fill to settings panel using SlotFill functionality
 
-The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. A helper function has been established which allows the user to pass an ID for the control as well as react components as children. Below are two examples, we have the correct methodology with ID passed, as well as the incorrect method ( invalid id ) that results in zero output.
+The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. A helper function has been established which allows the user to pass an ID for the control as well as react components as children. Below are two examples, we have the correct methodology with ID passed, as well as the incorrect method ( invalid id ) which has no output.
 
 
 ### Correct Method - Unique ID properly supplied
@@ -14,9 +14,7 @@ const buttonControls = (
 	<Button>Sample Controls</Button>
 );
 
-createSettingsFill.children = buttonControls;
-
-addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( 'sample-id' ).setup );
+addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( 'sample-id', buttonControls ).setup );
 ```
 
 ### Incorrect method - Controls require unique identifier
@@ -28,9 +26,7 @@ const buttonsControls = (
 	<Button>Sample Controls</Button>
 );
 
-createSettingsFill.children = buttonsControls;
-
-addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( '' ).setup );
+addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( buttonControls ).setup );
 ```
 
 ![image](https://user-images.githubusercontent.com/30462574/87710720-f9ca7300-c75a-11ea-97dd-d736d74eaf70.png)

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -2,7 +2,7 @@
 
 ## Add Fill to settings panel using SlotFill functionality
 
-The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. To use the filer the user should push elements onto the controls array provided by the filter. The filtered elements then are able to display within the CoBlocks settings modal. 
+The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. To use the filter push react elements onto the controls array provided by the filter. The filtered elements then are able to render within the CoBlocks settings modal. 
 
 *Example usage*
 ```javascript

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -2,7 +2,7 @@
 
 ## Add Fill to settings panel using SlotFill functionality
 
-The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. To use the filter push react elements onto the controls array provided by the filter. The filtered elements then are able to render within the CoBlocks settings modal. 
+The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. To use the filter push React classes or functional components onto the controls array provided by the filter. The filtered components then are able to render within the CoBlocks settings modal. 
 
 *Example usage*
 ```javascript

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -8,29 +8,29 @@ The following `JavaScript` filter will allow insertion of react components withi
 ### Correct Method - Unique ID properly supplied
 ```javascript
 import { addFilter } from '@wordpress/hooks';
-import { withCoBlocksSettings } from '../../extensions/coblocks-settings/coblocks-settings-slot';
+import { createSettingsFill } from '../../extensions/coblocks-settings/coblocks-settings-slot';
 
 const buttonControls = (
 	<Button>Sample Controls</Button>
 );
 
-withCoBlocksSettings.children = buttonControls;
+createSettingsFill.children = buttonControls;
 
-addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', withCoBlocksSettings( 'sample-id' ).setup, 50 );
+addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( 'sample-id' ).setup );
 ```
 
 ### Incorrect method - Controls require unique identifier
 ```javascript
 import { addFilter } from '@wordpress/hooks';
-import { withCoBlocksSettings } from '../../extensions/coblocks-settings/coblocks-settings-slot';
+import { createSettingsFill } from '../../extensions/coblocks-settings/coblocks-settings-slot';
 
 const buttonsControls = (
 	<Button>Sample Controls</Button>
 );
 
-withCoBlocksSettings.children = buttonsControls;
+createSettingsFill.children = buttonsControls;
 
-addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', withCoBlocksSettings( '' ).setup, 50 );
+addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( '' ).setup );
 ```
 
 ![image](https://user-images.githubusercontent.com/30462574/87710720-f9ca7300-c75a-11ea-97dd-d736d74eaf70.png)

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -1,5 +1,40 @@
 # Editor Settings
 
+## Add Fill to settings panel using SlotFill functionality
+
+The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. A helper function has been established which allows the user to pass an ID for the control as well as react components as children. Below are two examples, we have the correct methodology with ID passed, as well as the incorrect method ( invalid id ) that results in zero output.
+
+
+### Correct Method - Unique ID properly supplied
+```javascript
+import { addFilter } from '@wordpress/hooks';
+import { withCoBlocksSettings } from '../../extensions/coblocks-settings/coblocks-settings-slot';
+
+const buttonControls = (
+	<Button>Sample Controls</Button>
+);
+
+withCoBlocksSettings.children = buttonControls;
+
+addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', withCoBlocksSettings( 'sample-id' ).setup, 50 );
+```
+
+### Incorrect method - Controls require unique identifier
+```javascript
+import { addFilter } from '@wordpress/hooks';
+import { withCoBlocksSettings } from '../../extensions/coblocks-settings/coblocks-settings-slot';
+
+const buttonsControls = (
+	<Button>Sample Controls</Button>
+);
+
+withCoBlocksSettings.children = buttonsControls;
+
+addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', withCoBlocksSettings( '' ).setup, 50 );
+```
+
+![image](https://user-images.githubusercontent.com/30462574/87710720-f9ca7300-c75a-11ea-97dd-d736d74eaf70.png)
+
 ## Customize labels
 
 The following `JavaScript` filter will customize the text used for the menu item

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -22,7 +22,7 @@ addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSett
 import { addFilter } from '@wordpress/hooks';
 import { createSettingsFill } from '../../extensions/coblocks-settings/coblocks-settings-slot';
 
-const buttonsControls = (
+const buttonControls = (
 	<Button>Sample Controls</Button>
 );
 

--- a/docs/hooks/settings-panel.md
+++ b/docs/hooks/settings-panel.md
@@ -2,31 +2,20 @@
 
 ## Add Fill to settings panel using SlotFill functionality
 
-The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. A helper function has been established which allows the user to pass an ID for the control as well as react components as children. Below are two examples, we have the correct methodology with ID passed, as well as the incorrect method ( invalid id ) which has no output.
+The following `JavaScript` filter will allow insertion of react components within the CoBlocks settings modal. To use the filer the user should push elements onto the controls array provided by the filter. The filtered elements then are able to display within the CoBlocks settings modal. 
 
-
-### Correct Method - Unique ID properly supplied
+*Example usage*
 ```javascript
 import { addFilter } from '@wordpress/hooks';
-import { createSettingsFill } from '../../extensions/coblocks-settings/coblocks-settings-slot';
 
 const buttonControls = (
 	<Button>Sample Controls</Button>
 );
 
-addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( 'sample-id', buttonControls ).setup );
-```
-
-### Incorrect method - Controls require unique identifier
-```javascript
-import { addFilter } from '@wordpress/hooks';
-import { createSettingsFill } from '../../extensions/coblocks-settings/coblocks-settings-slot';
-
-const buttonControls = (
-	<Button>Sample Controls</Button>
-);
-
-addFilter( 'editor.BlockEdit', 'custom-slug/custom-coblocks-setting', createSettingsFill( buttonControls ).setup );
+addFilter( 'coblocks-settings-modal-controls', 'custom-slug', ( controls ) => {
+	controls.push( buttonControls );
+	return controls;
+} );
 ```
 
 ![image](https://user-images.githubusercontent.com/30462574/87710720-f9ca7300-c75a-11ea-97dd-d736d74eaf70.png)

--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -131,8 +131,7 @@ class CoBlocksSettingsModal extends Component {
 								<>
 									{ fills }
 								</>
-							)
-							}
+							) }
 						</CoBlocksSettingsSlot.Slot>
 
 						{ showLayoutSelectorControl &&

--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import Section from './section';
-import CoBlocksSettingsSlot, { Fill } from './coblocks-settings-slot';
+import CoBlocksSettingsModalControls from './coblocks-settings-slot';
 
 /**
  * WordPress dependencies
@@ -118,6 +118,8 @@ class CoBlocksSettingsModal extends Component {
 		const colorPanelEnabled = !! colorPanel;
 		const showLayoutSelectorControl = applyFilters( 'coblocks-show-layout-selector', true ) && !! getPlugin( 'coblocks-layout-selector' );
 
+		const settings = applyFilters( 'coblocks-settings-modal-controls', [] );
+
 		return (
 			<Modal
 				title={ applyFilters( 'coblocks-settings-title', __( 'Editor settings', 'coblocks' ) ) }
@@ -126,27 +128,21 @@ class CoBlocksSettingsModal extends Component {
 				<div className="coblocks-modal__content">
 					<Section title={ __( 'General' ) }>
 
-						<CoBlocksSettingsSlot.Slot>
-							{ ( fills ) => (
-								<>
-									{ fills }
-								</>
-							) }
-						</CoBlocksSettingsSlot.Slot>
+						<CoBlocksSettingsModalControls.Slot />
 
 						{ showLayoutSelectorControl &&
-						<Fill name="CoBlocksSettingsSlot">
-							<HorizontalRule />
-							<CheckboxControl
-								label={ __( 'Layout selector', 'coblocks' ) }
-								help={ __( 'Allow layout selection on new pages.', 'coblocks' ) }
-								onChange={ () => this.updateLayoutSelectorSetting() }
-								checked={ !! layoutSelector }
-							/>
-						</Fill>
+							<CoBlocksSettingsModalControls>
+								<HorizontalRule />
+								<CheckboxControl
+									label={ __( 'Layout selector', 'coblocks' ) }
+									help={ __( 'Allow layout selection on new pages.', 'coblocks' ) }
+									onChange={ () => this.updateLayoutSelectorSetting() }
+									checked={ !! layoutSelector }
+								/>
+							</CoBlocksSettingsModalControls>
 						}
 
-						<Fill name="CoBlocksSettingsSlot">
+						<CoBlocksSettingsModalControls>
 							<HorizontalRule />
 							<CheckboxControl
 								label={ __( 'Typography controls', 'coblocks' ) }
@@ -154,9 +150,9 @@ class CoBlocksSettingsModal extends Component {
 								onChange={ () => this.updateTypographyControlsSetting() }
 								checked={ !! typography }
 							/>
-						</Fill>
+						</CoBlocksSettingsModalControls>
 
-						<Fill name="CoBlocksSettingsSlot">
+						<CoBlocksSettingsModalControls>
 							<HorizontalRule />
 							<CheckboxControl
 								label={ __( 'Color settings', 'coblocks' ) }
@@ -164,31 +160,38 @@ class CoBlocksSettingsModal extends Component {
 								onChange={ () => this.updateColorPanel( !! colorPanel ) }
 								checked={ !! colorPanel }
 							/>
-						</Fill>
+						</CoBlocksSettingsModalControls>
 
 						{ colorPanelEnabled &&
-						<Fill name="CoBlocksSettingsSlot">
-							<HorizontalRule />
-							<CheckboxControl
-								label={ __( 'Custom color pickers', 'coblocks' ) }
-								help={ __( 'Allow styling with custom colors.', 'coblocks' ) }
-								onChange={ () => this.updateCustomColorsSetting( !! customColors ) }
-								checked={ !! customColors }
-							/>
-						</Fill>
+							<CoBlocksSettingsModalControls>
+								<HorizontalRule />
+								<CheckboxControl
+									label={ __( 'Custom color pickers', 'coblocks' ) }
+									help={ __( 'Allow styling with custom colors.', 'coblocks' ) }
+									onChange={ () => this.updateCustomColorsSetting( !! customColors ) }
+									checked={ !! customColors }
+								/>
+							</CoBlocksSettingsModalControls>
 						}
 
 						{ colorPanelEnabled && supportsGradients &&
-						<Fill name="CoBlocksSettingsSlot">
-							<HorizontalRule />
-							<CheckboxControl
-								label={ __( 'Gradient styles', 'coblocks' ) }
-								help={ __( 'Allow styling with gradient fills.', 'coblocks' ) }
-								onChange={ () => this.updateGradientsControlsSetting( !! gradientControls ) }
-								checked={ !! gradientControls }
-							/>
-						</Fill>
+							<CoBlocksSettingsModalControls>
+								<HorizontalRule />
+								<CheckboxControl
+									label={ __( 'Gradient styles', 'coblocks' ) }
+									help={ __( 'Allow styling with gradient fills.', 'coblocks' ) }
+									onChange={ () => this.updateGradientsControlsSetting( !! gradientControls ) }
+									checked={ !! gradientControls }
+								/>
+							</CoBlocksSettingsModalControls>
 						}
+
+						{ settings && settings.map( ( Control, index ) => (
+							<CoBlocksSettingsModalControls key={ `modal-control-${ index }` }>
+								<HorizontalRule />
+								<Control />
+							</CoBlocksSettingsModalControls>
+						) ) }
 
 						<HorizontalRule />
 					</Section>

--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import Section from './section';
+import CoBlocksSettingsSlot, { Fill } from './coblocks-settings-slot';
 
 /**
  * WordPress dependencies
@@ -124,8 +125,18 @@ class CoBlocksSettingsModal extends Component {
 			>
 				<div className="coblocks-modal__content">
 					<Section title={ __( 'General' ) }>
+
+						<CoBlocksSettingsSlot.Slot>
+							{ ( fills ) => (
+								<>
+									{ fills }
+								</>
+							)
+							}
+						</CoBlocksSettingsSlot.Slot>
+
 						{ showLayoutSelectorControl &&
-						<>
+						<Fill name="CoBlocksSettingsSlot">
 							<HorizontalRule />
 							<CheckboxControl
 								label={ __( 'Layout selector', 'coblocks' ) }
@@ -133,24 +144,31 @@ class CoBlocksSettingsModal extends Component {
 								onChange={ () => this.updateLayoutSelectorSetting() }
 								checked={ !! layoutSelector }
 							/>
-						</>
+						</Fill>
 						}
-						<HorizontalRule />
-						<CheckboxControl
-							label={ __( 'Typography controls', 'coblocks' ) }
-							help={ __( 'Allow block-level typography controls.', 'coblocks' ) }
-							onChange={ () => this.updateTypographyControlsSetting() }
-							checked={ !! typography }
-						/>
-						<HorizontalRule />
-						<CheckboxControl
-							label={ __( 'Color settings', 'coblocks' ) }
-							help={ __( 'Allow color settings throughout the editor.', 'coblocks' ) }
-							onChange={ () => this.updateColorPanel( !! colorPanel ) }
-							checked={ !! colorPanel }
-						/>
+
+						<Fill name="CoBlocksSettingsSlot">
+							<HorizontalRule />
+							<CheckboxControl
+								label={ __( 'Typography controls', 'coblocks' ) }
+								help={ __( 'Allow block-level typography controls.', 'coblocks' ) }
+								onChange={ () => this.updateTypographyControlsSetting() }
+								checked={ !! typography }
+							/>
+						</Fill>
+
+						<Fill name="CoBlocksSettingsSlot">
+							<HorizontalRule />
+							<CheckboxControl
+								label={ __( 'Color settings', 'coblocks' ) }
+								help={ __( 'Allow color settings throughout the editor.', 'coblocks' ) }
+								onChange={ () => this.updateColorPanel( !! colorPanel ) }
+								checked={ !! colorPanel }
+							/>
+						</Fill>
+
 						{ colorPanelEnabled &&
-						<>
+						<Fill name="CoBlocksSettingsSlot">
 							<HorizontalRule />
 							<CheckboxControl
 								label={ __( 'Custom color pickers', 'coblocks' ) }
@@ -158,20 +176,22 @@ class CoBlocksSettingsModal extends Component {
 								onChange={ () => this.updateCustomColorsSetting( !! customColors ) }
 								checked={ !! customColors }
 							/>
-						</>
+						</Fill>
 						}
-						<HorizontalRule />
+
 						{ colorPanelEnabled && supportsGradients &&
-						<>
+						<Fill name="CoBlocksSettingsSlot">
+							<HorizontalRule />
 							<CheckboxControl
 								label={ __( 'Gradient styles', 'coblocks' ) }
 								help={ __( 'Allow styling with gradient fills.', 'coblocks' ) }
 								onChange={ () => this.updateGradientsControlsSetting( !! gradientControls ) }
 								checked={ !! gradientControls }
 							/>
-							<HorizontalRule />
-						</>
+						</Fill>
 						}
+
+						<HorizontalRule />
 					</Section>
 				</div>
 			</Modal>

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -13,7 +13,7 @@ const CoBlocksSettingsSlot = <Slot />;
 CoBlocksSettingsSlot.Slot = Slot;
 export default CoBlocksSettingsSlot;
 
-export const withCoBlocksSettings = ( id ) => {
+export const createSettingsFill = ( id ) => {
 	if ( !! id === true ) {
 		return {
 			init: () => {
@@ -25,11 +25,11 @@ export const withCoBlocksSettings = ( id ) => {
 			},
 			setup: createHigherOrderComponent( ( BlockEdit ) => {
 				return ( props ) => {
-					if ( withCoBlocksSettings( id ).init() === true ) {
+					if ( createSettingsFill( id ).init() === true ) {
 						return (
 							<>
 								<Fill name="CoBlocksSettingsSlot">
-									{ withCoBlocksSettings.children }
+									{ createSettingsFill.children }
 								</Fill>
 
 								<BlockEdit { ...props } />
@@ -37,7 +37,7 @@ export const withCoBlocksSettings = ( id ) => {
 					}
 					return <BlockEdit { ...props } />;
 				};
-			}, 'withCoBlocksSettings' ),
+			}, 'createSettingsFill' ),
 		};
 	}
 	return !! id === false && {

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { createSlotFill } from '@wordpress/components';
+
+// Constants
+const initializedIds = [];
+
+export const { Fill, Slot } = createSlotFill( 'CoBlocksSettingsSlot' );
+const CoBlocksSettingsSlot = <Slot />;
+CoBlocksSettingsSlot.Slot = Slot;
+export default CoBlocksSettingsSlot;
+
+export const withCoBlocksSettings = ( id ) => {
+	if ( !! id === true ) {
+		return {
+			init: () => {
+				if ( ! initializedIds.includes( id ) ) {
+					initializedIds.push( id );
+					return true;
+				}
+				return false;
+			},
+			setup: createHigherOrderComponent( ( BlockEdit ) => {
+				return ( props ) => {
+					if ( withCoBlocksSettings( id ).init() === true ) {
+						return (
+							<>
+								<Fill name="CoBlocksSettingsSlot">
+									{ withCoBlocksSettings.children }
+								</Fill>
+
+								<BlockEdit { ...props } />
+							</> );
+					}
+					return <BlockEdit { ...props } />;
+				};
+			}, 'withCoBlocksSettings' ),
+		};
+	}
+	return !! id === false && {
+		setup: createHigherOrderComponent( ( BlockEdit ) => {
+			return ( props ) => {
+				return <BlockEdit { ...props } />;
+			};
+		} ),
+	};
+};

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -1,71 +1,13 @@
 /**
  * WordPress dependencies
  */
-
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { createSlotFill } from '@wordpress/components';
 
-// Constants
-const initializedIds = [];
+const { Fill, Slot } = createSlotFill( 'CoBlocksSettingsModalControls' );
 
-export const { Fill, Slot } = createSlotFill( 'CoBlocksSettingsSlot' );
+function CoBlocksSettingsModalControls( { children } ) {
+	return <Fill>{ children }</Fill>;
+}
 
-/**
- * CoBlocksSettingsSlot is a SlotFill Provider to be used exclusively with the CoBlocks Settings panel.
- *
- * @return {Object} Returns Slot Provider to be used exclusively with CoBlocks Settings panel.
- */
-const CoBlocksSettingsSlot = <Slot />;
-CoBlocksSettingsSlot.Slot = Slot;
-export default CoBlocksSettingsSlot;
-
-/**
- * Helper function for extending CoBlocks Settings panel.
- * Function allows user to embed custom react components into settings modal.
- * Function is intended for use with WordPress filter. Example: `addFilter( 'editor.BlockEdit', 'custom/slug', createSettingsFill( 'sample-id', ReactComponentHere ).setup );`.
- *
- * Developer Notes:
- * Filters set using the same ID will result in children from the most recently executed filter.
- * Filters set without an ID will cause children not to render.
- * Filters set without children will not render any custom controls.
- *
- * @param {string} id A unique identifier to the specified control.
- * @param {Object} children React components to display within the editor settings panel.
- *
- * @return {Object} Returns `BlockEdit` component in addition to `Fill` when correct parameters are supplied and control has not been initialized. Otherwise returns `BlockEdit` unchanged.
- */
-export const createSettingsFill = ( id, children ) => {
-	if ( typeof id === 'string' && !! id === true ) {
-		return {
-			init: () => {
-				if ( ! initializedIds.includes( id ) ) {
-					initializedIds.push( id );
-					return true;
-				}
-				return false;
-			},
-			setup: createHigherOrderComponent( ( BlockEdit ) => {
-				return ( props ) => {
-					if ( createSettingsFill( id ).init() === true ) {
-						return (
-							<>
-								<Fill name="CoBlocksSettingsSlot">
-									{ children }
-								</Fill>
-
-								<BlockEdit { ...props } />
-							</> );
-					}
-					return <BlockEdit { ...props } />;
-				};
-			}, 'createSettingsFill' ),
-		};
-	}
-	return {
-		setup: createHigherOrderComponent( ( BlockEdit ) => {
-			return ( props ) => {
-				return <BlockEdit { ...props } />;
-			};
-		} ),
-	};
-};
+CoBlocksSettingsModalControls.Slot = Slot;
+export default CoBlocksSettingsModalControls;

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -9,12 +9,33 @@ import { createSlotFill } from '@wordpress/components';
 const initializedIds = [];
 
 export const { Fill, Slot } = createSlotFill( 'CoBlocksSettingsSlot' );
+
+/**
+ * CoBlocksSettingsSlot is a SlotFill Provider to be used exclusively with the CoBlocks Settings panel.
+ *
+ * @return {Object} Returns Slot Provider to be used exclusively with CoBlocks Settings panel.
+ */
 const CoBlocksSettingsSlot = <Slot />;
 CoBlocksSettingsSlot.Slot = Slot;
 export default CoBlocksSettingsSlot;
 
-export const createSettingsFill = ( id ) => {
-	if ( !! id === true ) {
+/**
+ * Helper function for extending CoBlocks Settings panel.
+ * Function allows user to embed custom react components into settings modal.
+ * Function is intended for use with WordPress filter. Example: `addFilter( 'editor.BlockEdit', 'custom/slug', createSettingsFill( 'sample-id', ReactComponentHere ).setup );`.
+ *
+ * Developer Notes:
+ * Filters set using the same ID will result in children from the most recently executed filter.
+ * Filters set without an ID will cause children not to render.
+ * Filters set without children will not render any custom controls.
+ *
+ * @param {string} id A unique identifier to the specified control.
+ * @param {Object} children React components to display within the editor settings panel.
+ *
+ * @return {Object} Returns `BlockEdit` component in addition to `Fill` when correct parameters are supplied and control has not been initialized. Otherwise returns `BlockEdit` unchanged.
+ */
+export const createSettingsFill = ( id, children ) => {
+	if ( typeof id === 'string' && !! id === true ) {
 		return {
 			init: () => {
 				if ( ! initializedIds.includes( id ) ) {
@@ -29,7 +50,7 @@ export const createSettingsFill = ( id ) => {
 						return (
 							<>
 								<Fill name="CoBlocksSettingsSlot">
-									{ createSettingsFill.children }
+									{ children }
 								</Fill>
 
 								<BlockEdit { ...props } />
@@ -40,7 +61,7 @@ export const createSettingsFill = ( id ) => {
 			}, 'createSettingsFill' ),
 		};
 	}
-	return !! id === false && {
+	return {
 		setup: createHigherOrderComponent( ( BlockEdit ) => {
 			return ( props ) => {
 				return <BlockEdit { ...props } />;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Refactor of CoBlocks settings modal to use SlotFill components. All existing modal components are now Fill components. Helper function has been created to enable developers to easily extend the CoBlocks settings modal with complete react components.

Docs have been updated in this PR to show how to use the new helper function. Please review docs for example.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/87710720-f9ca7300-c75a-11ea-97dd-d736d74eaf70.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally within CoBlocks plugin with and without the Gutenberg plugin active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
