### PR TITLE
Fix lightbox extension display for core blocks

### DIFF
--- a/src/extensions/lightbox-controls/styles/style.scss
+++ b/src/extensions/lightbox-controls/styles/style.scss
@@ -1,9 +1,14 @@
 .edit-post-sidebar .components-panel__body.is-opened ~ .coblocks-lightbox-controls {
-    margin-top: -8px;
-    padding-left: 16px;
-    padding-right: 16px;
+	display: flex;
+	margin-top: -8px;
+	padding-left: 16px;
+	padding-right: 16px;
 }
 
 .edit-post-sidebar .components-panel__body.is-opened ~ .coblocks-lightbox-controls ~ .components-coblocks-replace-image {
-    margin-top: 0;
+	margin-top: 0;
+}
+
+.edit-post-sidebar .coblocks-lightbox-controls {
+	display: none;
 }


### PR DESCRIPTION
### Description
The lightbox control displays, even if the "Image settings" panel is closed.

### Screenshots
### Before:
<img width="1428" alt="before" src="https://user-images.githubusercontent.com/1813435/88560878-aed31a00-cffc-11ea-9f8a-480f49fbab05.png">
### After:

![after](https://user-images.githubusercontent.com/1813435/88560902-b85c8200-cffc-11ea-84ff-047771774bee.gif)

### Types of changes
Style fixes
