### PR TITLE
Experiment using a filter to set img tag height and width values

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -111,6 +111,7 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-google-map-block.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-accordion-ie-support.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-settings.php';
+			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-image-dimensions.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/get-dynamic-blocks.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-event.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-ical.php';

--- a/includes/class-coblocks-image-dimensions.php
+++ b/includes/class-coblocks-image-dimensions.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Add dimensions to post images so as to enable lazy loading.
+ *
+ * @package CoBlocks
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Replace post content where appropriate.
+ *
+ * @since 2.2.0
+ */
+class CoBlocks_Image_Dimensions {
+
+	/**
+	 * The Constructor.
+	 */
+	public function __construct() {
+		add_filter( 
+			'the_content', 
+			function( $content ) {
+				if ( false === strpos( $content, '<img' ) ) {
+					return $content;
+				}
+		
+				if ( ! preg_match_all( '/<img\s[^>]+>/', $content, $matches ) ) {
+					return $content;
+				}
+		
+				foreach ( $matches[0] as $image ) {
+					if ( false === strpos( $image, 'width=' ) && preg_match( '/wp-image-([0-9]+)/i', $image, $image_class_id ) ) {
+						$attachment_id = absint( $image_class_id[1] );
+						$src = wp_get_attachment_image_src( $attachment_id, 'full' );
+		
+						if ( ! empty( $src[1] ) && ! empty( $src[2] ) ) {
+							$image_with_width_height = str_replace(
+								'src=',
+								sprintf( 'width="%d" height="%d" loading="lazy" src=', $src[1], $src[2] ),
+								$image
+							);
+		
+							$content = str_replace( $image, $image_with_width_height, $content );
+						}
+					}
+				}
+		
+				return $content;
+			} 
+		);
+	}
+}
+
+new CoBlocks_Image_Dimensions();


### PR DESCRIPTION
### Description
This PR is a method to forcefully add image dimensions to post content. By utilizing a filter we can perform str_replace on the content to add in the appropriate height and width values where needed. 

The filter in this PR will add height, width, and loading="lazy" attributes to all `<img>` tags within the content. 
This PR is experimental and should not yet be merged. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
PHP filter

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the browser

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
