### PR TITLE
Move Gallery UI controls within the interface for consistency

### DIFF
--- a/src/blocks/gallery-carousel/inspector.js
+++ b/src/blocks/gallery-carousel/inspector.js
@@ -119,9 +119,9 @@ class Inspector extends Component {
 									className={ 'block-height-control__input' }
 									onChange={ ( event ) => {
 										const unprocessedValue = event.target.value;
-										const inputValue = unprocessedValue !== '' ?
-											parseInt( event.target.value, 10 ) :
-											undefined;
+										const inputValue = unprocessedValue !== ''
+											? parseInt( event.target.value, 10 )
+											: undefined;
 										if ( ( inputValue < 0 ) && inputValue !== undefined ) {
 											this.setTemporayInput( inputValue );
 											this.setHeightTo( 0 );
@@ -137,16 +137,16 @@ class Inspector extends Component {
 							</BaseControl>
 							}
 							<ToggleControl
-								label={ __( 'Thumbnails', 'coblocks' ) }
-								checked={ !! thumbnails }
-								onChange={ () => setAttributes( { thumbnails: ! thumbnails } ) }
-								help={ this.getThumbnailNavigationHelp }
-							/>
-							<ToggleControl
 								label={ __( 'Lightbox', 'coblocks' ) }
 								checked={ !! lightbox }
 								onChange={ () => setAttributes( { lightbox: ! lightbox } ) }
 								help={ this.getLightboxHelp }
+							/>
+							<ToggleControl
+								label={ __( 'Thumbnails', 'coblocks' ) }
+								checked={ !! thumbnails }
+								onChange={ () => setAttributes( { thumbnails: ! thumbnails } ) }
+								help={ this.getThumbnailNavigationHelp }
 							/>
 						</PanelBody>
 						<SliderPanel { ...this.props } />

--- a/src/blocks/gallery-collage/inspector.js
+++ b/src/blocks/gallery-collage/inspector.js
@@ -84,15 +84,21 @@ class Inspector extends Component {
 						label={ __( 'Gutter', 'coblocks' ) }
 						currentOption={ gutter }
 						options={ gutterOptions }
-						onChange={ ( gutter ) => setAttributes( { gutter } ) }
+						onChange={ ( newGutter ) => setAttributes( { gutter: newGutter } ) }
 					/> }
 					{ ! enableGutter && <OptionSelectorControl
 						label={ __( 'Shadow', 'coblocks' ) }
 						options={ shadowOptions }
 						currentOption={ shadow }
 						showNoneOption
-						onChange={ ( shadow ) => setAttributes( { shadow } ) }
+						onChange={ ( newShadow ) => setAttributes( { shadow: newShadow } ) }
 					/> }
+					<ToggleControl
+						label={ __( 'Lightbox', 'coblocks' ) }
+						checked={ !! lightbox }
+						onChange={ () => setAttributes( { lightbox: ! lightbox } ) }
+						help={ this.getLightboxHelp }
+					/>
 					{ enableCaptions && <ToggleControl
 						label={ __( 'Captions', 'coblocks' ) }
 						checked={ !! captions }
@@ -105,12 +111,6 @@ class Inspector extends Component {
 						onChange={ this.setCaptionStyleTo }
 						options={ captionOptions }
 					/> }
-					<ToggleControl
-						label={ __( 'Lightbox', 'coblocks' ) }
-						checked={ !! lightbox }
-						onChange={ () => setAttributes( { lightbox: ! lightbox } ) }
-						help={ this.getLightboxHelp }
-					/>
 				</PanelBody>
 				<GalleryLinkSettings { ...this.props } />
 			</InspectorControls>


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Gallery controls are out of order across blocks. This PR re-arranges UI controls for all CoBlocks gallery blocks for a more consistent experience.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Simple JavaScript changes.
Minor ESLint fix.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested locally within the editor.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
