### PR TITLE
Fix list styling of Food and Drinks block when column classes exist

### DIFF
--- a/src/blocks/food-and-drinks/styles/style.scss
+++ b/src/blocks/food-and-drinks/styles/style.scss
@@ -46,9 +46,10 @@
 		}
 	}
 
-	&.is-style-list .wp-block-coblocks-food-item {
+	&.is-style-list .wp-block-coblocks-food-item,
+	&.is-style-list div[data-type="coblocks/food-item"] {
 		display: flex;
-		flex: 1 100%;
+		flex: 1 100% !important;
 		margin-top: 1.5em;
 		max-width: 100%;
 


### PR DESCRIPTION
### Description
Fixes #1629. The block properly deprecated but column styles were overriding the list-style css.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
