### PR TITLE
Introduce Posts and Post Carousel block deprecations

### DIFF
--- a/src/blocks/post-carousel/block.json
+++ b/src/blocks/post-carousel/block.json
@@ -61,7 +61,10 @@
 			"default": "date"
 		},
 		"categories": {
-			"type": "array"
+			"type": "array",
+			"items": {
+				"type": "object"
+			}
 		}
 	}
 }

--- a/src/blocks/post-carousel/deprecated.js
+++ b/src/blocks/post-carousel/deprecated.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { attributes } = metadata;
+
+export default [
+	{
+		attributes: {
+			...attributes,
+			categories: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: true,
+			html: false,
+		},
+		migrate: ( oldAttributes ) => {
+			// This needs the full category object, not just the ID.
+			return {
+				...oldAttributes,
+				categories: [ { id: Number( oldAttributes.categories ) } ],
+			};
+		},
+		isEligible: ( { categories } ) =>
+			categories && 'string' === typeof categories,
+		save: () => null,
+	},
+];

--- a/src/blocks/post-carousel/index.js
+++ b/src/blocks/post-carousel/index.js
@@ -5,6 +5,7 @@ import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -41,6 +42,7 @@ const settings = {
 	},
 	transforms,
 	edit,
+	deprecated,
 	save() {
 		return null;
 	},

--- a/src/blocks/post-carousel/index.php
+++ b/src/blocks/post-carousel/index.php
@@ -341,3 +341,35 @@ function coblocks_register_post_carousel_block() {
 	);
 }
 add_action( 'init', 'coblocks_register_post_carousel_block' );
+
+
+
+/**
+ * Handles outdated versions of the `coblocks/post-carousel` block by converting
+ * attribute `categories` from a numeric string to an array with key `id`.
+ *
+ * This is done to accommodate the changes introduced in https://github.com/WordPress/gutenberg/pull/20781 that sought to
+ * add support for multiple categories to the block. However, given that this
+ * block is dynamic, the usual provisions for block migration are insufficient,
+ * as they only act when a block is loaded in the editor.
+ *
+ * TODO: Remove when and if the bottom client-side deprecation for this block
+ * is removed.
+ *
+ * @param array $block A single parsed block object.
+ *
+ * @return array The migrated block object.
+ */
+function block_coblocks_post_carousel_migrate_categories( $block ) {
+	if (
+		'coblocks/post-carousel' === $block['blockName'] &&
+		! empty( $block['attrs']['categories'] ) &&
+		is_string( $block['attrs']['categories'] )
+	) {
+		$block['attrs']['categories'] = array(
+			array( 'id' => absint( $block['attrs']['categories'] ) ),
+		);
+	}
+	return $block;
+}
+add_filter( 'render_block_data', 'block_coblocks_post_carousel_migrate_categories' );

--- a/src/blocks/post-carousel/index.php
+++ b/src/blocks/post-carousel/index.php
@@ -27,7 +27,7 @@ function coblocks_render_post_carousel_block( $attributes ) {
 
 	if ( isset( $attributes['categories'] ) ) {
 
-		$args['category'] = $attributes['categories'];
+		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 
 	}
 

--- a/src/blocks/posts/block.json
+++ b/src/blocks/posts/block.json
@@ -69,7 +69,10 @@
 			"default": "date"
 		},
 		"categories": {
-			"type": "array"
+			"type": "array",
+			"items": {
+				"type": "object"
+			}
 		}
 	}
 }

--- a/src/blocks/posts/deprecated.js
+++ b/src/blocks/posts/deprecated.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { attributes } = metadata;
+
+export default [
+	{
+		attributes: {
+			...attributes,
+			categories: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: true,
+			html: false,
+		},
+		migrate: ( oldAttributes ) => {
+			// This needs the full category object, not just the ID.
+			console.log( oldAttributes );
+			console.log( {
+				...oldAttributes,
+				categories: [ { id: Number( oldAttributes.categories ) } ],
+			} );
+			return {
+				...oldAttributes,
+				categories: [ { id: Number( oldAttributes.categories ) } ],
+			};
+		},
+		isEligible: ( { categories } ) =>
+			categories && 'string' === typeof categories,
+		save: () => null,
+	},
+];

--- a/src/blocks/posts/deprecated.js
+++ b/src/blocks/posts/deprecated.js
@@ -19,11 +19,6 @@ export default [
 		},
 		migrate: ( oldAttributes ) => {
 			// This needs the full category object, not just the ID.
-			console.log( oldAttributes );
-			console.log( {
-				...oldAttributes,
-				categories: [ { id: Number( oldAttributes.categories ) } ],
-			} );
 			return {
 				...oldAttributes,
 				categories: [ { id: Number( oldAttributes.categories ) } ],

--- a/src/blocks/posts/index.js
+++ b/src/blocks/posts/index.js
@@ -5,6 +5,7 @@ import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -39,6 +40,7 @@ const settings = {
 	},
 	transforms,
 	edit,
+	deprecated,
 	save() {
 		return null;
 	},

--- a/src/blocks/posts/index.php
+++ b/src/blocks/posts/index.php
@@ -329,3 +329,33 @@ function coblocks_register_posts_block() {
 	);
 }
 add_action( 'init', 'coblocks_register_posts_block' );
+
+/**
+ * Handles outdated versions of the `coblocks/posts` block by converting
+ * attribute `categories` from a numeric string to an array with key `id`.
+ *
+ * This is done to accommodate the changes introduced in https://github.com/WordPress/gutenberg/pull/20781 that sought to
+ * add support for multiple categories to the block. However, given that this
+ * block is dynamic, the usual provisions for block migration are insufficient,
+ * as they only act when a block is loaded in the editor.
+ *
+ * TODO: Remove when and if the bottom client-side deprecation for this block
+ * is removed.
+ *
+ * @param array $block A single parsed block object.
+ *
+ * @return array The migrated block object.
+ */
+function block_coblocks_posts_migrate_categories( $block ) {
+	if (
+		'coblocks/posts' === $block['blockName'] &&
+		! empty( $block['attrs']['categories'] ) &&
+		is_string( $block['attrs']['categories'] )
+	) {
+		$block['attrs']['categories'] = array(
+			array( 'id' => absint( $block['attrs']['categories'] ) ),
+		);
+	}
+	return $block;
+}
+add_filter( 'render_block_data', 'block_coblocks_posts_migrate_categories' );

--- a/src/blocks/posts/index.php
+++ b/src/blocks/posts/index.php
@@ -27,7 +27,7 @@ function coblocks_render_posts_block( $attributes ) {
 
 	if ( isset( $attributes['categories'] ) ) {
 
-		$args['category'] = $attributes['categories'];
+		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1632 
Following the lead of the Gutenberg team, this PR introduces measures that will allow proper migration/deprecation from previously configured and published blocks into a working state using modern interface and features. 

In this case, the `core/latest-posts` block had a number of breaking changes related to the implementation of a tokenized category selector. The new selector requires new logic and a new attribute schema.

This change is inspired by this [PR in Gutenberg](https://github.com/WordPress/gutenberg/blob/d0ca2551fdaa460d1ce4dc0a3bf0125ea4dbdba2/packages/block-library/src/latest-posts/index.php#L50). This PR resolves a bug with migration from old-style `coblocks/posts` and `coblocks/post-carousel` attributes.

This can be replicated using old markup:
```
<!-- wp:coblocks/post-carousel {“columns”:3,“categories”:“1”} /-->
OR
<!-- wp:coblocks/post-carousel {"categories":"4"} /-->

<!-- wp:coblocks/posts {“className”:“is-style-stacked”,“categories”:“3”} /-->
```
**Please note** This fix will successfully migrate the chosen category from a previously configured block into a category token within the new interface. While the token exists and works as expected as a filter, the token is missing contextual language. This is a [known issue with migration](https://github.com/WordPress/gutenberg/pull/21359#issuecomment-615273139).
![image](https://user-images.githubusercontent.com/30462574/90908502-5425a780-e389-11ea-87b5-763cf8e7d91a.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes and PHP changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually migrating from 5.4.2 -> 5.5
Tested with and without the Gutenberg plugin.
Tested migration from CoBlocks 1.23.0 -> 2.2.2

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
