### PR TITLE
Fix variation titles for Row and Form blocks

### DIFF
--- a/src/blocks/form/variations.js
+++ b/src/blocks/form/variations.js
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 const variations = [
 	{
 		name: 'contact-form',
-		label: __( 'Contact', 'coblocks' ),
+		title: __( 'Contact', 'coblocks' ),
 		icon: icons.layoutContact,
 		isDefault: true,
 		innerBlocks: [
@@ -30,7 +30,7 @@ const variations = [
 	},
 	{
 		name: 'rsvp-form',
-		label: __( 'RSVP', 'coblocks' ),
+		title: __( 'RSVP', 'coblocks' ),
 		icon: icons.layoutRSVP,
 		innerBlocks: [
 			[ 'coblocks/field-name', { required: true, hasLastName: true } ],
@@ -46,7 +46,7 @@ const variations = [
 	},
 	{
 		name: 'appointment-form',
-		label: __( 'Appointment', 'coblocks' ),
+		title: __( 'Event', 'coblocks' ),
 		icon: icons.layoutAppointment,
 		innerBlocks: [
 			[ 'coblocks/field-name', { required: true, hasLastName: true } ],

--- a/src/blocks/row/variations.js
+++ b/src/blocks/row/variations.js
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 const variations = [
 	{
 		name: 'one-column',
-		label: __( 'One column', 'coblocks' ),
+		title: __( '100', 'coblocks' ),
 		icon: rowIcons.colOne,
 		attributes: {
 			columns: 1,
@@ -31,7 +31,7 @@ const variations = [
 	},
 	{
 		name: 'two-column-split',
-		label: __( 'Two columns; equal split', 'coblocks' ),
+		title: __( '50 / 50', 'coblocks' ),
 		icon: rowIcons.layout5050,
 		attributes: {
 			columns: 2,
@@ -45,7 +45,7 @@ const variations = [
 	},
 	{
 		name: 'two-column-third',
-		label: __( 'Two columns; two thirds, one third split', 'coblocks' ),
+		title: __( '66 / 33', 'coblocks' ),
 		icon: rowIcons.layout6633,
 		attributes: {
 			columns: 2,
@@ -59,7 +59,7 @@ const variations = [
 	},
 	{
 		name: 'three-column',
-		label: __( 'Three columns; equal split', 'coblocks' ),
+		title: __( 'Thirds', 'coblocks' ),
 		icon: rowIcons.layout502525,
 		attributes: {
 			columns: 3,
@@ -75,7 +75,7 @@ const variations = [
 	},
 	{
 		name: 'four-column',
-		label: __( 'Four columns; equal split', 'coblocks' ),
+		title: __( 'Quarters', 'coblocks' ),
 		icon: rowIcons.layout25252525,
 		attributes: {
 			columns: 4,


### PR DESCRIPTION
### Description
Variations in our Row and Form blocks are not displaying the labels associated with each variation. Upon investigation, I uncovered that each variation's label should be defined with a `title` key, instead of label. 

### Screenshots

#### Before
<img width="651" alt="Screen Shot 2020-09-03 at 1 30 36 PM" src="https://user-images.githubusercontent.com/1813435/92147866-b18a1180-ede9-11ea-9783-5925523dd8a6.png">

#### After
<img width="669" alt="Screen Shot 2020-09-03 at 1 27 47 PM" src="https://user-images.githubusercontent.com/1813435/92147873-b3ec6b80-ede9-11ea-8718-b55ff2d02055.png">

### Types of changes
Bug fix (non-breaking change which fixes an issue)
