### PR TITLE
Fix formattingControls console warnings

### DIFF
--- a/src/blocks/click-to-tweet/edit.js
+++ b/src/blocks/click-to-tweet/edit.js
@@ -81,7 +81,7 @@ class Edit extends Component {
 						/* translators: the text of the click to tweet element */
 						placeholder={ __( 'Add a quote to tweet…', 'coblocks' ) }
 						value={ content }
-						formattingControls={ [] } // disable controls
+						allowedFormats={ [] } // disable controls
 						className={ classnames(
 							'wp-block-coblocks-click-to-tweet__text', {
 								'has-text-color': textColor.color,
@@ -108,7 +108,7 @@ class Edit extends Component {
 						multiline="false"
 						placeholder={ __( 'Add button…', 'coblocks' ) }
 						value={ buttonText }
-						formattingControls={ [] } // disable controls
+						allowedFormats={ [] } // disable controls
 						className={ classnames(
 							'wp-block-coblocks-click-to-tweet__twitter-btn', {
 								'has-button-color': buttonColor.color,

--- a/src/blocks/click-to-tweet/test/click-to-tweet.cypress.js
+++ b/src/blocks/click-to-tweet/test/click-to-tweet.cypress.js
@@ -31,7 +31,7 @@ describe( 'Test CoBlocks Click to Tweet Block', function() {
 		cy.get( '.wp-block-coblocks-click-to-tweet' ).click( { force: true } );
 
 		cy.get( '.wp-block-coblocks-click-to-tweet__via' ).type( 'TestUsername' );
-		cy.get( '.wp-block-coblocks-click-to-tweet__text' ).type( 'Some custom data here.' );
+		cy.get( '.wp-block-coblocks-click-to-tweet__text' ).focus().type( 'Some custom data here.' );
 
 		helpers.savePage();
 

--- a/src/blocks/food-and-drinks/food-item/edit.js
+++ b/src/blocks/food-and-drinks/food-item/edit.js
@@ -280,7 +280,7 @@ class FoodItem extends Component {
 
 		const richTextAttributes = {
 			keepPlaceholderOnFocus: true,
-			formattingControls: [ 'bold', 'italic' ],
+			allowedFormats: [ 'bold', 'italic' ],
 		};
 
 		return (

--- a/src/blocks/food-and-drinks/food-item/test/food-item.cypress.js
+++ b/src/blocks/food-and-drinks/food-item/test/food-item.cypress.js
@@ -4,7 +4,6 @@
 import * as helpers from '../../../../../.dev/tests/cypress/helpers';
 
 describe( 'Block: Food Item', () => {
-
 	beforeEach( () => {
 		helpers.addBlockToPost( 'coblocks/food-and-drinks', true );
 	} );
@@ -15,24 +14,23 @@ describe( 'Block: Food Item', () => {
 	} );
 
 	it( 'removes .is-empty when the \'title\', \'description\', \'price\' attributes have content', () => {
-		cy.get( '[data-type="coblocks/food-item"]' ).first().click().within( () => {
-
-			// Set heading.
-			cy.get( '.wp-block-coblocks-food-item__heading .block-editor-rich-text__editable' ).type( 'item heading' );
+		cy.get( '[data-type="coblocks/food-item"]' ).first().within( () => {
+		// Set heading.
+			cy.get( '.wp-block-coblocks-food-item__heading .block-editor-rich-text__editable' ).focus().type( 'item heading', { force: true } );
 			cy.get( '.wp-block-coblocks-food-item' ).should( 'not.have.class', 'is-empty' );
-			cy.get( '.wp-block-coblocks-food-item__heading .block-editor-rich-text__editable' ).type( '{selectall}{del}' );
+			cy.get( '.wp-block-coblocks-food-item__heading .block-editor-rich-text__editable' ).focus().type( '{selectall}{del}', { force: true } );
 			cy.get( '.wp-block-coblocks-food-item' ).should( 'have.class', 'is-empty' );
 
 			// Set price.
-			cy.get( '.wp-block-coblocks-food-item__price .block-editor-rich-text__editable' ).type( 'item price' );
+			cy.get( '.wp-block-coblocks-food-item__price .block-editor-rich-text__editable' ).focus().type( 'item price', { force: true } );
 			cy.get( '.wp-block-coblocks-food-item' ).should( 'not.have.class', 'is-empty' );
-			cy.get( '.wp-block-coblocks-food-item__price .block-editor-rich-text__editable' ).type( '{selectall}{del}' );
+			cy.get( '.wp-block-coblocks-food-item__price .block-editor-rich-text__editable' ).focus().type( '{selectall}{del}', { force: true } );
 			cy.get( '.wp-block-coblocks-food-item' ).should( 'have.class', 'is-empty' );
 
 			// Set description.
-			cy.get( '.wp-block-coblocks-food-item__description .block-editor-rich-text__editable' ).type( 'item description' );
+			cy.get( '.wp-block-coblocks-food-item__description .block-editor-rich-text__editable' ).focus().type( 'item description', { force: true } );
 			cy.get( '.wp-block-coblocks-food-item' ).should( 'not.have.class', 'is-empty' );
-			cy.get( '.wp-block-coblocks-food-item__description .block-editor-rich-text__editable' ).type( '{selectall}{del}' );
+			cy.get( '.wp-block-coblocks-food-item__description .block-editor-rich-text__editable' ).focus().type( '{selectall}{del}', { force: true } );
 			cy.get( '.wp-block-coblocks-food-item' ).should( 'have.class', 'is-empty' );
 		} );
 	} );
@@ -74,9 +72,9 @@ describe( 'Block: Food Item', () => {
 			vegan: /vegan/i,
 			vegetarian: /vegetarian/i,
 		} ).forEach( ( [ className, controlLabel ] ) => {
-			cy.get( '[data-type="coblocks/food-item"]' ).first().find( `.wp-block-coblocks-food-item__attribute--${className}` ).should( 'not.exist' );
+			cy.get( '[data-type="coblocks/food-item"]' ).first().find( `.wp-block-coblocks-food-item__attribute--${ className }` ).should( 'not.exist' );
 			cy.get( '.components-base-control__field' ).contains( controlLabel ).click();
-			cy.get( '[data-type="coblocks/food-item"]' ).first().find( `.wp-block-coblocks-food-item__attribute--${className}` ).should( 'exist' );
+			cy.get( '[data-type="coblocks/food-item"]' ).first().find( `.wp-block-coblocks-food-item__attribute--${ className }` ).should( 'exist' );
 		} );
 
 		helpers.checkForBlockErrors( 'coblocks/food-item' );
@@ -93,7 +91,7 @@ describe( 'Block: Food Item', () => {
 		cy.get( '[data-type="coblocks/food-item"]' ).first().find( '.block-editor-media-placeholder' ).should( 'exist' );
 
 		// Drag-and-drop a file to upload.
-		helpers.upload.imageToBlock('coblocks/food-item');
+		helpers.upload.imageToBlock( 'coblocks/food-item' );
 
 		// Assert that the image was added.
 		cy.get( '[data-type="coblocks/food-item"] img[src*="http"]' )

--- a/src/blocks/form/fields/submit-button/edit.js
+++ b/src/blocks/form/fields/submit-button/edit.js
@@ -104,7 +104,7 @@ class CoBlocksSubmitButton extends Component {
 						onChange={ ( nextValue ) => setAttributes( { submitButtonText: nextValue } ) }
 						className={ this.getButtonClasses() }
 						style={ buttonStyle }
-						formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+						allowedFormats={ [ 'bold', 'italic', 'strikethrough' ] }
 						keepPlaceholderOnFocus
 					/>
 				</div>

--- a/src/blocks/pricing-table/pricing-table-item/edit.js
+++ b/src/blocks/pricing-table/pricing-table-item/edit.js
@@ -51,7 +51,7 @@ class Edit extends Component {
 			placeholder,
 		} = attributes;
 
-		const formattingControls = [ 'bold', 'italic', 'strikethrough' ];
+		const allowedFormats = [ 'bold', 'italic', 'strikethrough' ];
 
 		return (
 			<Fragment>
@@ -80,7 +80,7 @@ class Edit extends Component {
 						onChange={ ( nextTitle ) => setAttributes( { title: nextTitle } ) }
 						value={ title }
 						placeholder={ placeholder || __( 'Plan A', 'coblocks' ) }
-						formattingControls={ formattingControls }
+						allowedFormats={ allowedFormats }
 						keepPlaceholderOnFocus
 					/>
 					<div className="wp-block-coblocks-pricing-table-item__price-wrapper">
@@ -90,7 +90,7 @@ class Edit extends Component {
 							onChange={ ( nextCurrency ) => setAttributes( { currency: nextCurrency } ) }
 							value={ currency }
 							placeholder={ __( '$', 'coblocks' ) }
-							formattingControls={ formattingControls }
+							allowedFormats={ allowedFormats }
 							keepPlaceholderOnFocus
 						/>
 						<RichText
@@ -99,7 +99,7 @@ class Edit extends Component {
 							onChange={ ( nextAmount ) => setAttributes( { amount: nextAmount } ) }
 							value={ amount }
 							placeholder="99"
-							formattingControls={ formattingControls }
+							allowedFormats={ allowedFormats }
 							keepPlaceholderOnFocus
 						/>
 					</div>

--- a/src/blocks/pricing-table/pricing-table-item/test/pricing-table-item.cypress.js
+++ b/src/blocks/pricing-table/pricing-table-item/test/pricing-table-item.cypress.js
@@ -45,12 +45,12 @@ describe( 'Test CoBlocks Pricing Table Item Block', function() {
 		const { textColor, backgroundColor, textColorRGB, backgroundColorRGB, title, currency, amount, features, buttonText } = pricingTableItemData;
 		helpers.addBlockToPost( 'coblocks/pricing-table', true );
 
-		cy.get( '.wp-block-coblocks-pricing-table-item' ).first().click().then( $firstItem => {
-			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__title' ).click().type( `{selectall}${title}` );
-			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__currency' ).click().type( `{selectall}${currency}` );
-			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__amount' ).click().type( `{selectall}${amount}` );
-			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__features' ).click().type( `{selectall} ${features}` );
-			cy.get( $firstItem ).find( '.wp-block-button' ).find( 'div[role="textbox"]' ).click().type( `{selectall}${buttonText}` );
+		cy.get( '.wp-block-coblocks-pricing-table-item' ).first().click().then( ( $firstItem ) => {
+			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__title' ).focus().type( `{selectall}${ title }` );
+			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__currency' ).focus().type( `{selectall}${ currency }` );
+			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__amount' ).focus().type( `{selectall}${ amount }` );
+			cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__features' ).focus().type( `{selectall} ${ features }` );
+			cy.get( $firstItem ).find( '.wp-block-button' ).find( 'div[role="textbox"]' ).focus().type( `{selectall}${ buttonText }` );
 
 			cy.get( $firstItem ).click( 'topRight' );
 			helpers.setColorSetting( 'background color', backgroundColor );
@@ -69,7 +69,7 @@ describe( 'Test CoBlocks Pricing Table Item Block', function() {
 			.should( 'have.css', 'color', textColorRGB );
 
 		cy.get( '.wp-block-coblocks-pricing-table-item' ).first()
-			.then( $firstItem => {
+			.then( ( $firstItem ) => {
 				cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__title' ).should( 'have.html', title );
 				cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__currency' ).should( 'have.html', currency );
 				cy.get( $firstItem ).find( '.wp-block-coblocks-pricing-table-item__amount' ).should( 'have.html', amount );


### PR DESCRIPTION
### Description
Fix the console warning being thrown due to `formattingControls` being deprecated in favor of `allowedFormats`.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested each block for any regressions, ran related jest tests and checked that the console warnings are now gone.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
