### PR TITLE
Fix Click to Tweet inline toolbar via SVG

### DIFF
--- a/src/blocks/click-to-tweet/styles/editor.scss
+++ b/src/blocks/click-to-tweet/styles/editor.scss
@@ -69,6 +69,6 @@
 	}
 
 	.edit-post-header-toolbar__block-toolbar &__via-label {
-		padding-left: 2px;
+		padding: 0 10px;
 	}
 }

--- a/src/blocks/click-to-tweet/styles/editor.scss
+++ b/src/blocks/click-to-tweet/styles/editor.scss
@@ -31,8 +31,8 @@
 	}
 
 	&__via {
-		margin: 3px;
-		padding-left: 26px !important;
+		margin: 5px;
+		padding-left: 32px !important;
 	}
 
 	&__via-label {
@@ -40,14 +40,11 @@
 		display: flex;
 		flex-basis: 0;
 		font-size: 12px;
-		height: 36px;
-		left: 7px;
+		top: 0;
+		bottom: 0;
+		padding: 0 10px;
 		position: absolute;
 		white-space: nowrap;
-
-		svg {
-			color: $dark-gray-500;
-		}
 	}
 
 	&__via-wrapper {


### PR DESCRIPTION
This PR is a quick style fix to adjust the SVG within the "via" toolbar component in the Click to Tweet block. Tested with core WP and Gutenberg 8.5.1

Before: 
<img width="616" alt="Screen Shot 2020-07-17 at 12 49 18 PM" src="https://user-images.githubusercontent.com/1813435/87811064-0cf94380-c82c-11ea-97f7-3642e1573f9f.png">

After: 
<img width="1143" alt="Screen Shot 2020-07-17 at 12 48 05 PM" src="https://user-images.githubusercontent.com/1813435/87811085-18e50580-c82c-11ea-81d8-9ee2c73cd2b7.png">
<img width="1016" alt="Screen Shot 2020-07-17 at 12 48 42 PM" src="https://user-images.githubusercontent.com/1813435/87811090-1aaec900-c82c-11ea-8d60-442ce6d5db57.png">

