### PR TITLE
Fix alignment of descriptions in the editor settings modal

### DIFF
--- a/src/extensions/coblocks-settings/styles/style.scss
+++ b/src/extensions/coblocks-settings/styles/style.scss
@@ -13,11 +13,11 @@
 		color: $dark-gray-500;
 		display: block;
 		font-style: normal;
-		padding-left: 37px;
+		padding-left: 36px;
 		padding-top: 2px;
 
 		@include break-small() {
-			padding-left: 28px;
+			padding-left: 32px;
 		}
 	}
 }


### PR DESCRIPTION
### Description
Styles added to fix the alignment of descriptions in the editor settings modal

### Screenshots
![Screen Shot 2020-08-26 at 6 01 03 PM](https://user-images.githubusercontent.com/375788/91362156-e255bf80-e7c7-11ea-9ad3-94bca5ac1be9.png)

### Types of changes
Bug fix

### How has this been tested?
Inspected visually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
