### PR TITLE
Fix Media Card resize capability

### DIFF
--- a/src/blocks/media-card/styles/editor.scss
+++ b/src/blocks/media-card/styles/editor.scss
@@ -7,13 +7,15 @@
 		}
 	}
 
-	.wp-block[data-type="coblocks/media-card"] & &__wrapper {
+	.wp-block[data-type="coblocks/media-card"] & &__wrapper,
+	[data-type="coblocks/media-card"] & &__wrapper {
 		grid-template-areas:
 			"media-text-media media-text-content"
 			"resizer resizer";
 	}
 
-	.wp-block[data-type="coblocks/media-card"] &.is-style-right &__wrapper {
+	.wp-block[data-type="coblocks/media-card"] &.is-style-right &__wrapper,
+	[data-type="coblocks/media-card"] &.is-style-right &__wrapper {
 		grid-template-areas:
 			"media-text-content media-text-media"
 			"resizer resizer";
@@ -85,7 +87,7 @@
 	}
 
 	// Create a fake circular handle point.
-	&:not(.has-no-media) .wp-block-coblocks-media-card__media-container {
+	&:not(.has-no-media).is-selected .wp-block-coblocks-media-card__media-container {
 
 		&::after {
 			background: theme(primary);
@@ -161,7 +163,8 @@
 	}
 }
 
-.wp-block[data-type="coblocks/media-card"] {
+.wp-block[data-type="coblocks/media-card"],
+[data-type="coblocks/media-card"] {
 	background: transparent !important;
 
 	.has-no-media .components-placeholder {
@@ -199,12 +202,8 @@
 		}
 	}
 
-	// Child blocks should not have a max-width.
-	.block-editor-inner-blocks .wp-block {
-		// max-width: none;
-	}
-
-	.wp-block[data-type="coblocks/row"] .block-editor-block-mover {
+	.wp-block[data-type="coblocks/row"] .block-editor-block-mover,
+	[data-type="coblocks/row"] .block-editor-block-mover {
 		display: none;
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Media Card block uses the ResizableBox component from Core WordPress. Due to [changes in markup](https://github.com/WordPress/gutenberg/pull/21822) within the editor, a number of overriding styles for the editor had not been activating. 

This PR introduces the necessary CSS changes to correctly apply in the case of WordPress 5.4.2 as well as 5.5.

### Screenshots
<!-- if applicable -->
![mediaCardFix](https://user-images.githubusercontent.com/30462574/88967169-42f1eb00-d262-11ea-9951-b94747adc668.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Fixes to block CSS.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and E2E.
Tested with WP 5.4.2 and 5.5.
Tested with and without the Gutenberg plugin active.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
