### PR TITLE
Fix SVG icon deprecation in the Food and Drinks block

### DIFF
--- a/src/blocks/food-and-drinks/food-item/deprecated/deprecatedIcons.js
+++ b/src/blocks/food-and-drinks/food-item/deprecated/deprecatedIcons.js
@@ -8,8 +8,56 @@ import fromEntries from '../../../../js/coblocks-fromEntries';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { createElement, Component, isValidElement, cloneElement } from '@wordpress/element';
 import { RichText } from '@wordpress/block-editor';
-import { Icon, SVG, Path } from '@wordpress/components';
+
+const Path = ( props ) => createElement( 'path', props );
+
+const SVG = ( props ) => {
+	const appliedProps = {
+		...props,
+		role: 'img',
+		'aria-hidden': 'true',
+		focusable: 'false',
+	};
+
+	// Disable reason: We need to have a way to render HTML tag for web.
+	// eslint-disable-next-line react/forbid-elements
+	return <svg { ...appliedProps } />;
+};
+
+function Icon( { icon = null, size, ...additionalProps } ) {
+	// Any other icons should be 24x24 by default
+	const iconSize = size || 24;
+
+	if ( 'function' === typeof icon ) {
+		if ( icon.prototype instanceof Component ) {
+			return createElement( icon, { size: iconSize, ...additionalProps } );
+		}
+
+		return icon( { size: iconSize, ...additionalProps } );
+	}
+
+	if ( icon && ( icon.type === 'svg' || icon.type === SVG ) ) {
+		const appliedProps = {
+			width: iconSize,
+			height: iconSize,
+			...icon.props,
+			...additionalProps,
+		};
+
+		return <SVG { ...appliedProps } />;
+	}
+
+	if ( isValidElement( icon ) ) {
+		return cloneElement( icon, {
+			size: iconSize,
+			...additionalProps,
+		} );
+	}
+
+	return icon;
+}
 
 /**
  * Block user interface icons


### PR DESCRIPTION
### Description
Fixes #1595. The Food & Drinks deprecation was failing on the icons because we are using an upgraded version of the `@wordpress/primitives` package and those functions have changed. The fix involved pulling in the old functions from this package into the `deprecatedIcons.js` file.

I don't really like how this is done but it works. It would be nice to pull in the package at the specific version so this file can use it directly.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
