### PR TITLE
Prevent empty Advanced panel from showing on blocks

### DIFF
--- a/.dev/bin/setup-test-specs.sh
+++ b/.dev/bin/setup-test-specs.sh
@@ -27,9 +27,13 @@ do
   if [[ $FILE == *"src/extensions/"* ]]; then
     testSpec=$(echo $FILE | cut -d'/' -f3)
 		foundwords=$(echo ${SPECS[@]} | grep -o "${testSpec}" | wc -w)
+		# Catch cases where no cypress spec file exists. 
+			if [[ $(ls -l src/extensions/${testSpec}/**/*.cypress.js | wc -l) -eq 0 ]]; then
+				continue
+			fi
 		# The test spec does not yet exist in the SPECS array
 		if [[ "${foundwords}" -eq 0 ]]; then
-			# Spec file string is empty, do not start string with a ,
+			# Spec file string is empty, do not start string with a comma
 			if [[ ${#SPECSTRING} -eq 0 ]]; then
 				SPECSTRING="src/extensions/${testSpec}/**/*.cypress.js"
 			else

--- a/.dev/bin/setup-test-specs.sh
+++ b/.dev/bin/setup-test-specs.sh
@@ -28,9 +28,9 @@ do
     testSpec=$(echo $FILE | cut -d'/' -f3)
 		foundwords=$(echo ${SPECS[@]} | grep -o "${testSpec}" | wc -w)
 		# Catch cases where no cypress spec file exists. 
-			if [[ $(ls -l src/extensions/${testSpec}/**/*.cypress.js | wc -l) -eq 0 ]]; then
-				continue
-			fi
+		if [[ $(ls -l src/extensions/${testSpec}/**/*.cypress.js | wc -l) -eq 0 ]]; then
+			continue
+		fi
 		# The test spec does not yet exist in the SPECS array
 		if [[ "${foundwords}" -eq 0 ]]; then
 			# Spec file string is empty, do not start string with a comma

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -135,10 +135,12 @@ const withAdvancedControls = createHigherOrderComponent( ( BlockEdit ) => {
 			}
 		}, [ noBottomMargin, noTopMargin ] );
 
+		const hasAdvancedControl = !! hasStackedControl || !! withBlockSpacing;
+
 		return (
 			<Fragment>
 				<BlockEdit { ...props } />
-				{ isSelected && (
+				{ isSelected && hasAdvancedControl && (
 					<InspectorAdvancedControls>
 						{ hasStackedControl && (
 							<ToggleControl
@@ -207,7 +209,7 @@ const withAdvancedControls = createHigherOrderComponent( ( BlockEdit ) => {
 }, 'withAdvancedControls' );
 
 /**
- * Override props assigned to save component to inject atttributes
+ * Override props assigned to save component to inject attributes
  *
  * @param {Object} extraProps Additional props applied to save element.
  * @param {Object} blockType  Block type.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1364
The `advanced-controls` extension for CoBlocks had been inadvertently adding an `InspectorAdvancedControls` where it should not be. This PR adds logic to exclude the `InspectorAdvancedControls` component when necessary.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/89319286-c16cd500-d634-11ea-858e-733406eb080b.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the editor.
Tested with and without the Gutenberg plugin active.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
