### PR TITLE
Remove arrows from lightbox in single image galleries

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -58,6 +58,10 @@
 
 		if ( images.length > 0 ) {
 			document.getElementsByTagName( 'BODY' )[ 0 ].append( wrapper );
+			if ( images.length === 1 ) {
+				arrowRightContainer.remove();
+				arrowLeftContainer.remove();
+			}
 		}
 
 		if ( captions.length > 0 ) {


### PR DESCRIPTION
### Description
Remove gallery lightbox arrows when only one image is used in a gallery.

Resolves #1601 

### Types of changes
Non-breaking change

### How has this been tested?
Manually. Created one gallery of each type with only one image. Each gallery had the `lightbox` property turned on.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
