### PR TITLE
Introduce Shape Divider deprecations related to extensions

### DIFF
--- a/src/blocks/shape-divider/deprecated.js
+++ b/src/blocks/shape-divider/deprecated.js
@@ -121,4 +121,15 @@ const deprecated = [
 	},
 ];
 
+// Deprecations for Advanced Spacing controls.
+[ 'noTopMargin', 'noBottomMargin' ].forEach( ( attr ) => {
+	deprecated.push( {
+		attributes: {
+			...metadata.attributes,
+			[ attr ]: false,
+		},
+		save: deprecatedSVGs,
+	} );
+} );
+
 export default deprecated;

--- a/src/blocks/shape-divider/test/shape-divider.cypress.js
+++ b/src/blocks/shape-divider/test/shape-divider.cypress.js
@@ -43,7 +43,7 @@ describe( 'Test CoBlocks Shape Divider Block', function() {
 		const { shapeHeight, backgroundHeight } = shapeDividerData;
 		helpers.addBlockToPost( 'coblocks/shape-divider', true );
 
-		cy.get( '.wp-block-coblocks-shape-divider' ).click();
+		cy.get( '.edit-post-visual-editor .wp-block-coblocks-shape-divider' ).click();
 
 		helpers.setInputValue( 'divider settings', 'shape height', shapeHeight );
 		helpers.setInputValue( 'divider settings', 'background height', backgroundHeight );
@@ -69,7 +69,7 @@ describe( 'Test CoBlocks Shape Divider Block', function() {
 		const { shapeColor, backgroundColor, shapeColorRGB, backgroundColorRGB } = shapeDividerData;
 		helpers.addBlockToPost( 'coblocks/shape-divider', true );
 
-		cy.get( '.wp-block-coblocks-shape-divider' ).click();
+		cy.get( '.edit-post-visual-editor .wp-block-coblocks-shape-divider' ).click();
 		helpers.setColorSetting( 'shape color', shapeColor );
 		helpers.setColorSetting( 'background color', backgroundColor );
 
@@ -95,7 +95,7 @@ describe( 'Test CoBlocks Shape Divider Block', function() {
 		const { style } = shapeDividerData;
 		helpers.addBlockToPost( 'coblocks/shape-divider', true );
 
-		cy.get( '.wp-block-coblocks-shape-divider' ).click();
+		cy.get( '.edit-post-visual-editor .wp-block-coblocks-shape-divider' ).click();
 
 		helpers.setBlockStyle( style );
 


### PR DESCRIPTION
### Description
Closes #1594 
The shape divider block at one point generated content with differing class names assigned by default. This is likely due to changes within the Advanced Controls extension over time. 

By using an array of attribute strings that are injected from the Advanced Controls extension we are able to iterate through possible values easily while reusing significant portions of code and improving readability. 
```javascript
[ 'noTopMargin', 'noBottomMargin' ]
```

### Screenshots
<!-- if applicable -->
![shapedividerAdvancedControls](https://user-images.githubusercontent.com/30462574/90678834-17846f80-e214-11ea-9963-774406570d04.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually using markup from #1594 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
