### PR TITLE
Fix editor crash when running CoBlocks and WordPress 5.4.2

### DIFF
--- a/includes/class-block-patterns.php
+++ b/includes/class-block-patterns.php
@@ -23,11 +23,10 @@ class CoBlocks_Block_Patterns {
 	 * The Constructor.
 	 */
 	public function __construct() {
-		global $wp_version;
-		$version = str_replace( '-src', '', $wp_version );  // Strip '-src' from the version string. Messes up version_compare().
+		
 		add_action( 'admin_enqueue_scripts', array( $this, 'conditional_load_patterns' ) );
 		
-		if ( version_compare( $version, '5.5-beta', '>=' ) ) {
+		if ( is_wp_version_compatible('5.5-beta') ) {
 			add_action( 'init', array( $this, 'register_post_type' ) );
 			add_action( 'init', array( $this, 'register_type_taxonomy' ) );
 			add_action( 'init', array( $this, 'register_category_taxonomy' ) );
@@ -117,14 +116,11 @@ class CoBlocks_Block_Patterns {
 	 * @access public
 	 */
 	public function conditional_load_patterns() {
-		global $wp_version;
-		$version = str_replace( '-src', '', $wp_version ); // Strip '-src' from the version string. Messes up version_compare().
-
 		wp_localize_script(
 			'coblocks-editor',
 			'coblocksBlockPatterns',
 			array(
-				'patternsEnabled' => version_compare( $version, '5.5-beta', '>=' ),
+				'patternsEnabled' => is_wp_version_compatible('5.5-beta'),
 			)
 		);
 	}

--- a/includes/class-block-patterns.php
+++ b/includes/class-block-patterns.php
@@ -26,7 +26,7 @@ class CoBlocks_Block_Patterns {
 		
 		add_action( 'admin_enqueue_scripts', array( $this, 'conditional_load_patterns' ) );
 		
-		if ( is_wp_version_compatible('5.5-beta') ) {
+		if ( is_wp_version_compatible('5.5') ) {
 			add_action( 'init', array( $this, 'register_post_type' ) );
 			add_action( 'init', array( $this, 'register_type_taxonomy' ) );
 			add_action( 'init', array( $this, 'register_category_taxonomy' ) );
@@ -120,7 +120,7 @@ class CoBlocks_Block_Patterns {
 			'coblocks-editor',
 			'coblocksBlockPatterns',
 			array(
-				'patternsEnabled' => is_wp_version_compatible('5.5-beta'),
+				'patternsEnabled' => is_wp_version_compatible('5.5'),
 			)
 		);
 	}

--- a/includes/class-block-patterns.php
+++ b/includes/class-block-patterns.php
@@ -118,8 +118,7 @@ class CoBlocks_Block_Patterns {
 	 */
 	public function conditional_load_patterns() {
 		global $wp_version;
-		// Strip '-src' from the version string. Messes up version_compare().
-		$version = str_replace( '-src', '', $wp_version );
+		$version = str_replace( '-src', '', $wp_version ); // Strip '-src' from the version string. Messes up version_compare().
 
 		wp_localize_script(
 			'coblocks-editor',

--- a/src/extensions/block-patterns/index.js
+++ b/src/extensions/block-patterns/index.js
@@ -1,3 +1,4 @@
+/*global coblocksBlockPatterns*/
 /**
  * WordPress dependencies
  */
@@ -40,6 +41,8 @@ const CoBlocksBlockPatterns = () => {
 	);
 };
 
-registerPlugin( 'coblocks-block-patterns', {
-	render: CoBlocksBlockPatterns,
-} );
+if ( typeof coblocksBlockPatterns !== 'undefined' && !! coblocksBlockPatterns?.patternsEnabled ) {
+	registerPlugin( 'coblocks-block-patterns', {
+		render: CoBlocksBlockPatterns,
+	} );
+}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
CoBlocks has implemented components that are bundled natively with WordPress 5.5 but which are not bundled with 5.4.2 resulting in editor crash when editing or adding a new post.

Closes #1666.

This PR adds new logic to conditionally load Block-Patten extension.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Logic to PHP and JavaScript to conditonally load block patterns extension.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually using WordPress 5.4.2 as well as 5.5.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
