### PR TITLE
Update icons to utilize @wordpress/icons edit icon

### DIFF
--- a/src/blocks/author/controls.js
+++ b/src/blocks/author/controls.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { Toolbar, Button } from '@wordpress/components';
+import { edit } from '@wordpress/icons';
 
 class Controls extends Component {
 	render() {
@@ -34,7 +35,7 @@ class Controls extends Component {
 										<Button
 											className="components-toolbar__control"
 											label={ __( 'Edit avatar', 'coblocks' ) }
-											icon="edit"
+											icon={ edit }
 											onClick={ open }
 										/>
 									) }

--- a/src/blocks/events/edit.js
+++ b/src/blocks/events/edit.js
@@ -21,6 +21,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, dispatch } from '@wordpress/data';
 import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
+import { edit } from '@wordpress/icons';
 
 const ALLOWED_BLOCKS = [ 'coblocks/event-item' ];
 
@@ -147,7 +148,7 @@ class EventsEdit extends Component {
 
 		const toolbarControls = [
 			{
-				icon: 'edit',
+				icon: edit,
 				title: __( 'Edit calendar URL', 'coblocks' ),
 				onClick: () => this.setState( { isEditing: ! this.state.isEditing } ),
 			},

--- a/src/blocks/gist/controls.js
+++ b/src/blocks/gist/controls.js
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 import { Toolbar } from '@wordpress/components';
+import { edit } from '@wordpress/icons';
 
 class Controls extends Component {
 	render() {
@@ -15,7 +16,7 @@ class Controls extends Component {
 
 		const editControl = [
 			{
-				icon: 'edit',
+				icon: edit,
 				title: preview ?
 					sprintf(
 						/* translators: %s: "Gist", the name of a code sharing platform */

--- a/src/blocks/logos/controls.js
+++ b/src/blocks/logos/controls.js
@@ -14,6 +14,7 @@ import {
 	MediaUpload,
 	MediaUploadCheck,
 } from '@wordpress/block-editor';
+import { edit } from '@wordpress/icons';
 
 class Controls extends Component {
 	constructor() {
@@ -48,7 +49,7 @@ class Controls extends Component {
 										<Button
 											className="components-toolbar__control"
 											label={ __( 'Edit logos', 'coblocks' ) }
-											icon="edit"
+											icon={ edit }
 											onClick={ open }
 										/>
 									) }

--- a/src/blocks/map/controls.js
+++ b/src/blocks/map/controls.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
 import { Toolbar } from '@wordpress/components';
+import { edit } from '@wordpress/icons';
 
 function Controls( { attributes, setAttributes } ) {
 	const {
@@ -13,7 +14,7 @@ function Controls( { attributes, setAttributes } ) {
 
 	const toolbarControls = [
 		{
-			icon: 'edit',
+			icon: edit,
 			title: __( 'Edit Location', 'coblocks' ),
 			isActive: ! pinned,
 			onClick: () => setAttributes( { pinned: ! pinned } ),

--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -33,6 +33,7 @@ import {
 	TextControl,
 	Toolbar,
 } from '@wordpress/components';
+import { edit } from '@wordpress/icons';
 
 /**
  * Module Constants
@@ -119,7 +120,7 @@ class PostCarousel extends Component {
 
 		const editToolbarControls = [
 			{
-				icon: 'edit',
+				icon: edit,
 				title: __( 'Edit RSS URL', 'coblocks' ),
 				onClick: () => this.setState( { editing: true } ),
 			},

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -35,7 +35,7 @@ import {
 	Toolbar,
 } from '@wordpress/components';
 import GutterWrapper from '../../components/gutter-control/gutter-wrapper';
-import { pullLeft, pullRight } from '@wordpress/icons';
+import { pullLeft, pullRight, edit } from '@wordpress/icons';
 
 /**
  * Module Constants
@@ -237,7 +237,7 @@ class PostsEdit extends Component {
 
 		const editToolbarControls = [
 			{
-				icon: 'edit',
+				icon: edit,
 				title: __( 'Edit RSS URL', 'coblocks' ),
 				onClick: () => this.setState( { editing: true } ),
 			},


### PR DESCRIPTION
### Description
Update icons in certain blocks to utilize `@wordpress/icons` edit icon

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/94074806-03f69680-fdc8-11ea-9ded-ac23bf4a66de.png)

### Types of changes
Update to icons, non-breaking change.

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
