### PR TITLE
Pricing Table: Use ToolbarGroup to render controls correctly

### DIFF
--- a/src/blocks/pricing-table/controls.js
+++ b/src/blocks/pricing-table/controls.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { AlignmentToolbar, BlockControls } from '@wordpress/block-editor';
-import { Toolbar, Path, SVG } from '@wordpress/components';
+import { ToolbarGroup, Path, SVG } from '@wordpress/components';
 
 const DEFAULT_ALIGNMENT_CONTROLS = [
 	{
@@ -57,7 +57,7 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-					<Toolbar
+					<ToolbarGroup
 						isCollapsed={ true }
 						icon={ activeCount.icon }
 						label={ __( 'Change pricing table count', 'coblocks' ) }


### PR DESCRIPTION
Fixes #1670

### Description
Use ToolbarGroup instead of Toolbar to render Pricing Table controls correctly. This fixes a bug that's present when CoBlocks are used with Gutenberg >=8.8.0. This solution is based on how the [Gutenberg's alignment toolbar is implemented](https://github.com/WordPress/gutenberg/blob/v8.9.3/packages/block-editor/src/components/block-alignment-toolbar/index.js#L69-L86).

### Screenshots
| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1451471/92619797-41383000-f2c2-11ea-94e1-bdd4430eef53.png) | ![image](https://user-images.githubusercontent.com/1451471/92619855-4eedb580-f2c2-11ea-8ddf-f86d7a9c027d.png) |

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Confirmed happening with activated Gutenberg plugin v8.8.0 and later.