### PR TITLE
HeadingToolbar: Use ToolbarGroup to render controls correctly

### DIFF
--- a/src/components/heading-toolbar/index.js
+++ b/src/components/heading-toolbar/index.js
@@ -13,7 +13,7 @@ import HeadingLevelIcon from './icon';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 
 class HeadingToolbar extends Component {
 	createLevelControl( targetLevel, selectedLevel, onChange ) {
@@ -38,7 +38,7 @@ class HeadingToolbar extends Component {
 		} = this.props;
 
 		return (
-			<Toolbar
+			<ToolbarGroup
 				isCollapsed={ isCollapsed }
 				icon={ <HeadingLevelIcon level={ selectedLevel } /> }
 				controls={ range( minLevel, maxLevel ).map( ( index ) =>


### PR DESCRIPTION
### Description
Use ToolbarGroup instead of Toolbar to render HeadingToolbar controls correctly. This fixes a bug that's present when CoBlocks are used with Gutenberg >=8.8.0. This solution is based on how the Gutenberg's alignment toolbar is implemented.

### Screenshots
Before: 
<img width="667" alt="Screen Shot 2020-09-09 at 1 35 35 PM" src="https://user-images.githubusercontent.com/1813435/92633896-75e7bf80-f2a1-11ea-9dff-69b78849fe69.png">

After:
<img width="685" alt="Screen Shot 2020-09-09 at 1 35 16 PM" src="https://user-images.githubusercontent.com/1813435/92633907-7a13dd00-f2a1-11ea-8639-e9bd50ee1957.png">


### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Confirmed happening with activated Gutenberg plugin v8.8.0 and later - and with core WordPress.
