### PR TITLE
Fix Lightbox use with Go theme and Carousel Gallery block

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -3,7 +3,7 @@
 
 	const lightboxModals = document.getElementsByClassName( 'has-lightbox' );
 
-	Array.from( lightboxModals ).forEach( ( lightbox, index ) => {
+	Array.from( lightboxModals ).forEach( function( lightbox, index ) {
 		lightbox.className += ' lightbox-' + index + ' ';
 		renderLightboxModal( index );
 	} );
@@ -69,7 +69,7 @@
 		}
 
 		Array.from( images ).forEach( function( img, imgIndex ) {
-			img.addEventListener( 'click', function() {
+			img.closest( 'figure' ).addEventListener( 'click', function() {
 				changeImage( imgIndex );
 			} );
 		} );
@@ -116,8 +116,8 @@
 						imagePreloader[ `img-${ imgIndex }` ] = new window.Image();
 						imagePreloader[ `img-${ imgIndex }` ].src = img.attributes.src.value;
 						imagePreloader[ `img-${ imgIndex }` ][ 'data-caption' ] =
-							( images[ imgIndex ] && images[ imgIndex ].nextElementSibling )
-								? getImageCaption( images[ imgIndex ] ) : '';
+								( images[ imgIndex ] && images[ imgIndex ].nextElementSibling )
+									? getImageCaption( images[ imgIndex ] ) : '';
 					} );
 					setKeyboardListener();
 				}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The CoBlocks Lightbox works by adding `click` event listeners to document elements. Previous iterations of Lightbox worked by adding a click listener to the `img` elements which were arguably at the bottom of the document hierarchy. Because the event listener was near the bottom of hierarchy we made it possible for events to fire on elements that reside above our selected target. As a result of this bug, the Lightbox for Go theme when using the Carousel Gallery block would not function. 

This PR changes the listener target from the lowest `img` element to the parent `figure` element of each respective image. This allows the event bubbling to function as expected even if theme styles result in click events firing on the Figure or the Img elements. 

### Screenshots
<!-- if applicable -->
![CarouselGoFixed](https://user-images.githubusercontent.com/30462574/88414494-cd81a880-cd91-11ea-8abe-0d3ab182c746.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript change to use `.closest( 'figure' )` function. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in Chrome, and Firefox. 
Tested with and without the Gutenberg plugin active.
Tested with Go, TwentyTwenty, Barebones theme (underscores).

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
