### PR TITLE
Transform Form fields with with proper labels

### DIFF
--- a/src/blocks/form/fields/checkbox/transforms.js
+++ b/src/blocks/form/fields/checkbox/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,10 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-select', 'coblocks/field-radio' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-checkbox',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-checkbox', {
+					label: __( 'Checkbox', 'coblocks' ),
+					options: attributes.options,
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/date/transforms.js
+++ b/src/blocks/form/fields/date/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-name', 'coblocks/field-textarea', 'coblocks/field-phone', 'coblocks/field-text', 'coblocks/field-website', 'coblocks/field-hidden' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-date', attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-date', {
+					label: __( 'Date', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/hidden/transforms.js
+++ b/src/blocks/form/fields/hidden/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-name', 'coblocks/field-date', 'coblocks/field-textarea', 'coblocks/field-phone', 'coblocks/field-text', 'coblocks/field-website' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-hidden',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-hidden', {
+					label: __( 'Hidden', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/name/transforms.js
+++ b/src/blocks/form/fields/name/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-date', 'coblocks/field-textarea', 'coblocks/field-phone', 'coblocks/field-text', 'coblocks/field-website', 'coblocks/field-hidden' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-name', attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-name', {
+					label: __( 'Name', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/phone/transforms.js
+++ b/src/blocks/form/fields/phone/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-name', 'coblocks/field-date', 'coblocks/field-textarea', 'coblocks/field-text', 'coblocks/field-website', 'coblocks/field-hidden' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-phone',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-phone', {
+					label: __( 'Phone', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/radio/transforms.js
+++ b/src/blocks/form/fields/radio/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,10 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-select', 'coblocks/field-checkbox' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-radio',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-radio', {
+					label: __( 'Choose one', 'coblocks' ),
+					options: attributes.options,
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/select/transforms.js
+++ b/src/blocks/form/fields/select/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,10 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-checkbox', 'coblocks/field-radio' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-select',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-select', {
+					label: __( 'Select', 'coblocks' ),
+					options: attributes.options,
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/text/transforms.js
+++ b/src/blocks/form/fields/text/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-name', 'coblocks/field-date', 'coblocks/field-textarea', 'coblocks/field-phone', 'coblocks/field-website', 'coblocks/field-hidden' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-text',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-text', {
+					label: __( 'Text', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/textarea/transforms.js
+++ b/src/blocks/form/fields/textarea/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-name', 'coblocks/field-date', 'coblocks/field-phone', 'coblocks/field-text', 'coblocks/field-website', 'coblocks/field-hidden' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-textarea',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-textarea', {
+					label: __( 'Message', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],

--- a/src/blocks/form/fields/website/transforms.js
+++ b/src/blocks/form/fields/website/transforms.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
@@ -9,9 +10,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'coblocks/field-name', 'coblocks/field-date', 'coblocks/field-textarea', 'coblocks/field-phone', 'coblocks/field-text', 'coblocks/field-hidden' ],
 			transform: ( attributes, innerBlocks ) => {
-				return [
-					createBlock( 'coblocks/field-website',  attributes, innerBlocks ),
-				];
+				return createBlock( 'coblocks/field-website', {
+					label: __( 'Website', 'coblocks' ),
+				}, innerBlocks );
 			},
 		},
 	],


### PR DESCRIPTION
### Description
This PR builds on #1676 by adapting the transformed field label to it's original label. For example, if transforming a Date block into a Website block, the label "Date" becomes "Website". 