### PR TITLE
Tweak Form label color controls

### DIFF
--- a/src/components/form-label-colors/label-color-control.js
+++ b/src/components/form-label-colors/label-color-control.js
@@ -58,15 +58,12 @@ export default compose( [
 
 		const updateInnerAttributes = ( newAttributes ) => {
 			const innerItems = getBlocksByClientId(	props.clientId	)[ 0 ].innerBlocks;
-			const exculdeBlocks = [ 'coblocks/field-hidden', 'coblocks/field-submit-button' ];
-			innerItems
-				.filter( ( item ) => exculdeBlocks.indexOf( item.name ) === -1 )
-				.forEach( ( item ) => {
-					updateBlockAttributes(
-						item.clientId,
-						newAttributes
-					);
-				} );
+			innerItems.forEach( ( item ) => {
+				updateBlockAttributes(
+					item.clientId,
+					newAttributes
+				);
+			} );
 		};
 
 		return {

--- a/src/components/form-label-colors/label-color-control.js
+++ b/src/components/form-label-colors/label-color-control.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { InspectorControls, withColors, PanelColorSettings } from '@wordpress/block-editor';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Color Settings
@@ -59,10 +60,12 @@ export default compose( [
 		const updateInnerAttributes = ( newAttributes ) => {
 			const innerItems = getBlocksByClientId(	props.clientId	)[ 0 ].innerBlocks;
 			innerItems.forEach( ( item ) => {
-				updateBlockAttributes(
-					item.clientId,
-					newAttributes
-				);
+				if ( hasBlockSupport( item.name, 'labelColor', false ) ) {
+					updateBlockAttributes(
+						item.clientId,
+						newAttributes
+					);
+				}
 			} );
 		};
 


### PR DESCRIPTION
### Description
I had a realization that I was using a superfluous block exclusion here where it is not required. This behavior is already handled here - except for cases where the same attribute schema exists regardless of defined block supports.
https://github.com/godaddy-wordpress/coblocks/blob/4db325197106746692240a29d64818adcb9b4fe6/src/components/form-label-colors/index.js#L7-L11

Because we might end up altering attributes of children blocks that do not have explicit form label support, this component has been modified to allow attribute propagation to only blocks with defined supports. (form child blocks)

This change prevents colors from being set on a child paragraph block within the Form block.

### Screenshots
Exclude blocks without defined support.
<!-- if applicable -->
![formLabelColorsHidden](https://user-images.githubusercontent.com/30462574/93224920-81663b00-f726-11ea-8b3e-1b3f5ce00f5a.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Remove and replace JavaScript logic. This change will use defined block supports to determine attribute propagation.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. E2E.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
