### PR TITLE
Fix Post and Post Carousel blocks compatibility across versions

### DIFF
--- a/src/blocks/post-carousel/block.json
+++ b/src/blocks/post-carousel/block.json
@@ -61,7 +61,7 @@
 			"default": "date"
 		},
 		"categories": {
-			"type": "string"
+			"type": "array"
 		}
 	}
 }

--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isUndefined, pickBy } from 'lodash';
+import { isUndefined, pickBy, get, includes, invoke } from 'lodash';
 import Slick from 'react-slick';
 
 /**
@@ -30,6 +30,7 @@ import {
 	Button,
 	Disabled,
 	ServerSideRender,
+	QueryControls,
 } from '@wordpress/components';
 
 /**
@@ -175,9 +176,9 @@ class PostCarousel extends Component {
 						icon={ <BlockIcon icon={ icon } /> }
 						label={ __( 'Post Carousel', 'coblocks' ) }
 					>
-						{ ! Array.isArray( latestPosts ) ?
-							<Spinner /> :
-							<Fragment>
+						{ ! Array.isArray( latestPosts )
+							? <Spinner />
+							: <Fragment>
 								{ __( 'No posts found. Start publishing or add posts from an RSS feed.', 'coblocks' ) }
 								<Button
 									className="components-placeholder__cancel-button"
@@ -295,9 +296,9 @@ class PostCarousel extends Component {
 															<RawHTML>
 																{ titleTrimmed }
 															</RawHTML>
-														) :
+														)
 															/* translators: placeholder when a post has no title */
-															__( '(no title)', 'coblocks' )
+															: __( '(no title)', 'coblocks' )
 														}
 													</a>
 												</Disabled>
@@ -334,26 +335,70 @@ class PostCarousel extends Component {
 export default compose( [
 	withSelect( ( select, props ) => {
 		const { postsToShow, order, orderBy, categories } = props.attributes;
-		const { getEntityRecords } = select( 'core' );
-		const latestPostsQuery = pickBy( {
-			categories,
-			order,
-			orderby: orderBy,
-			per_page: postsToShow,
-		}, ( value ) => ! isUndefined( value ) );
+		const { getEntityRecords, getMedia } = select( 'core' );
 
-		let latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );
-		if ( latestPosts ) {
-			latestPosts = latestPosts.map( ( post ) => {
-				return {
-					...post,
-					featured_media_object: post.featured_media && select( 'core' ).getMedia( post.featured_media ),
-				};
-			} );
-		}
+		const useUpdatedQueryControls = QueryControls.toString().includes( 'selectedCategories' );
+
+		const deprecatedQuery = () => {
+			const latestPostsQuery = pickBy( {
+				categories,
+				order,
+				orderby: orderBy,
+				per_page: postsToShow,
+			}, ( value ) => ! isUndefined( value ) );
+
+			let latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );
+			if ( latestPosts ) {
+				latestPosts = latestPosts.map( ( post ) => {
+					return {
+						...post,
+						featured_media_object: post.featured_media && select( 'core' ).getMedia( post.featured_media ),
+					};
+				} );
+			}
+			return latestPosts;
+		};
+
+		const updatedQuery = () => {
+			const catIds = categories && categories.length > 0
+				? categories.map( ( cat ) => cat.id )
+				: [];
+
+			const latestPostsQuery = pickBy( {
+				categories: catIds,
+				order,
+				orderby: orderBy,
+				per_page: postsToShow,
+			}, ( value ) => ! isUndefined( value ) );
+
+			const latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );
+
+			return ! Array.isArray( latestPosts )
+				? latestPosts
+				: latestPosts.map( ( post ) => {
+					if ( post.featured_media ) {
+						const image = getMedia( post.featured_media );
+						let url = get(
+							image,
+							[
+								'media_details',
+								'sizes',
+								'source_url',
+							],
+							null
+						);
+						if ( ! url ) {
+							url = get( image, 'source_url', null );
+						}
+						return { ...post, featuredImageSourceUrl: url };
+					}
+					return post;
+				} );
+		};
 
 		return {
-			latestPosts,
+			latestPosts: useUpdatedQueryControls ? updatedQuery() : deprecatedQuery(),
+			useUpdatedQueryControls,
 		};
 	} ),
 ] )( PostCarousel );

--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isUndefined, pickBy, get, includes, invoke } from 'lodash';
+import { isUndefined, pickBy, get } from 'lodash';
 import Slick from 'react-slick';
 
 /**

--- a/src/blocks/posts/block.json
+++ b/src/blocks/posts/block.json
@@ -69,7 +69,7 @@
 			"default": "date"
 		},
 		"categories": {
-			"type": "string"
+			"type": "array"
 		}
 	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Post and Post carousel blocks use core component QueryControls. The QueryControls component has changed over time and backward compatibility had not been properly implemented. [This diff](https://github.com/WordPress/gutenberg/commit/e17d104ee3fe6eb8d81373226ab73096f59f9ba3?diff=unified#) shows where the onChange prop associated with CategorySelect had been moved to the proposed replacement component FormTokenField. This removal of props without backward compatibility had been reported on Gutenberg [Here](https://github.com/WordPress/gutenberg/issues/23285). [This PR here](https://github.com/WordPress/gutenberg/pull/23419) has been merged and is reported to fix the issue yet the fix failed to replace the original onChange function.

This failure in maintaining backward compatibility results in needing to deprecate QueryControl components with new attributes, props, and logic. These changes effectively alter the category selector from a single choice select component to using a tokenized multi-select input. 

This PR introduces the ability for CoBlocks post related blocks to use both classic QueryControls located in WP 5.4.1 and the newly updated QueryControls packed with GB 8.5.1 and Core 5.5. This PR also features UX improvement which resolves  the issue reported at #1555.

### Screenshots
<!-- if applicable -->
![postsFixed](https://user-images.githubusercontent.com/30462574/87821179-40d06b00-c824-11ea-8a2e-467d918b0033.gif)

![postCarouselFixed](https://user-images.githubusercontent.com/30462574/87821190-43cb5b80-c824-11ea-987d-dab24b47228c.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes to sever side rendered blocks. No deprecations needed across versions.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally with and without the Gutenberg Plugin active. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
