### PR TITLE
Resolve errors around icon imports

### DIFF
--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -23,6 +23,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withNotices, ResizableBox } from '@wordpress/components';
 import { RichText } from '@wordpress/block-editor';
+import { Icon } from '@wordpress/icons';
 
 class GalleryCarouselEdit extends Component {
 	constructor() {
@@ -162,6 +163,21 @@ class GalleryCarouselEdit extends Component {
 
 		const hasImages = !! images.length;
 
+		const carouselGalleryPlaceholder = (
+			<Fragment>
+				{ ! hasImages ? noticeUI : null }
+				<GalleryPlaceholder
+					{ ...this.props }
+					label={ __( 'Carousel', 'coblocks' ) }
+					icon={ <Icon icon={ icon } /> }
+					gutter={ gutter }
+				/>
+			</Fragment> );
+
+		if ( ! hasImages ) {
+			return carouselGalleryPlaceholder;
+		}
+
 		const innerClasses = classnames(
 			'is-cropped',
 			...GalleryClasses( attributes ), {
@@ -236,21 +252,6 @@ class GalleryCarouselEdit extends Component {
 			}
 		);
 
-		const carouselGalleryPlaceholder = (
-			<Fragment>
-				{ ! hasImages ? noticeUI : null }
-				<GalleryPlaceholder
-					{ ...this.props }
-					label={ __( 'Carousel', 'coblocks' ) }
-					icon={ <Icon icon={ icon } /> }
-					gutter={ gutter }
-				/>
-			</Fragment> );
-
-		if ( ! hasImages ) {
-			return carouselGalleryPlaceholder;
-		}
-
 		return (
 			<Fragment>
 				{ isSelected &&
@@ -310,7 +311,7 @@ class GalleryCarouselEdit extends Component {
 									);
 
 									return (
-										<div className="coblocks-gallery--item" key={ img.id || img.url } onClick={ this.onItemClick }>
+										<div className="coblocks-gallery--item" role="button" tabIndex="0" key={ img.id || img.url } onKeyDown={ this.onItemClick } onClick={ this.onItemClick }>
 											<GalleryImage
 												url={ img.url }
 												alt={ img.alt }


### PR DESCRIPTION
### Description
E2E failures were missed for the Gallery Carousel block. This PR fixes the edit function to properly import the Icon component for use within the editor. Also made changes for eslint to the Edit function. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. E2E
### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
