### PR TITLE
Remove core/image support from Crop Settings utility

### DIFF
--- a/src/extensions/image-crop/index.js
+++ b/src/extensions/image-crop/index.js
@@ -21,7 +21,6 @@ import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 const supportedBlocks = [
-	'core/image',
 	'core/cover',
 ];
 


### PR DESCRIPTION
### Description
CoBlocks added a Crop-Settings utility for use with `core/image` block. With the imminent release of WP 5.5 the image block now has crop controls provided by Core. This PR removes support for `core/image` from the Crop Settings utility.

The Crop-Settings utility still exists in its original state with support only for `core/cover`.


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally with and without the Gutenberg plugin active.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
