### PR TITLE
Remove box shadow from selected form field

### DIFF
--- a/src/blocks/form/styles/editor.scss
+++ b/src/blocks/form/styles/editor.scss
@@ -168,6 +168,10 @@
 	.coblocks-field-multiple__add-option svg {
 		margin-right: 5px;
 	}
+
+	.wp-block:focus::after {
+		box-shadow: none !important;
+	}
 }
 
 .block-editor-block-preview__container .coblocks-form__submit.wp-block-button {


### PR DESCRIPTION
### Description
Remove the box-shadow from the selected form field.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/91910964-0ad53200-ec7e-11ea-800f-603e45a03574.png)

### Types of changes
Non-breaking change

### How has this been tested?
Manually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
