### PR TITLE
Fix Icon block style previews

### DIFF
--- a/src/blocks/icon/styles/editor.scss
+++ b/src/blocks/icon/styles/editor.scss
@@ -170,4 +170,9 @@
 	align-items: center;
 	display: flex;
 	justify-content: center;
+
+	.components-resizable-box__container {
+		width: 100% !important;
+		padding: 4rem !important;
+	}
 }

--- a/src/blocks/icon/styles/editor.scss
+++ b/src/blocks/icon/styles/editor.scss
@@ -126,37 +126,6 @@
 	}
 }
 
-
-// Editor style preview.
-.editor-block-preview,
-.block-editor-block-styles__item-preview {
-
-	.wp-block-coblocks-icon__inner {
-		align-items: center;
-		background: transparent !important;
-		display: flex;
-		height: 100% !important;
-		justify-content: center;
-		margin-top: 16px;
-		padding: 0 !important;
-		transform: scale(1.23);
-		width: 100% !important;
-
-		> svg {
-			fill: #3f464d;
-			height: 24px;
-			width: 24px;
-		}
-	}
-}
-
-.editor-block-preview {
-
-	.wp-block-coblocks-icon__inner {
-		margin-top: 3px;
-	}
-}
-
 // Hide screen reader label for Gutenberg < 6.4
 .components-coblocks-icon-size__controls {
 	align-items: center;
@@ -196,13 +165,9 @@
 }
 
 // Shim to get icons to display correctly in G 6.3+ only.
-.components-panel__body .block-editor-block-preview__container .wp-block-coblocks-icon {
+.block-editor-block-preview__container .wp-block-coblocks-icon {
 	align-content: center;
 	align-items: center;
 	display: flex;
 	justify-content: center;
-
-	svg {
-		transform: scale(4);
-	}
 }


### PR DESCRIPTION
### Description
Remove unecessary CSS to fix Icon block style previews.

### Screenshots
![Screen Shot 2020-08-26 at 6 30 38 PM](https://user-images.githubusercontent.com/375788/91363362-79bc1200-e7ca-11ea-88fe-1281233af786.png)


### Types of changes
Bug fix

### How has this been tested?
Inspected visually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
