### PR TITLE
Fix carousel arrows in an RTL environment

### DIFF
--- a/src/blocks/gallery-carousel/styles/style.scss
+++ b/src/blocks/gallery-carousel/styles/style.scss
@@ -177,3 +177,21 @@
 		}
 	}
 }
+
+body.rtl {
+
+	.flickity-viewport {
+		position: relative;
+	}
+
+	.flickity-prev-next-button {
+
+		&.next {
+			left: 0;
+		}
+
+		&.previous {
+			left: unset;
+		}
+	}
+}

--- a/src/blocks/gallery-carousel/test/gallery-carousel.cypress.js
+++ b/src/blocks/gallery-carousel/test/gallery-carousel.cypress.js
@@ -122,7 +122,7 @@ describe( 'Test CoBlocks Gallery Carousel Block', function() {
 			}
 		} );
 
-		cy.get( '[data-type="coblocks/gallery-carousel"]' ).find( 'figcaption' ).click().type( caption );
+		cy.get( '[data-type="coblocks/gallery-carousel"]' ).find( 'figcaption' ).focus().type( caption );
 
 		helpers.savePage();
 


### PR DESCRIPTION
### Description
Fix the carousel arrows in an RTL environment.

### Screenshots
***Note:*** I changed the arrow button background to black in the DOM for the screenshot so the arrow icons were easier to see.
![image](https://user-images.githubusercontent.com/5321364/94736253-eed6b600-0339-11eb-8998-44c89c7d9dbf.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested in an RTL environment.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
