### PR TITLE
Introduce ability to define a custom 'Success Message' setting in the form block

### DIFF
--- a/.dev/tests/phpunit/includes/test-coblocks-form.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-form.php
@@ -633,7 +633,7 @@ class CoBlocks_Form_Tests extends WP_UnitTestCase {
 
 		$this->expectOutputRegex( '/<div class="coblocks-form__submitted">Your message was sent: <\/div>/' );
 
-		$this->coblocks_form->success_message();
+		$this->coblocks_form->success_message( [ 'successText' => $this->coblocks_form->default_success_text() ] );
 
 	}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -179,7 +179,9 @@ class CoBlocks_Block_Assets {
 		 */
 		$bundled_icons_enabled = (bool) apply_filters( 'coblocks_bundled_icons_enabled', true );
 
-		$form_subject = ( new CoBlocks_Form() )->default_subject();
+		$form         = new CoBlocks_Form();
+		$form_subject = $form->default_subject();
+		$success_text = $form->default_success_text();
 
 		wp_localize_script(
 			'coblocks-editor',
@@ -188,6 +190,7 @@ class CoBlocks_Block_Assets {
 				'form'                           => array(
 					'adminEmail'   => $email_to,
 					'emailSubject' => $form_subject,
+					'successText'  => $success_text,
 				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -1041,7 +1041,7 @@ class CoBlocks_Form {
 		/**
 		 * Filter the sent notice above the success message.
 		 */
-		$sent_notice = ( isset( $atts['successText'] ) && ! empty( $atts['successText'] ) )  ? $atts['successText'] : (string) apply_filters( 'coblocks_form_sent_notice', __( 'Your message was sent:', 'coblocks' ) );
+		$sent_notice = ( isset( $atts['successText'] ) && ! empty( $atts['successText'] ) )  ? wp_kses_post( $atts['successText'] ) : (string) apply_filters( 'coblocks_form_sent_notice', __( 'Your message was sent:', 'coblocks' ) );
 
 		/**
 		 * Filter the success message after a form submission

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -203,7 +203,7 @@ class CoBlocks_Form {
 
 				if ( $submit_form ) {
 
-					$this->success_message();
+					$this->success_message( $atts );
 
 					print( '</div>' );
 
@@ -1033,14 +1033,15 @@ class CoBlocks_Form {
 	/**
 	 * Display the form success data
 	 *
-	 * @return mixed Markup for a preview of the submitted data
+	 * @param  array $atts Block attributes array.
+	 * @return mixed Success Text followed by the submitted form data.
 	 */
-	public function success_message() {
+	public function success_message( $atts ) {
 
 		/**
 		 * Filter the sent notice above the success message.
 		 */
-		$sent_notice = (string) apply_filters( 'coblocks_form_sent_notice', __( 'Your message was sent:', 'coblocks' ) );
+		$sent_notice = ( isset( $atts['successText'] ) && ! empty( $atts['successText'] ) )  ? $atts['successText'] : (string) apply_filters( 'coblocks_form_sent_notice', __( 'Your message was sent:', 'coblocks' ) );
 
 		/**
 		 * Filter the success message after a form submission

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -1063,10 +1063,7 @@ class CoBlocks_Form {
 			'coblocks_form_success_message',
 			sprintf(
 				'<div class="coblocks-form__submitted">%1$s %2$s</div>',
-				/**
-				 * Filter the sent notice above the success message.
-				 */
-				(string) apply_filters( 'coblocks_form_sent_notice', wp_kses_post( $sent_notice ) ),
+				wp_kses_post( $sent_notice ),
 				wp_kses_post( $this->email_content )
 			),
 			get_the_ID()

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -52,6 +52,18 @@ class CoBlocks_Form {
 	}
 
 	/**
+	 * Default success text
+	 *
+	 * @var string
+	 */
+	public function default_success_text() {
+		/**
+		 * Filter the sent notice above the success message.
+		 */
+		return (string) apply_filters( 'coblocks_form_sent_notice', __( 'Your message was sent:', 'coblocks' ) );
+	}
+
+	/**
 	 * The Constructor.
 	 */
 	public function __construct() {
@@ -1038,10 +1050,7 @@ class CoBlocks_Form {
 	 */
 	public function success_message( $atts ) {
 
-		/**
-		 * Filter the sent notice above the success message.
-		 */
-		$sent_notice = ( isset( $atts['successText'] ) && ! empty( $atts['successText'] ) )  ? wp_kses_post( $atts['successText'] ) : (string) apply_filters( 'coblocks_form_sent_notice', __( 'Your message was sent:', 'coblocks' ) );
+		$sent_notice = ( isset( $atts['successText'] ) && ! empty( $atts['successText'] ) )  ? $atts['successText'] : $this->default_success_text();
 
 		/**
 		 * Filter the success message after a form submission
@@ -1053,8 +1062,11 @@ class CoBlocks_Form {
 		$success_message = (string) apply_filters(
 			'coblocks_form_success_message',
 			sprintf(
-				'<div class="coblocks-form__submitted">%s %s</div>',
-				wp_kses_post( $sent_notice ),
+				'<div class="coblocks-form__submitted">%1$s %2$s</div>',
+				/**
+				 * Filter the sent notice above the success message.
+				 */
+				(string) apply_filters( 'coblocks_form_sent_notice', wp_kses_post( $sent_notice ) ),
 				wp_kses_post( $this->email_content )
 			),
 			get_the_ID()

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -20,7 +20,7 @@ import { TEMPLATE_OPTIONS } from './deprecatedTemplates/layouts';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { Button, PanelBody, TextControl, ExternalLink } from '@wordpress/components';
+import { Button, PanelBody, TextControl, ExternalLink, TextareaControl } from '@wordpress/components';
 import { InspectorControls, InnerBlocks, __experimentalBlockVariationPicker } from '@wordpress/block-editor';
 import { applyFilters } from '@wordpress/hooks';
 import { compose } from '@wordpress/compose';
@@ -41,6 +41,7 @@ class FormEdit extends Component {
 		super( ...arguments );
 
 		this.onChangeSubject = this.onChangeSubject.bind( this );
+		this.onChangeSuccessText = this.onChangeSuccessText.bind( this );
 		this.onBlurTo = this.onBlurTo.bind( this );
 		this.onChangeTo = this.onChangeTo.bind( this );
 		this.getToValidationError = this.getToValidationError.bind( this );
@@ -151,6 +152,10 @@ class FormEdit extends Component {
 	onChangeSubject( subject ) {
 		this.setState( { subjectValue: subject } );
 		this.props.setAttributes( { subject } );
+	}
+
+	onChangeSuccessText( successText ) {
+		this.props.setAttributes( { successText } );
 	}
 
 	getToValidationError( email ) {
@@ -268,7 +273,7 @@ class FormEdit extends Component {
 	renderToAndSubjectFields() {
 		const fieldEmailError = this.state.toError;
 		const { instanceId, attributes } = this.props;
-		const { to } = attributes;
+		const { to, successText } = attributes;
 		const { subjectValue } = this.state;
 		return (
 			<Fragment>
@@ -282,6 +287,7 @@ class FormEdit extends Component {
 					value={ to || '' === to ? to : coblocksBlockData.form.adminEmail }
 					onBlur={ this.onBlurTo }
 					onChange={ this.onChangeTo }
+					help={ __( 'Enter the email address where emails should be sent to.', 'coblocks' ) }
 				/>
 				<Notice isError id={ `contact-form-${instanceId}-email-error` }>
 					{ this.getfieldEmailError( fieldEmailError ) }
@@ -290,22 +296,32 @@ class FormEdit extends Component {
 					label={ __( 'Subject', 'coblocks' ) }
 					value={ subjectValue }
 					onChange={ this.onChangeSubject }
-					help={ <Fragment> { __( 'You may use the following tags in the subject field: ', 'coblocks' ) }
-						<Button
-							isLink
-							onClick={ this.appendTagsToSubject }
-						>
-							[{ __( 'email', 'coblocks' ) }]
-						</Button>
-						<Button
-							isLink
-							onClick={ this.appendTagsToSubject }
-						>
-							[{ __( 'name', 'coblocks' ) }]
-						</Button></Fragment> }
-
+					help={
+						<Fragment>
+							{ __( 'You may use the following tags in the subject field: ', 'coblocks' ) }
+							<Button
+								isLink
+								onClick={ this.appendTagsToSubject }
+							>
+								{ __( 'email', 'coblocks' ) }
+							</Button>
+							<Button
+								isLink
+								onClick={ this.appendTagsToSubject }
+							>
+								{ __( 'name', 'coblocks' ) }
+							</Button>
+						</Fragment>
+					}
 				/>
-
+				<TextareaControl
+					label={ __( 'Success Message', 'coblocks' ) }
+					placeholder={ __( 'Your message was sent:', 'coblocks' ) }
+					onKeyDown={ this.preventEnterSubmission }
+					value={ successText }
+					onChange={ this.onChangeSuccessText }
+					help={ __( 'Enter the success text to display back to the user.', 'coblocks' ) }
+				/>
 			</Fragment>
 		);
 	}

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -303,13 +303,13 @@ class FormEdit extends Component {
 								isLink
 								onClick={ this.appendTagsToSubject }
 							>
-								{ __( 'email', 'coblocks' ) }
+								[{ __( 'email', 'coblocks' ) }]
 							</Button>
 							<Button
 								isLink
 								onClick={ this.appendTagsToSubject }
 							>
-								{ __( 'name', 'coblocks' ) }
+								[{ __( 'name', 'coblocks' ) }]
 							</Button>
 						</Fragment>
 					}

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -315,12 +315,12 @@ class FormEdit extends Component {
 					}
 				/>
 				<TextareaControl
-					label={ __( 'Success Message', 'coblocks' ) }
+					label={ __( 'Success message', 'coblocks' ) }
 					placeholder={ __( 'Your message was sent:', 'coblocks' ) }
 					onKeyDown={ this.preventEnterSubmission }
 					value={ successText }
 					onChange={ this.onChangeSuccessText }
-					help={ __( 'Enter the success text to display back to the user.', 'coblocks' ) }
+					help={ __( 'Form submission confirmation text.', 'coblocks' ) }
 				/>
 			</Fragment>
 		);

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -26,6 +26,10 @@ const metadata = {
 			type: 'string',
 			default: null,
 		},
+		successText: {
+			type: 'string',
+			default: __( 'Your message was sent:', 'coblocks' ),
+		},
 	},
 };
 

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -1,3 +1,5 @@
+/* global coblocksBlockData */
+
 /**
  * Internal dependencies
  */
@@ -10,6 +12,9 @@ import variations from './variations';
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
+
+// Note: Check that coblocksBlockData is set. So jest tests will pass.
+const successTextDefault = typeof coblocksBlockData === 'undefined' ? __( 'Your message was sent:', 'coblocks' ) : 'coblocksBlockData.form.successText';
 
 /**
  * Block constants
@@ -28,7 +33,7 @@ const metadata = {
 		},
 		successText: {
 			type: 'string',
-			default: __( 'Your message was sent:', 'coblocks' ),
+			default: successTextDefault,
 		},
 	},
 };

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 // Note: Check that coblocksBlockData is set. So jest tests will pass.
-const successTextDefault = typeof coblocksBlockData === 'undefined' ? __( 'Your message was sent:', 'coblocks' ) : 'coblocksBlockData.form.successText';
+const successTextDefault = typeof coblocksBlockData === 'undefined' ? __( 'Your message was sent:', 'coblocks' ) : coblocksBlockData.form.successText;
 
 /**
  * Block constants

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -435,4 +435,61 @@ describe( 'Test CoBlocks Form Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test the custom success message displays as intended.
+	 */
+	it( 'Test the custom success message displays as intended.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( '[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:first-child' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		cy.get( '[data-type="coblocks/form"]' )
+			.click( { force: true } );
+
+			cy.get( 'div.edit-post-sidebar' )
+				.contains( /Success Message/i )
+				.next( 'textarea' )
+				.then( ( $inputElem ) => {
+					cy.get( $inputElem ).invoke( 'val' ).then( ( val ) => {
+						cy.get( $inputElem )
+							.clear()
+							.type( 'Thank you for submitting this form!' );
+					} );
+				} );
+
+		helpers.savePage();
+		helpers.viewPage();
+
+		cy.get( '.coblocks-form' )
+			.should( 'exist' );
+
+		cy.get( 'input[name="field-name[value]"]' )
+			.type( 'Name' );
+
+		cy.get( 'input[name="field-email[value]"]' )
+			.type( 'email@example.com' );
+
+		cy.get( 'textarea[name="field-message[value]"]' )
+			.type( 'My message for you.' );
+
+		cy.get( '.coblocks-form__submit button' )
+			.click();
+
+		cy.get( '.coblocks-form__submitted' ).contains( 'Thank you for submitting this form!' );
+
+		helpers.editPage();
+	} );
 } );


### PR DESCRIPTION
### Description
This PR introduces a custom Success Text field for the form block, allowing users to display a custom message back to the user once the form has been submitted.

Resolves #1519 

### Screenshots

#### Form Settings
<img src="https://user-images.githubusercontent.com/5321364/91243849-e545a700-e718-11ea-89a3-390fe8ad019c.png" width="250" />

#### Submitted Form
<img src="https://user-images.githubusercontent.com/5321364/91243833-dced6c00-e718-11ea-928a-8da5552eeddc.png" width="100%" />

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested. We need to include Cypress tests for this feature.

### Checklist:
- [x] My code is tested (manually - needs Cypress tests)
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
