### PR TITLE
Fix test selectors used for the CoBlocks Settings E2E tests

### DIFF
--- a/src/extensions/coblocks-settings/test/coblocks-settings.cypress.js
+++ b/src/extensions/coblocks-settings/test/coblocks-settings.cypress.js
@@ -34,9 +34,9 @@ describe( 'Extension: CoBlocks Settings', function() {
 		cy.get( '.components-menu-group' ).find( 'button' ).contains( 'Editor settings' ).click();
 
 		// Typography Test
-		cy.get( 'button[aria-label="Change typography"]' ).should( 'exist' );
+		cy.get( '.components-coblocks-typography-dropdown' ).should( 'exist' );
 		cy.get( '.coblocks-modal__content' ).contains( 'Typography controls' ).click();
-		cy.get( 'button[aria-label="Change typography"]' ).should( 'not.exist' );
+		cy.get( '.components-coblocks-typography-dropdown' ).should( 'not.exist' );
 
 		cy.get( '.components-modal__header' ).find( 'button[aria-label="Close dialog"]' ).click();
 	} );


### PR DESCRIPTION
### Description
Failing tests on the master branch for these tests. This PR will fix failing tests on master for the CoBlocks settings controls. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Selector used within .cypress.js file.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and e2e

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
