### PR TITLE
Enhance social block style previews

### DIFF
--- a/src/blocks/share/styles/editor.scss
+++ b/src/blocks/share/styles/editor.scss
@@ -1,7 +1,5 @@
 .wp-block-coblocks-social {
-
 	&__button {
-
 		&:active {
 			animation: none !important;
 		}
@@ -26,113 +24,6 @@
 	}
 }
 
-.block-editor-block-styles {
-
-	.wp-block-coblocks-social {
-		align-content: center;
-		align-items: center;
-		background: transparent !important;
-		display: flex;
-		height: 100%;
-		justify-content: center;
-		text-align: center !important;
-
-		&.is-style-mask {
-
-			.wp-block-coblocks-social__icon {
-				height: 32px !important;
-				width: 32px !important;
-			}
-		}
-
-		&.is-style-text,
-		&.is-style-icon-and-text {
-
-			.wp-block-coblocks-social__button {
-				width: 61%;
-			}
-		}
-
-		&.is-style-circular {
-
-			.wp-block-coblocks-social__icon {
-				height: 18px !important;
-				width: 18px !important;
-			}
-
-			.wp-block-coblocks-social__button {
-				padding: 14px !important;
-			}
-		}
-
-		ul {
-			margin: 0;
-		}
-
-		li {
-			display: none;
-			margin: 0 !important;
-
-			&:first-child {
-				display: block;
-			}
-
-			&::before,
-			&::after {
-				display: none;
-			}
-		}
-
-		&__text {
-			max-width: 70%;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
-		}
-
-		&__button {
-			margin: 0;
-			max-width: 100%;
-			padding-left: 10px;
-			padding-right: 10px;
-			width: 100%;
-
-			&.is-empty {
-				opacity: 1 !important;
-			}
-		}
-	}
-
-	.wp-block-coblocks-social-profiles {
-
-		&.is-style-text,
-		&.is-style-icon-and-text {
-
-			.wp-block-coblocks-social__button {
-				width: 96%;
-			}
-		}
-	}
-
-	// Gutenberg 5.9+ tweaks.
-	[data-type="coblocks/social"] [data-block],
-	[data-type="coblocks/social-profiles"] [data-block] {
-		margin-bottom: 0;
-
-		.wp-block-coblocks-social {
-			margin-top: 10px;
-
-			&.is-style-icon {
-				margin-top: 8px;
-			}
-
-			&.is-style-circular {
-				margin-top: 5px;
-			}
-		}
-	}
-}
-
 .components-range-control + .components-coblocks-inspector__social-button-size {
 	margin-top: -13px !important;
 }
@@ -142,20 +33,109 @@
 }
 
 .edit-post-settings-sidebar__panel-block .components-social-icons-list {
-
 	.components-base-control {
 		margin-bottom: 8px;
 	}
 }
 
 .edit-post-settings-sidebar__panel-block .components-social-links-list {
-
 	.components-base-control {
 		margin-bottom: 8px;
 	}
 }
 
-// Shim to get buttons to display correctly in G 6.3+ only.
-.components-panel__body .block-editor-block-preview__container .wp-block-coblocks-social__button {
-	transform: scale(4.2);
+// Styles to handle style previews for both share and social profiles.
+.components-panel__body {
+	.block-editor-block-styles {
+		.block-editor-block-preview__container {
+			height: 100% !important;
+
+			.block-editor-block-preview__content {
+				margin-top: 35%;
+
+				.wp-block-coblocks-social {
+					align-content: center;
+					align-items: center;
+					background: transparent !important;
+					display: flex;
+					height: 100%;
+					justify-content: center;
+					text-align: center !important;
+
+					&.is-style-text,
+					&.is-style-icon-and-text {
+
+						&.wp-block-coblocks-social-profiles {
+							.wp-block-coblocks-social__button {
+								transform: scale(3);
+							}
+						}
+
+						.wp-block-coblocks-social__button {
+							transform: scale(2);
+						}
+					}
+
+					&.is-style-mask {
+						.wp-block-coblocks-social__icon {
+							height: 32px !important;
+							width: 32px !important;
+						}
+					}
+
+					&.is-style-circular {
+						.wp-block-coblocks-social__icon {
+							height: 18px !important;
+							width: 18px !important;
+						}
+
+						.wp-block-coblocks-social__button {
+							padding: 14px !important;
+						}
+					}
+
+					.wp-block-coblocks-social__button {
+						transform: scale(4.1);
+					}
+
+					ul {
+						margin: 0;
+					}
+
+					li {
+						display: none;
+						margin: 0 !important;
+
+						&:first-child {
+							display: block;
+						}
+
+						&::before,
+						&::after {
+							display: none;
+						}
+					}
+
+					&__text {
+						max-width: 95%;
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
+					}
+
+					&__button {
+						margin: 0;
+						max-width: 100%;
+						padding-left: 10px;
+						padding-right: 10px;
+						width: 100%;
+
+						&.is-empty {
+							opacity: 1 !important;
+						}
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Block alternate style previews and the associated CSS styles have changed over time. The style changes have resulted in a broken user interface for selecting styles where a user cannot properly preview the alternate styles. Changes in this PR fix the appearance of the block style previews so a user may properly preview the alternate block styles.


### Screenshots
<!-- if applicable -->
**Before**
![image](https://user-images.githubusercontent.com/30462574/94704603-ef992900-02f4-11eb-8695-e44f00430de8.png)

**After**
![image](https://user-images.githubusercontent.com/30462574/94704536-ddb78600-02f4-11eb-9bd8-80a5ab2988ac.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
CSS changes that apply to both Share and Social Profiles blocks.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually, E2E, with Go and TwentyTwenty as well as running the Gutenberg plugin.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
