### PR TITLE
POC for adding animation based on viewport visibility

### DIFF
--- a/.dev/config/webpack.config.js
+++ b/.dev/config/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		'coblocks-editor': path.resolve( process.cwd(), 'src/styles/editor.scss' ),
 		'coblocks-style': path.resolve( process.cwd(), 'src/styles/style.scss' ),
 
+		'js/coblocks-animations': path.resolve( process.cwd(), 'src/js/coblocks-animations.js' ),
 		'js/coblocks-accordion-polyfill': path.resolve( process.cwd(), 'src/js/coblocks-accordion-polyfill.js' ),
 		'js/coblocks-accordion-carousel': path.resolve( process.cwd(), 'src/js/coblocks-accordion-carousel.js' ),
 		'js/coblocks-datepicker': path.resolve( process.cwd(), 'src/js/coblocks-datepicker.js' ),

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -294,6 +294,15 @@ class CoBlocks_Block_Assets {
 		// Define where the vendor asset is loaded from.
 		$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
 
+		// Temporary for testing animations
+		wp_enqueue_script(
+			'coblocks-animations',
+			$dir . 'coblocks-animations.js',
+			array( 'jquery' ),
+			COBLOCKS_VERSION,
+			true
+		);
+
 		// Masonry block.
 		if ( has_block( 'coblocks/gallery-masonry' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(

--- a/src/js/coblocks-animations.js
+++ b/src/js/coblocks-animations.js
@@ -1,0 +1,18 @@
+const elems = document.querySelectorAll( '.animate' );
+
+const observer = new IntersectionObserver( ( entries ) => {
+	entries.forEach( ( entry ) => {
+		if ( ! entry.isIntersecting ) {
+			return;
+		}
+
+		entry.target.classList.add( 'fadeIn' );
+		observer.unobserve( entry.target );
+	} );
+}, {
+	threshold: [ 0.15 ],
+} );
+
+elems.forEach( ( elem ) => {
+	observer.observe( elem );
+} );

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -10,6 +10,7 @@
 @import "style/shadow";
 @import "style/tooltips";
 @import "style/datepicker";
+@import "style/animations";
 @import "../components/**/style.scss";
 @import "../extensions/**/style.scss";
 @import "../blocks/**/style.scss";

--- a/src/styles/style/animations.scss
+++ b/src/styles/style/animations.scss
@@ -1,0 +1,29 @@
+body:not(.wp-admin) {
+
+	.animate {
+		opacity: 0;
+		transform: translateX(-20rem);
+		animation-duration: 1s;
+		animation-fill-mode: both;
+	}
+
+	.fadeIn {
+		animation-name: fadeIn;
+		animation-timing-function: ease-in;
+	}
+
+	@keyframes fadeIn {
+
+		from {
+			opacity: 0;
+			transform: translateX(-20rem);
+		}
+
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+}
+
+


### PR DESCRIPTION
### Description
Playing around possibility of adding custom classes to block and have them trigger animation on the front-end based on viewport visibility.

This is using new IntersectionObserver for checking if element is intersecting with viewport. No external dependencies. Would require a polyfill for IE.

### Screenshots

![animation](https://user-images.githubusercontent.com/1933681/90277473-b2a3d080-de33-11ea-8a48-e7390a9c21ef.gif)

