### PR TITLE
Fix required checkbox/radio hidden message escaped markup

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -622,7 +622,7 @@ class CoBlocks_Form {
 			'<div class="coblocks-field checkbox%1$s">
 				%2$s',
 			esc_attr( $required ? ' required' : '' ),
-			esc_html(
+			wp_kses_post(
 				$required ? sprintf(
 					'<div class="required-error hidden">%s</div>',
 					/**


### PR DESCRIPTION
### Description
There was a bug with the output of the required text, which should be hidden on initial load. Because we were passing the HTML through `esc_html()` the markup was not properly parsed on the front of site. This PR switches things to use `wp_kses_post()`  which parses the HTML as expected.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/5321364/92655611-b5250900-f2bf-11ea-8cca-a3fb4dfcfc44.png)

#### With Patch
![image](https://user-images.githubusercontent.com/5321364/92655637-bbb38080-f2bf-11ea-929b-5505cbe6b367.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
