### PR TITLE
Collage block: Add caption margin zero

### DIFF
--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -180,12 +180,12 @@
 	figcaption {
 		bottom: 0;
 		font-size: 13px;
+		margin: 0;
 		opacity: 0.9;
 		padding: 30px 10px 10px;
 		position: absolute;
 		text-align: center;
 		width: 100%;
-		margin: 0;
 	}
 
 	&.has-caption-style-dark figcaption {

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -185,6 +185,7 @@
 		position: absolute;
 		text-align: center;
 		width: 100%;
+		margin: 0;
 	}
 
 	&.has-caption-style-dark figcaption {


### PR DESCRIPTION
### Description

Add `margin: 0` to collage gallery captions.

This prevents theme styles from introducing a margin to gallery
captions.

Fixes https://github.com/Automattic/themes/issues/2374


### Screenshots

**Varia theme**

Before:

![before](https://user-images.githubusercontent.com/841763/93063943-3fca8700-f677-11ea-8c61-c186fa63fe96.png)

After:

![after](https://user-images.githubusercontent.com/841763/93063952-422ce100-f677-11ea-8fa6-0d7732feb6b7.png)

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Apply the styles and confirm in browser.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
