### PR TITLE
Update the HeadingLevel Icon to match Gutenberg

### DIFF
--- a/src/components/heading-toolbar/icon.js
+++ b/src/components/heading-toolbar/icon.js
@@ -18,8 +18,8 @@ export default function HeadingLevelIcon( { level, isPressed = false } ) {
 
 	return (
 		<SVG
-			width="20"
-			height="20"
+			width="24"
+			height="24"
 			viewBox="0 0 20 20"
 			xmlns="http://www.w3.org/2000/svg"
 			isPressed={ isPressed }


### PR DESCRIPTION
### Description
Update the HeadingLevel Icon to match Gutenberg.

### Types of changes
Update the height/width of the SVG.

https://raw.githubusercontent.com/WordPress/gutenberg/47ae410fc4bff9e5d6b0796480b28257c9e1705e/packages/block-library/src/heading/heading-level-icon.js
