### PR TITLE
Deprecate IconButton in favor of Button component

### DIFF
--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -11,7 +11,7 @@ import Inspector from './inspector';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -107,7 +107,7 @@ class AccordionEdit extends Component {
 					/>
 					{ isSelected && (
 						<div className="components-coblocks-add-accordion-item">
-							<IconButton
+							<Button
 								isLarge
 								className="block-editor-button-block-appender components-coblocks-add-accordion-item__button"
 								/* translators: Add a child element for the Accordion block */
@@ -115,7 +115,7 @@ class AccordionEdit extends Component {
 								icon="insert"
 								onMouseUp={ handleEvent }
 							>
-							</IconButton>
+							</Button>
 						</div>
 					) }
 				</div>

--- a/src/blocks/author/controls.js
+++ b/src/blocks/author/controls.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { Toolbar, IconButton } from '@wordpress/components';
+import { Toolbar, Button } from '@wordpress/components';
 
 class Controls extends Component {
 	render() {
@@ -31,7 +31,7 @@ class Controls extends Component {
 									allowedTypes={ [ 'image' ] }
 									value={ imgId }
 									render={ ( { open } ) => (
-										<IconButton
+										<Button
 											className="components-toolbar__control"
 											label={ __( 'Edit avatar', 'coblocks' ) }
 											icon="edit"

--- a/src/blocks/author/styles/editor.scss
+++ b/src/blocks/author/styles/editor.scss
@@ -42,7 +42,7 @@
 		background: $white;
 		position: relative;
 
-		button {
+		.components-button {
 			border-radius: 100%;
 			height: 100%;
 			left: 0;

--- a/src/blocks/events/appender.js
+++ b/src/blocks/events/appender.js
@@ -7,12 +7,12 @@ import { noop } from 'lodash';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 
 const CustomAppender = ( { onClick = noop } ) => {
 	return (
 		<div className="coblocks-list-appender">
-			<IconButton
+			<Button
 				icon="insert"
 				label={ __( 'Add event', 'coblocks' ) }
 				labelPosition="bottom"
@@ -20,7 +20,7 @@ const CustomAppender = ( { onClick = noop } ) => {
 				onClick={ onClick }
 			>
 				{ __( 'Add event', 'coblocks' ) }
-			</IconButton>
+			</Button>
 		</div>
 	);
 };

--- a/src/blocks/events/styles/editor.scss
+++ b/src/blocks/events/styles/editor.scss
@@ -4,23 +4,24 @@
 		margin-left: -12px;
 		margin-right: -12px;
 		margin-top: 28px;
-	}
 
-	.coblocks-list-appender__toggle {
-		align-items: center;
-		background: $dark-opacity-light-200 !important;
-		border-radius: 0;
-		box-shadow: none;
-		color: $dark-gray-500;
-		display: flex;
-		justify-content: center;
-		outline: 1px dashed $dark-gray-150;
-		padding: 16px;
-		width: 100%;
+		&__toggle.components-button {
+			align-items: center;
+			background: $dark-opacity-light-200 !important;
+			border-radius: 0;
+			box-shadow: none;
+			color: $dark-gray-500;
+			display: flex;
+			padding: 16px;
+			height: auto;
+			justify-content: center;
+			outline: 1px dashed $dark-gray-150;
+			width: 100%;
 
-		&:hover {
-			box-shadow: none !important;
-			outline: 1px dashed $dark-gray-500;
+			&:hover {
+				box-shadow: none !important;
+				outline: 1px dashed $dark-gray-500;
+			}
 		}
 	}
 

--- a/src/blocks/food-and-drinks/appender.js
+++ b/src/blocks/food-and-drinks/appender.js
@@ -7,12 +7,12 @@ import { noop } from 'lodash';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 
 const CustomAppender = ( { onClick = noop } ) => {
 	return (
 		<div className="coblocks-list-appender">
-			<IconButton
+			<Button
 				icon="insert"
 				label={ __( 'Add menu section', 'coblocks' ) }
 				labelPosition="bottom"
@@ -20,7 +20,7 @@ const CustomAppender = ( { onClick = noop } ) => {
 				onClick={ onClick }
 			>
 				{ __( 'Add menu section', 'coblocks' ) }
-			</IconButton>
+			</Button>
 		</div>
 	);
 };

--- a/src/blocks/food-and-drinks/food-item/edit.js
+++ b/src/blocks/food-and-drinks/food-item/edit.js
@@ -17,7 +17,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { IconButton, DropZone, Spinner } from '@wordpress/components';
+import { Button, DropZone, Spinner } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { RichText, MediaPlaceholder } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
@@ -203,7 +203,7 @@ class FoodItem extends Component {
 				<figure className={ classes }>
 					{ isSelected && (
 						<div className="wp-block-coblocks-food-item__remove-menu">
-							<IconButton
+							<Button
 								icon="no-alt"
 								onClick={ () => {
 									setAttributes( { url: '' } )
@@ -312,7 +312,7 @@ class FoodItem extends Component {
 							/>
 							<div className="wp-block-coblocks-food-item__attributes">
 								{ ( ( isSelected && title ) || ( !! popular ) ) && (
-									<IconButton
+									<Button
 										icon={ icons.popular }
 										label={ __( 'Popular', 'coblocks' ) }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--popular', {
@@ -324,7 +324,7 @@ class FoodItem extends Component {
 									/>
 								) }
 								{ ( ( isSelected && title ) || ( !! spicy ) ) && (
-									<IconButton
+									<Button
 										icon={ icons.spicy }
 										label={ __( 'Spicy', 'coblocks' ) }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--spicy', {
@@ -335,7 +335,7 @@ class FoodItem extends Component {
 									/>
 								) }
 								{ ( ( isSelected && title && !! spicy ) || ( !! spicier ) ) && (
-									<IconButton
+									<Button
 										icon={ icons.spicy }
 										label={ __( 'Hot', 'coblocks' ) }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--spicier', {
@@ -348,7 +348,7 @@ class FoodItem extends Component {
 									/>
 								) }
 								{ ( ( isSelected && title ) || ( !! vegetarian ) ) && (
-									<IconButton
+									<Button
 										icon={ icons.vegetarian }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--vegetarian', {
 											'is-toggled': vegetarian,
@@ -364,7 +364,7 @@ class FoodItem extends Component {
 								) }
 								{ ( ( isSelected && !! glutenFree ) || ( !! glutenFree ) ) && (
 									// Only renders if the option is checked within the Settings sidebar.
-									<IconButton
+									<Button
 										icon={ icons.glutenFree }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--gluten-free', {
 											'is-toggled': glutenFree,
@@ -379,7 +379,7 @@ class FoodItem extends Component {
 								) }
 								{ ( ( isSelected && !! pescatarian ) || ( !! pescatarian ) ) && (
 									// Only renders if the option is checked within the Settings sidebar.
-									<IconButton
+									<Button
 										icon={ icons.pescatarian }
 										label={ __( 'Pescatarian', 'coblocks' ) }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--pescatarian', {
@@ -395,7 +395,7 @@ class FoodItem extends Component {
 								) }
 								{ ( ( isSelected && !! vegan ) || ( !! vegan ) ) && (
 									// Only renders if the option is checked within the Settings sidebar.
-									<IconButton
+									<Button
 										icon={ icons.vegan }
 										className={ classnames( 'wp-block-coblocks-food-item__attribute', 'wp-block-coblocks-food-item__attribute--vegan', {
 											'is-toggled': vegan,

--- a/src/blocks/food-and-drinks/food-item/styles/editor.scss
+++ b/src/blocks/food-and-drinks/food-item/styles/editor.scss
@@ -73,12 +73,12 @@
 			}
 		}
 
-		&__attribute.components-icon-button,
 		&__attribute.components-button {
 			color: inherit;
 			padding: 1px;
 			height: auto;
 			opacity: 0.55;
+			min-width: auto;
 
 			&:not(.is-toggled):hover,
 			&:not(.is-toggled):focus {

--- a/src/blocks/food-and-drinks/styles/editor.scss
+++ b/src/blocks/food-and-drinks/styles/editor.scss
@@ -10,7 +10,7 @@
 		flex: 1 100%;
 		max-width: 100% !important;
 
-		&__toggle {
+		&__toggle.components-button {
 			align-items: center;
 			background: rgba(139, 139, 150, 0.1) !important;
 			border-radius: 0;

--- a/src/blocks/form/fields/coblocks-option.js
+++ b/src/blocks/form/fields/coblocks-option.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Component, createRef, Fragment } from '@wordpress/element';
 
 class CoBlocksFieldOption extends Component {
@@ -68,7 +68,7 @@ class CoBlocksFieldOption extends Component {
 							onKeyDown={ this.onKeyPress }
 							ref={ this.textInput }
 						/>
-						<IconButton
+						<Button
 							className="coblocks-option__remove"
 							icon="trash"
 							label={ __( 'Remove Option', 'coblocks' ) }

--- a/src/blocks/form/fields/multi-field.js
+++ b/src/blocks/form/fields/multi-field.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BaseControl, IconButton } from '@wordpress/components';
+import { BaseControl, Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
 import classnames from 'classnames';
@@ -106,14 +106,14 @@ class CoBlocksFieldMultiple extends Component {
 						</ol>
 					) }
 					{ isSelected && (
-						<IconButton
+						<Button
 							className="coblocks-field-multiple__add-option"
 							icon="insert"
 							label={ 'radio' === type || 'select' === type ? __( 'Add option', 'coblocks' ) : __( 'Add checkbox', 'coblocks' ) }
 							onClick={ this.addNewOption }
 						>
 							{ 'radio' === type || 'select' === type ? __( 'Add option', 'coblocks' ) : __( 'Add checkbox', 'coblocks' ) }
-						</IconButton>
+						</Button>
 					) }
 				</BaseControl>
 			</Fragment>

--- a/src/blocks/gallery-collage/edit.js
+++ b/src/blocks/gallery-collage/edit.js
@@ -16,7 +16,7 @@ import * as helper from './../../utils/helper';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withNotices, DropZone, Spinner, IconButton, Dashicon } from '@wordpress/components';
+import { withNotices, DropZone, Spinner, Button, Dashicon } from '@wordpress/components';
 import { MediaPlaceholder, RichText, URLInput } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
 import { isBlobURL } from '@wordpress/blob';
@@ -160,7 +160,7 @@ class GalleryCollageEdit extends Component {
 						} ) }>
 						{ isSelected && (
 							<div className="components-coblocks-gallery-item__remove-menu">
-								<IconButton
+								<Button
 									icon="no-alt"
 									onClick={ () => this.removeImage( index ) }
 									className="coblocks-gallery-item__button"
@@ -178,7 +178,7 @@ class GalleryCollageEdit extends Component {
 									value={ image.imgLink }
 									onChange={ ( imgLink ) => this.updateImageAttributes( index, { imgLink } ) }
 								/>
-								<IconButton icon={ this.state.isSaved ? 'saved' : 'editor-break' } label={ this.state.isSaved ? __( 'Saving', 'coblocks' ) : __( 'Apply', 'coblocks' ) } onClick={ this.saveCustomLink } type="submit" />
+								<Button icon={ this.state.isSaved ? 'saved' : 'editor-break' } label={ this.state.isSaved ? __( 'Saving', 'coblocks' ) : __( 'Apply', 'coblocks' ) } onClick={ this.saveCustomLink } type="submit" />
 							</form>
 						}
 						{ dropZone }

--- a/src/blocks/gif/controls.js
+++ b/src/blocks/gif/controls.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, BlockAlignmentToolbar } from '@wordpress/block-editor';
-import { Toolbar, IconButton } from '@wordpress/components';
+import { Toolbar, Button } from '@wordpress/components';
 
 class Controls extends Component {
 	constructor() {
@@ -39,7 +39,7 @@ class Controls extends Component {
 					/>
 					<Toolbar>
 						{ url &&
-							<IconButton
+							<Button
 								className="components-toolbar__control"
 								label={ __( 'Remove gif', 'coblocks' ) }
 								icon="trash"

--- a/src/blocks/logos/controls.js
+++ b/src/blocks/logos/controls.js
@@ -8,7 +8,7 @@ import * as helper from './../../utils/helper';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { IconButton, Toolbar } from '@wordpress/components';
+import { Button, Toolbar } from '@wordpress/components';
 import {
 	BlockControls,
 	MediaUpload,
@@ -45,7 +45,7 @@ class Controls extends Component {
 									gallery
 									value={ attributes.images.map( ( img ) => img.id ) }
 									render={ ( { open } ) => (
-										<IconButton
+										<Button
 											className="components-toolbar__control"
 											label={ __( 'Edit logos', 'coblocks' ) }
 											icon="edit"

--- a/src/blocks/media-card/media-container.js
+++ b/src/blocks/media-card/media-container.js
@@ -15,7 +15,7 @@ import icons from './icons';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, MediaPlaceholder, MediaUpload, BlockIcon } from '@wordpress/block-editor';
-import { IconButton, ResizableBox, Toolbar, DropZone, Spinner } from '@wordpress/components';
+import { Button, ResizableBox, Toolbar, DropZone, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 
 /**
@@ -33,7 +33,7 @@ class MediaContainer extends Component {
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ mediaId }
 						render={ ( { open } ) => (
-							<IconButton
+							<Button
 								className="components-toolbar__control"
 								label={ __( 'Edit media', 'coblocks' ) }
 								icon="edit"

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -24,7 +24,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, useDispatch, withDispatch } from '@wordpress/data';
 import { BlockIcon, InnerBlocks, __experimentalBlockVariationPicker } from '@wordpress/block-editor';
-import { ButtonGroup, Button, IconButton, Tooltip, Placeholder, Spinner } from '@wordpress/components';
+import { ButtonGroup, Button, Tooltip, Placeholder, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 
 /**
@@ -145,17 +145,17 @@ class Edit extends Component {
 						className="components-coblocks-row-placeholder"
 						icon={ <BlockIcon icon={ columns ? rowIcons.layout : rowIcons.row } /> }
 						label={ columns ? __( 'Row layout', 'coblocks' ) : __( 'Row', 'coblocks' ) }
-						instructions={ columns ?
-							sprintf(
+						instructions={ columns
+							? sprintf(
 								/* translators: %s: 'one' 'two' 'three' and 'four' */
 								__( 'Select a layout for this %s column row.', 'coblocks' ),
 								this.numberToText( columns )
-							) :
-							__( 'Select the number of columns for this row.', 'coblocks' )
+							)
+							: __( 'Select the number of columns for this row.', 'coblocks' )
 						}
 					>
-						{ ! columns ?
-							<ButtonGroup aria-label={ __( 'Select row columns', 'coblocks' ) } className="block-editor-inner-blocks__template-picker-options block-editor-block-pattern-picker__patterns">
+						{ ! columns
+							? <ButtonGroup aria-label={ __( 'Select row columns', 'coblocks' ) } className="block-editor-inner-blocks__template-picker-options block-editor-block-pattern-picker__patterns">
 								{ map( columnOptions, ( option ) => (
 									<Tooltip text={ option.name }>
 										<div className="components-coblocks-row-placeholder__button-wrapper">
@@ -179,10 +179,10 @@ class Edit extends Component {
 										</div>
 									</Tooltip>
 								) ) }
-							</ButtonGroup> :
-							<Fragment>
+							</ButtonGroup>
+							: <Fragment>
 								<ButtonGroup aria-label={ __( 'Select row layout', 'coblocks' ) } className="block-editor-inner-blocks__template-picker-options block-editor-block-pattern-picker__patterns">
-									<IconButton
+									<Button
 										icon="exit"
 										className="components-coblocks-row-placeholder__back"
 										onClick={ () => {
@@ -296,9 +296,9 @@ class Edit extends Component {
 						{ isBlobURL( backgroundImg ) && <Spinner /> }
 						<div className={ innerClasses } style={ innerStyles }>
 							{ BackgroundVideo( attributes ) }
-							{ this.supportsBlockVariationPicker() ?
-								variationInnerBlocks() :
-								deprecatedInnerBlocks() }
+							{ this.supportsBlockVariationPicker()
+								? variationInnerBlocks()
+								: deprecatedInnerBlocks() }
 						</div>
 					</div>
 				</Fragment>

--- a/src/blocks/services/service/edit.js
+++ b/src/blocks/services/service/edit.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	DropZone,
-	IconButton,
+	Button,
 	Spinner,
 } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';
@@ -162,7 +162,7 @@ class Edit extends Component {
 				<figure className={ classes }>
 					{ isSelected && (
 						<div className="components-coblocks-gallery-item__remove-menu">
-							<IconButton
+							<Button
 								icon="no-alt"
 								onClick={ () => setAttributes( { imageUrl: '' } ) }
 								className="coblocks-gallery-item__button"

--- a/src/components/background/controls.js
+++ b/src/components/background/controls.js
@@ -10,7 +10,7 @@ import { ALLOWED_BG_MEDIA_TYPES } from './';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { Toolbar, IconButton, Popover, MenuItem } from '@wordpress/components';
+import { Toolbar, Button, Popover, MenuItem } from '@wordpress/components';
 
 /**
  * Background image block toolbar controls.
@@ -74,7 +74,7 @@ function BackgroundControls( props ) {
 						</Popover>
 					) }
 					{ backgroundImg ?
-						<IconButton
+						<Button
 							className="components-dropdown-menu__toggle"
 							icon={ icons.background }
 							aria-haspopup="true"
@@ -83,7 +83,7 @@ function BackgroundControls( props ) {
 							onClick={ () => setAttributes( { openPopover: ! openPopover } ) }
 						>
 							<span className="components-dropdown-menu__indicator" />
-						</IconButton>					:
+						</Button>					:
 						<MediaUpload
 							onSelect={ ( media ) => {
 								setAttributes( { backgroundImg: media.url, backgroundType: media.type } );
@@ -91,7 +91,7 @@ function BackgroundControls( props ) {
 							allowedTypes={ ALLOWED_BG_MEDIA_TYPES }
 							value={ backgroundImg }
 							render={ ( { open } ) => (
-								<IconButton
+								<Button
 									className="components-toolbar__control"
 									label={ __( 'Add background image', 'coblocks' ) }
 									icon={ icons.background }

--- a/src/components/background/controls.js
+++ b/src/components/background/controls.js
@@ -10,7 +10,7 @@ import { ALLOWED_BG_MEDIA_TYPES } from './';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { Toolbar, Button, Popover, MenuItem } from '@wordpress/components';
+import { Toolbar, ToolbarButton, Popover, MenuItem } from '@wordpress/components';
 
 /**
  * Background image block toolbar controls.
@@ -74,16 +74,15 @@ function BackgroundControls( props ) {
 						</Popover>
 					) }
 					{ backgroundImg ?
-						<Button
+						<ToolbarButton
 							className="components-dropdown-menu__toggle"
 							icon={ icons.background }
 							aria-haspopup="true"
 							label={ __( 'Edit background image', 'coblocks' ) }
 							tooltip={ __( 'Edit background image', 'coblocks' ) }
 							onClick={ () => setAttributes( { openPopover: ! openPopover } ) }
-						>
-							<span className="components-dropdown-menu__indicator" />
-						</Button>					:
+						/>
+						:
 						<MediaUpload
 							onSelect={ ( media ) => {
 								setAttributes( { backgroundImg: media.url, backgroundType: media.type } );
@@ -91,7 +90,7 @@ function BackgroundControls( props ) {
 							allowedTypes={ ALLOWED_BG_MEDIA_TYPES }
 							value={ backgroundImg }
 							render={ ( { open } ) => (
-								<Button
+								<ToolbarButton
 									className="components-toolbar__control"
 									label={ __( 'Add background image', 'coblocks' ) }
 									icon={ icons.background }

--- a/src/components/block-gallery/gallery-image.js
+++ b/src/components/block-gallery/gallery-image.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { IconButton, Spinner, Dashicon } from '@wordpress/components';
+import { Button, Spinner, Dashicon } from '@wordpress/components';
 import { RichText, URLInput } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
@@ -187,7 +187,7 @@ class GalleryImage extends Component {
 					<Fragment>
 						{ supportsMoving &&
 							<div className="components-coblocks-gallery-item__move-menu">
-								<IconButton
+								<Button
 									icon={ verticalMoving ? 'arrow-up' : 'arrow-left' }
 									onClick={ ! isFirstItem && onMoveBackward }
 									className="coblocks-gallery-item__button"
@@ -195,7 +195,7 @@ class GalleryImage extends Component {
 									aria-disabled={ isFirstItem }
 									disabled={ ! isSelected }
 								/>
-								<IconButton
+								<Button
 									icon={ verticalMoving ? 'arrow-down' : 'arrow-right' }
 									onClick={ ! isLastItem && onMoveForward }
 									className="coblocks-gallery-item__button"
@@ -206,7 +206,7 @@ class GalleryImage extends Component {
 							</div>
 						}
 						<div className="components-coblocks-gallery-item__remove-menu">
-							<IconButton
+							<Button
 								icon="no-alt"
 								onClick={ onRemove }
 								className="coblocks-gallery-item__button"
@@ -223,7 +223,7 @@ class GalleryImage extends Component {
 									value={ imgLink }
 									onChange={ ( value ) => setAttributes( { imgLink: value } ) }
 								/>
-								<IconButton icon={ this.state.isSaved ? 'saved' : 'editor-break' } label={ this.state.isSaved ? __( 'Saving', 'coblocks' ) : __( 'Apply', 'coblocks' ) } onClick={ this.saveCustomLink } type="submit" />
+								<Button icon={ this.state.isSaved ? 'saved' : 'editor-break' } label={ this.state.isSaved ? __( 'Saving', 'coblocks' ) : __( 'Apply', 'coblocks' ) } onClick={ this.saveCustomLink } type="submit" />
 							</form>
 						}
 					</Fragment>

--- a/src/components/crop-settings/index.js
+++ b/src/components/crop-settings/index.js
@@ -17,7 +17,6 @@ import { TextControl,
 	RangeControl,
 	ButtonGroup,
 	Button,
-	IconButton,
 } from '@wordpress/components';
 
 class CropSettings extends Component {
@@ -302,14 +301,14 @@ class CropSettings extends Component {
 				<p>{ __( 'Image orientation', 'coblocks' ) }</p>
 				<div className="components-coblocks-rotate-control">
 					<ButtonGroup >
-						<IconButton
+						<Button
 							isLarge
 							isSecondary
 							icon={ icons.rotateLeft }
 							label={ __( 'Rotate counter-clockwise', 'coblocks' ) }
 							onClick={ () => this.applyRotation( self.state.r - 90 ) }
 						/>
-						<IconButton
+						<Button
 							isLarge
 							isSecondary
 							icon={ icons.rotateRight }

--- a/src/components/grid-control/toolbar.js
+++ b/src/components/grid-control/toolbar.js
@@ -12,7 +12,7 @@ import CSSGridControl from './';
  * WordPress dependencies
  */
 import { DOWN } from '@wordpress/keycodes';
-import { Button, Dropdown, NavigableMenu } from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup, Dropdown, NavigableMenu } from '@wordpress/components';
 
 function CSSGridToolbar( {
 	icon = 'menu',
@@ -34,18 +34,15 @@ function CSSGridToolbar( {
 					}
 				};
 				return (
-					<Button
-						className="components-dropdown-menu__toggle"
-						icon={ icon }
+					<ToolbarButton
 						onClick={ onToggle }
-						onKeyDown={ openOnArrowDown }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
+						onKeyDown={ openOnArrowDown }
 						label={ label }
-						tooltip={ label }
-					>
-						<span className="components-dropdown-menu__indicator" />
-					</Button>
+						icon={ icon }
+						showTooltip
+					/>
 				);
 			} }
 			renderContent={ () => {

--- a/src/components/grid-control/toolbar.js
+++ b/src/components/grid-control/toolbar.js
@@ -12,7 +12,7 @@ import CSSGridControl from './';
  * WordPress dependencies
  */
 import { DOWN } from '@wordpress/keycodes';
-import { IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
+import { Button, Dropdown, NavigableMenu } from '@wordpress/components';
 
 function CSSGridToolbar( {
 	icon = 'menu',
@@ -34,7 +34,7 @@ function CSSGridToolbar( {
 					}
 				};
 				return (
-					<IconButton
+					<Button
 						className="components-dropdown-menu__toggle"
 						icon={ icon }
 						onClick={ onToggle }
@@ -45,7 +45,7 @@ function CSSGridToolbar( {
 						tooltip={ label }
 					>
 						<span className="components-dropdown-menu__indicator" />
-					</IconButton>
+					</Button>
 				);
 			} }
 			renderContent={ () => {

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { DOWN } from '@wordpress/keycodes';
-import { RangeControl, withFallbackStyles, ToggleControl, Dropdown, IconButton, SelectControl, Toolbar } from '@wordpress/components';
+import { RangeControl, withFallbackStyles, ToggleControl, Dropdown, Button, SelectControl, Toolbar } from '@wordpress/components';
 import { withSelect, select } from '@wordpress/data';
 
 /**
@@ -175,7 +175,7 @@ class TypographyControls extends Component {
 						};
 
 						return (
-							<IconButton
+							<Button
 								className="components-dropdown-menu__toggle"
 								icon={ icon }
 								onClick={ onToggle }
@@ -186,7 +186,7 @@ class TypographyControls extends Component {
 								tooltip={ label }
 							>
 								<span className="components-dropdown-menu__indicator" />
-							</IconButton>
+							</Button>
 						);
 					} }
 					renderContent={ () => (
@@ -198,8 +198,8 @@ class TypographyControls extends Component {
 									onChange={ ( nextFontFamily ) => onFontChange( nextFontFamily ) }
 									className="components-base-control--with-flex components-coblocks-typography-dropdown__inner--font"
 								/>
-								{ ( ( typeof attributes.textPanelFontWeight === 'undefined' || ( typeof attributes.textPanelFontWeight !== 'undefined' && typeof attributes.textPanelFontWeight === 'undefined' ) ) ) ?
-									<SelectControl
+								{ ( ( typeof attributes.textPanelFontWeight === 'undefined' || ( typeof attributes.textPanelFontWeight !== 'undefined' && typeof attributes.textPanelFontWeight === 'undefined' ) ) )
+									? <SelectControl
 										label={ __( 'Weight', 'coblocks' ) }
 										value={ fontWeight }
 										options={ weight }
@@ -207,8 +207,8 @@ class TypographyControls extends Component {
 										className="components-base-control--with-flex components-coblocks-typography-dropdown__inner--weight"
 									/> : null
 								}
-								{ ( ( typeof attributes.textPanelTextTransform === 'undefined' || ( typeof attributes.textPanelTextTransform !== 'undefined' && typeof attributes.textPanelTextTransform === 'undefined' ) ) ) ?
-									<SelectControl
+								{ ( ( typeof attributes.textPanelTextTransform === 'undefined' || ( typeof attributes.textPanelTextTransform !== 'undefined' && typeof attributes.textPanelTextTransform === 'undefined' ) ) )
+									? <SelectControl
 										label={ __( 'Transform', 'coblocks' ) }
 										value={ textTransform }
 										options={ transform }
@@ -216,8 +216,8 @@ class TypographyControls extends Component {
 										className="components-base-control--with-flex components-coblocks-typography-dropdown__inner--transform"
 									/> : null
 								}
-								{ ( ( typeof attributes.textPanelHideSize === 'undefined' || ( typeof attributes.textPanelHideSize !== 'undefined' && typeof attributes.textPanelHideSize === 'undefined' ) ) ) ?
-									<RangeControl
+								{ ( ( typeof attributes.textPanelHideSize === 'undefined' || ( typeof attributes.textPanelHideSize !== 'undefined' && typeof attributes.textPanelHideSize === 'undefined' ) ) )
+									? <RangeControl
 										label={ __( 'Size', 'coblocks' ) }
 										value={ parseFloat( customFontSize ) || undefined }
 										onChange={ ( nextFontSize ) => setAttributes( { customFontSize: nextFontSize } ) }
@@ -227,8 +227,8 @@ class TypographyControls extends Component {
 										className="components-coblocks-typography-dropdown__inner--size"
 									/> : null
 								}
-								{ ( ( typeof attributes.textPanelLineHeight === 'undefined' || ( typeof attributes.textPanelLineHeight !== 'undefined' && typeof attributes.textPanelLineHeight === 'undefined' ) ) ) ?
-									<RangeControl
+								{ ( ( typeof attributes.textPanelLineHeight === 'undefined' || ( typeof attributes.textPanelLineHeight !== 'undefined' && typeof attributes.textPanelLineHeight === 'undefined' ) ) )
+									? <RangeControl
 										label={ __( 'Line height', 'coblocks' ) }
 										value={ parseFloat( lineHeight ) || undefined }
 										onChange={ ( nextLineHeight ) => setAttributes( { lineHeight: nextLineHeight } ) }
@@ -238,8 +238,8 @@ class TypographyControls extends Component {
 										className="components-coblocks-typography-dropdown__inner--line-height"
 									/> : null
 								}
-								{ ( ( typeof attributes.textPanelLetterSpacing === 'undefined' || ( typeof attributes.textPanelLetterSpacing !== 'undefined' && typeof attributes.textPanelLetterSpacing === 'undefined' ) ) ) ?
-									<RangeControl
+								{ ( ( typeof attributes.textPanelLetterSpacing === 'undefined' || ( typeof attributes.textPanelLetterSpacing !== 'undefined' && typeof attributes.textPanelLetterSpacing === 'undefined' ) ) )
+									? <RangeControl
 										label={ __( 'Letter spacing', 'coblocks' ) }
 										value={ parseFloat( letterSpacing ) || undefined }
 										onChange={ ( nextLetterSpacing ) => setAttributes( { letterSpacing: nextLetterSpacing } ) }

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { DOWN } from '@wordpress/keycodes';
-import { RangeControl, withFallbackStyles, ToggleControl, Dropdown, Button, SelectControl, Toolbar } from '@wordpress/components';
+import { RangeControl, withFallbackStyles, ToggleControl, Dropdown, ToolbarButton, SelectControl, Toolbar } from '@wordpress/components';
 import { withSelect, select } from '@wordpress/data';
 
 /**
@@ -175,7 +175,7 @@ class TypographyControls extends Component {
 						};
 
 						return (
-							<Button
+							<ToolbarButton
 								className="components-dropdown-menu__toggle"
 								icon={ icon }
 								onClick={ onToggle }
@@ -184,9 +184,7 @@ class TypographyControls extends Component {
 								aria-expanded={ isOpen }
 								label={ label }
 								tooltip={ label }
-							>
-								<span className="components-dropdown-menu__indicator" />
-							</Button>
+							/>
 						);
 					} }
 					renderContent={ () => (

--- a/src/components/typography-controls/styles/editor.scss
+++ b/src/components/typography-controls/styles/editor.scss
@@ -5,7 +5,7 @@
 	}
 
 	&__inner {
-		padding: 16px;
+		padding: 8px;
 
 		.components-select-control__input {
 			appearance: none;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Replace all instances of IconButton with core Button component.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes to deprecate IconButton component in favor of Button component.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in the browser and e2e.
No deprecations needed for this change.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
