### PR TITLE
Prevent layout selector on posts saved as a draft

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ commands:
       - run:
           name: Install Go theme
           command: |
-            ./vendor/bin/wp theme install go --activate
+            ./vendor/bin/wp theme install go --activate --path=/tmp/wordpress
       - run:
           name: Activate CoBlocks
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,10 @@ commands:
             ./vendor/bin/wp core install --url="http://coblocks.test" --title=CoBlocks --admin_user=admin --admin_password=password --admin_email=test@admin.com --skip-email --path=/tmp/wordpress
             ./vendor/bin/wp post generate --count=5 --path=/tmp/wordpress
       - run:
+          name: Install Go theme
+          command: |
+            ./vendor/bin/wp theme install go --activate
+      - run:
           name: Activate CoBlocks
           command: |
             cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -282,10 +282,15 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 		render: compose( [
 			withSelect( ( select ) => {
 				const { isTemplateSelectorActive } = select( 'coblocks/template-selector' );
-				const { hasEditorUndo, isCurrentPostPublished } = select( 'core/editor' );
+				const {
+					getCurrentPostAttribute,
+					hasEditorUndo,
+					isCurrentPostPublished,
+				} = select( 'core/editor' );
 				const { getLayoutSelector } = select( 'coblocks-settings' );
 
-				const isCleanUnpublishedPost = ! isCurrentPostPublished() && ! hasEditorUndo();
+				const isDraft = [ 'draft' ].indexOf( getCurrentPostAttribute( 'status' ) ) !== -1;
+				const isCleanUnpublishedPost = ! isCurrentPostPublished() && ! hasEditorUndo() && ! isDraft;
 
 				const layouts = coblocksLayoutSelector.layouts || [];
 				const categories = coblocksLayoutSelector.categories || [];

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -87,4 +87,25 @@ describe( 'Extension: Layout Selector', () => {
 		cy.get( '.coblocks-layout-selector-modal' ).should( 'exist' );
 	} );
 
+	it( 'does not open modal when editing a draft post', () => {
+		helpers.goTo( '/wp-admin/post-new.php?post_type=page' );
+		helpers.disableGutenbergFeatures();
+
+		cy.get( '.coblocks-layout-selector__layout' ).first().click();
+		cy.get( '.editor-post-save-draft' ).click();
+
+		// Reload the post.
+		let postID;
+		cy.window()
+			.then( (win) => {
+				postID = win.wp.data.select( 'core/editor' ).getCurrentPostId()
+			} )
+			.then( () => {
+				helpers.goTo( `/wp-admin/post.php?post=${postID}&action=edit` );
+
+				helpers.disableGutenbergFeatures();
+				cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+			} );
+	} );
+
 } );


### PR DESCRIPTION
### Description
Fixes #1664

### Types of changes
Bug fix

### How has this been tested?
Manually and E2E test included.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
