### PR TITLE
Fix post carousel arrows/text-align when in an RTL environment

### DIFF
--- a/src/blocks/post-carousel/styles/editor.scss
+++ b/src/blocks/post-carousel/styles/editor.scss
@@ -27,3 +27,21 @@
 	padding-top: 100%;
 	width: 100%;
 }
+
+body.rtl {
+
+	.slick-slider.coblocks-slick {
+		text-align: left; // opposite, rtl converts left to right.
+	}
+
+	.wp-block-coblocks-post-carousel:not(.alignwide) {
+
+		.slick-prev::before {
+			background-image: url(images/lightbox/arrow-right.svg);
+		}
+
+		.slick-next::before {
+			background-image: url(images/lightbox/arrow-left.svg);
+		}
+	}
+}

--- a/src/blocks/post-carousel/styles/style.scss
+++ b/src/blocks/post-carousel/styles/style.scss
@@ -83,5 +83,19 @@
 	}
 }
 
+body.rtl {
+
+	.wp-block-coblocks-post-carousel:not(.alignwide) {
+
+		.slick-prev::before {
+			background-image: url(images/lightbox/arrow-right.svg);
+		}
+
+		.slick-next::before {
+			background-image: url(images/lightbox/arrow-left.svg);
+		}
+	}
+}
+
 // Import style tweaks for core WordPress themes
 @import "theme";


### PR DESCRIPTION
### Description
Fix the post carousel arrows in the editor and front end, and fix the text align in the post carousel block in an RTL environment.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/94739144-7f16fa00-033e-11eb-92cc-7f672b724e34.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested in an RTL environment.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->>
