### PR TITLE
Fix appearance of Row block column spacing controls

### DIFF
--- a/src/blocks/row/controls.js
+++ b/src/blocks/row/controls.js
@@ -6,6 +6,8 @@ import map from 'lodash/map';
 /**
  * Internal dependencies
  */
+import { layoutOptions } from './utilities';
+import rowIcons from './icons';
 import { BackgroundControls } from '../../components/background';
 
 /**
@@ -14,8 +16,31 @@ import { BackgroundControls } from '../../components/background';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, BlockVerticalAlignmentToolbar } from '@wordpress/block-editor';
+import { ToolbarGroup } from '@wordpress/components';
 
 class Controls extends Component {
+	// Switches the icon based on the layout selected,
+	// Fallback is the default layout icon.
+	layoutIcon() {
+		const {
+			columns,
+			layout,
+		} = this.props.attributes;
+
+		let selectedRows = 1;
+
+		if ( columns ) {
+			selectedRows = parseInt( columns.toString().split( '-' ) );
+		}
+
+		if ( layout === undefined ) {
+			return rowIcons.layout;
+		}
+
+		return map( layoutOptions[ selectedRows ], ( { key, smallIcon } ) => (
+			( key === layout ) ? smallIcon : ''
+		) );
+	}
 
 	render() {
 		const {
@@ -27,9 +52,16 @@ class Controls extends Component {
 		} = this.props;
 
 		const {
+			columns,
 			layout,
 			verticalAlignment,
 		} = attributes;
+
+		let selectedRows = 1;
+
+		if ( columns ) {
+			selectedRows = parseInt( columns.toString().split( '-' ) );
+		}
 
 		if ( ! layout ) {
 			return null;
@@ -38,6 +70,34 @@ class Controls extends Component {
 		return (
 			<Fragment>
 				<BlockControls>
+					{ ( columns && selectedRows > 1 ) &&
+						<ToolbarGroup
+							isCollapsed={ true }
+							icon={ this.layoutIcon() }
+							label={ __( 'Change row block layout', 'coblocks' ) }
+							controls={ map( layoutOptions[ selectedRows ], ( { name, key, smallIcon } ) => {
+								return {
+									title: name,
+									key,
+									icon: smallIcon,
+									isActive: key === layout,
+									onClick: () => {
+										const selectedWidth = key.toString().split( '-' );
+										const children = getBlocksByClientId( clientId );
+										setAttributes( {
+											layout: key,
+										} );
+										if ( typeof children[ 0 ].innerBlocks !== 'undefined' ) {
+											map( children[ 0 ].innerBlocks, ( blockProps, index ) => (
+												updateBlockAttributes( blockProps.clientId, { width: selectedWidth[ index ] } )
+											) );
+										}
+									},
+								};
+							} ) }
+						>
+						</ToolbarGroup>
+					}
 					<BlockVerticalAlignmentToolbar
 						onChange={ ( alignment ) => {
 							const children = getBlocksByClientId( clientId );

--- a/src/blocks/row/controls.js
+++ b/src/blocks/row/controls.js
@@ -6,8 +6,6 @@ import map from 'lodash/map';
 /**
  * Internal dependencies
  */
-import { layoutOptions } from './utilities';
-import rowIcons from './icons';
 import { BackgroundControls } from '../../components/background';
 
 /**
@@ -16,31 +14,8 @@ import { BackgroundControls } from '../../components/background';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, BlockVerticalAlignmentToolbar } from '@wordpress/block-editor';
-import { ToolbarGroup } from '@wordpress/components';
 
 class Controls extends Component {
-	// Switches the icon based on the layout selected,
-	// Fallback is the default layout icon.
-	layoutIcon() {
-		const {
-			columns,
-			layout,
-		} = this.props.attributes;
-
-		let selectedRows = 1;
-
-		if ( columns ) {
-			selectedRows = parseInt( columns.toString().split( '-' ) );
-		}
-
-		if ( layout === undefined ) {
-			return rowIcons.layout;
-		}
-
-		return map( layoutOptions[ selectedRows ], ( { key, smallIcon } ) => (
-			( key === layout ) ? smallIcon : ''
-		) );
-	}
 
 	render() {
 		const {
@@ -52,16 +27,9 @@ class Controls extends Component {
 		} = this.props;
 
 		const {
-			columns,
 			layout,
 			verticalAlignment,
 		} = attributes;
-
-		let selectedRows = 1;
-
-		if ( columns ) {
-			selectedRows = parseInt( columns.toString().split( '-' ) );
-		}
 
 		if ( ! layout ) {
 			return null;
@@ -70,34 +38,6 @@ class Controls extends Component {
 		return (
 			<Fragment>
 				<BlockControls>
-					{ ( columns && selectedRows > 1 ) &&
-						<ToolbarGroup
-							isCollapsed={ true }
-							icon={ this.layoutIcon() }
-							label={ __( 'Change row block layout', 'coblocks' ) }
-							controls={ map( layoutOptions[ selectedRows ], ( { name, key, smallIcon } ) => {
-								return {
-									title: name,
-									key,
-									icon: smallIcon,
-									isActive: key === layout,
-									onClick: () => {
-										const selectedWidth = key.toString().split( '-' );
-										const children = getBlocksByClientId( clientId );
-										setAttributes( {
-											layout: key,
-										} );
-										if ( typeof children[ 0 ].innerBlocks !== 'undefined' ) {
-											map( children[ 0 ].innerBlocks, ( blockProps, index ) => (
-												updateBlockAttributes( blockProps.clientId, { width: selectedWidth[ index ] } )
-											) );
-										}
-									},
-								};
-							} ) }
-						>
-						</ToolbarGroup>
-					}
 					<BlockVerticalAlignmentToolbar
 						onChange={ ( alignment ) => {
 							const children = getBlocksByClientId( clientId );

--- a/src/blocks/row/controls.js
+++ b/src/blocks/row/controls.js
@@ -16,7 +16,7 @@ import { BackgroundControls } from '../../components/background';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, BlockVerticalAlignmentToolbar } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 
 class Controls extends Component {
 	// Switches the icon based on the layout selected,
@@ -71,7 +71,7 @@ class Controls extends Component {
 			<Fragment>
 				<BlockControls>
 					{ ( columns && selectedRows > 1 ) &&
-						<Toolbar
+						<ToolbarGroup
 							isCollapsed={ true }
 							icon={ this.layoutIcon() }
 							label={ __( 'Change row block layout', 'coblocks' ) }
@@ -96,7 +96,7 @@ class Controls extends Component {
 								};
 							} ) }
 						>
-						</Toolbar>
+						</ToolbarGroup>
 					}
 					<BlockVerticalAlignmentToolbar
 						onChange={ ( alignment ) => {
@@ -107,7 +107,7 @@ class Controls extends Component {
 									updateBlockAttributes( blockProps.clientId, { verticalAlignment: alignment } )
 								) );
 							}
-							} }
+						} }
 						value={ verticalAlignment }
 					/>
 					{ layout &&


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR changes the component used within the Row block from Toolbar to ToolbarGroup. This change allows for proper use of the toolbar controls while in the editor.

### Screenshots
<!-- if applicable -->
**before**
![image](https://user-images.githubusercontent.com/30462574/94465670-1d576400-0175-11eb-850b-346355d97883.png)

**after**
![image](https://user-images.githubusercontent.com/30462574/94465611-044eb300-0175-11eb-904c-03eb39d8fdc7.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the editor and using Gutenberg plugin.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
