### PR TITLE
Minor icon fixes

### DIFF
--- a/src/blocks/accordion/accordion-item/controls.js
+++ b/src/blocks/accordion/accordion-item/controls.js
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import icons from './../../../utils/icons';
+import { OpenIcon } from '@godaddy-wordpress/coblocks-icons';
 
 /**
  * WordPress dependencies
@@ -9,7 +9,7 @@ import icons from './../../../utils/icons';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
+import { Toolbar, Icon } from '@wordpress/components';
 
 class Controls extends Component {
 	render() {
@@ -24,7 +24,7 @@ class Controls extends Component {
 
 		const customControls = [
 			{
-				icon: icons.open,
+				icon: <Icon icon={ OpenIcon } />,
 				/* translators: toggle label to display the accordion open */
 				title: __( 'Display as open', 'coblocks' ),
 				onClick: () => setAttributes( { open: ! open } ),

--- a/src/blocks/row/column/icon.js
+++ b/src/blocks/row/column/icon.js
@@ -1,6 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { Path, SVG } from '@wordpress/components';
-
-export default <SVG fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="m3.75 18v-12c0-.69036.55964-1.25 1.25-1.25h14c.6904 0 1.25.55964 1.25 1.25v12c0 .6904-.5596 1.25-1.25 1.25h-14c-.69036 0-1.25-.5596-1.25-1.25z" stroke="currentColor" strokeWidth="1.5" fill="none" /><Path d="m3 15h6v18h-6z" fill="currentColor" transform="matrix(0 -1 1 0 -12 18)" /></SVG>;

--- a/src/blocks/row/column/index.js
+++ b/src/blocks/row/column/index.js
@@ -1,10 +1,14 @@
 /**
+ * External dependencies
+ */
+import { ColumnIcon } from '@godaddy-wordpress/coblocks-icons';
+
+/**
  * Internal dependencies
  */
 import deprecated from './deprecated';
 import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 import edit from './edit';
-import icon from './icon';
 import metadata from './block.json';
 import save from './save';
 import { BackgroundAttributes } from '../../../components/background';
@@ -13,6 +17,7 @@ import { BackgroundAttributes } from '../../../components/background';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
 
 /**
  * Block constants
@@ -30,7 +35,7 @@ const settings = {
 	title: __( 'Column', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'An immediate child of a row.', 'coblocks' ),
-	icon,
+	icon: <Icon icon={ ColumnIcon } />,
 	parent: [ 'coblocks/row' ],
 	supports: {
 		inserter: false,

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -4,6 +4,7 @@
 import classnames from 'classnames';
 import map from 'lodash/map';
 import get from 'lodash/get';
+import { RowIcon } from '@godaddy-wordpress/coblocks-icons';
 
 /**
  * Internal dependencies
@@ -24,8 +25,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, useDispatch, withDispatch } from '@wordpress/data';
-import { BlockIcon, InnerBlocks, __experimentalBlockVariationPicker } from '@wordpress/block-editor';
-import { ButtonGroup, Button, Tooltip, Placeholder, Spinner } from '@wordpress/components';
+import { InnerBlocks, __experimentalBlockVariationPicker } from '@wordpress/block-editor';
+import { ButtonGroup, Button, Tooltip, Placeholder, Spinner, Icon } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 
 /**
@@ -143,7 +144,7 @@ class Edit extends Component {
 					<Placeholder
 						key="placeholder"
 						className="components-coblocks-row-placeholder"
-						icon={ <BlockIcon icon={ columns ? rowIcons.layout : rowIcons.row } /> }
+						icon={ <Icon icon={ RowIcon } /> }
 						label={ columns ? __( 'Row layout', 'coblocks' ) : __( 'Row', 'coblocks' ) }
 						instructions={ columns
 							? sprintf(

--- a/src/blocks/row/index.js
+++ b/src/blocks/row/index.js
@@ -1,21 +1,26 @@
 /**
+ * External dependencies
+ */
+import { RowIcon } from '@godaddy-wordpress/coblocks-icons';
+
+/**
  * Internal dependencies
  */
-import edit from './edit';
 import deprecated from './deprecated';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
-import { getEditWrapperProps } from './utilities';
-import icon from './icon';
+import edit from './edit';
 import metadata from './block.json';
-import variations from './variations';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 import { BackgroundAttributes } from '../../components/background';
+import { getEditWrapperProps } from './utilities';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
 
 /**
  * Block constants
@@ -33,7 +38,7 @@ const settings = {
 	title: __( 'Row', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add a structured wrapper for column blocks, then add content blocks you’d like to the columns.', 'coblocks' ),
-	icon,
+	icon: <Icon icon={ RowIcon } />,
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */


### PR DESCRIPTION
### Description
This PR addresses a few small follow-up icon fixes for the G2 styling that came in WordPress 5.5  for the Row, Accordion, and Column blocks. 

### Screenshots
#### Before:
<img width="248" alt="Screen Shot 2020-09-03 at 1 57 29 PM" src="https://user-images.githubusercontent.com/1813435/92150456-6f62cf00-eded-11ea-9fd9-9b76ba95998d.png">
<img width="283" alt="Screen Shot 2020-09-03 at 1 57 34 PM" src="https://user-images.githubusercontent.com/1813435/92150463-7093fc00-eded-11ea-9d65-7ac04c2a45e1.png">

#### After: 
<img width="246" alt="Screen Shot 2020-09-03 at 1 47 21 PM" src="https://user-images.githubusercontent.com/1813435/92150352-4c381f80-eded-11ea-9132-33379cf433a3.png">
<img width="678" alt="Screen Shot 2020-09-03 at 1 46 16 PM" src="https://user-images.githubusercontent.com/1813435/92150364-4e9a7980-eded-11ea-86b5-a62432368c2a.png">
