### PR TITLE
Remove deprecated isLarge prop from button componnets

### DIFF
--- a/src/blocks/events/edit.js
+++ b/src/blocks/events/edit.js
@@ -182,7 +182,7 @@ class EventsEdit extends Component {
 							onChange={ ( newExternalCalendarUrl ) => this.setState( { externalCalendarUrl: newExternalCalendarUrl } ) }
 							className={ 'components-placeholder__input' }
 						/>
-						<Button isLarge type="button" onClick={ this.saveExternalCalendarUrl } disabled={ ! this.state.externalCalendarUrl }>
+						<Button type="button" onClick={ this.saveExternalCalendarUrl } disabled={ ! this.state.externalCalendarUrl }>
 							{ __( 'Use URL', 'coblocks' ) }
 						</Button>
 					</Placeholder>

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -428,7 +428,6 @@ class FormEdit extends Component {
 							<div className="components-base-control">
 								<Button
 									isPrimary
-									isLarge
 									onClick={ this.saveRecaptchaKey }
 									disabled={
 										this.state.recaptchaSiteKey === '' ||
@@ -441,7 +440,6 @@ class FormEdit extends Component {
 									this.state.recaptchaSecretKey !== '' && (
 									<Button
 										className="components-block-coblocks-form-recaptcha-key-remove__button"
-										isLarge
 										isSecondary
 										onClick={ this.removeRecaptchaKey }
 										disabled={ this.state.recaptchaSiteKey === '' || this.state.recaptchaSecretKey === '' }

--- a/src/blocks/icon/inspector.js
+++ b/src/blocks/icon/inspector.js
@@ -153,8 +153,8 @@ class Inspector extends Component {
 			<Fragment>
 				<InspectorControls>
 					<PanelBody title={ __( 'Icon settings', 'coblocks' ) }>
-						{ iconSize === 'advanced' ?
-							<Fragment>
+						{ iconSize === 'advanced'
+							? <Fragment>
 								<div className="components-base-control components-coblocks-icon-block--advanced-size">
 									<Button
 										type="button"
@@ -180,8 +180,8 @@ class Inspector extends Component {
 										step={ 1 }
 									/>
 								</div>
-							</Fragment> :
-							<BaseControl label={ label } help={ help }>
+							</Fragment>
+							: <BaseControl label={ label } help={ help }>
 								<div className="components-coblocks-icon-size__controls">
 									<IconSizeSelect
 										setAttributes={ setAttributes }
@@ -233,10 +233,9 @@ class Inspector extends Component {
 						/>
 						<div className="coblocks-icon-types-list-wrapper">
 							<ul className="block-editor-block-types-list coblocks-icon-types-list">
-								{ ! this.state.isSearching ?
-									<li className="block-editor-block-types-list__list-item selected-svg">
+								{ ! this.state.isSearching
+									? <li className="block-editor-block-types-list__list-item selected-svg">
 										<Button
-											isLarge
 											className="editor-block-list-item-button"
 											onClick={ () => {
 												return false;
@@ -246,11 +245,11 @@ class Inspector extends Component {
 												{ icon && svg[ iconStyle ][ icon ].icon }
 											</span>
 										</Button>
-									</li> :
-									null
+									</li>
+									: null
 								}
-								{ Object.keys( this.state.filteredIcons[ iconStyle ] ).length > 0 ?
-									Object.keys( this.state.filteredIcons[ iconStyle ] ).map( ( keyName, i ) => {
+								{ Object.keys( this.state.filteredIcons[ iconStyle ] ).length > 0
+									? Object.keys( this.state.filteredIcons[ iconStyle ] ).map( ( keyName, i ) => {
 										return (
 											<li key={ `editor-pblock-types-list-item-${ i }` } className={ classnames(
 												'block-editor-block-types-list__list-item', {
@@ -258,7 +257,6 @@ class Inspector extends Component {
 											) }>
 												<Tooltip text={ ( svg[ iconStyle ][ keyName ].label ) ? svg[ iconStyle ][ keyName ].label : keyName }>
 													<Button
-														isLarge
 														isSecondary
 														isPrimary={ icon && icon === keyName }
 														className="editor-block-list-item-button"
@@ -273,8 +271,8 @@ class Inspector extends Component {
 												</Tooltip>
 											</li>
 										);
-									} ) :
-									<li className="no-results"> { __( 'No results found.', 'coblocks' ) } </li>
+									} )
+									: <li className="no-results"> { __( 'No results found.', 'coblocks' ) } </li>
 								}
 							</ul>
 						</div>

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -292,7 +292,6 @@ class Edit extends Component {
 								}
 							/>
 							<Button
-								isLarge
 								isPrimary={ !! this.state.address }
 								isSecondary={ ! this.state.address }
 								type="submit"

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -220,7 +220,6 @@ class Inspector extends Component {
 						/>
 						<Button
 							isPrimary
-							isLarge
 							onClick={ this.updateApiKey }
 							disabled={ ( this.state.apiKey === '' ) || ( this.state.apiKey === this.props.apiKey ) }
 						>
@@ -230,7 +229,6 @@ class Inspector extends Component {
 						<Button
 							className="components-block-coblocks-map-api-key-remove__button"
 							isSecondary
-							isLarge
 							onClick={ this.removeApiKey }
 							disabled={ this.state.apiKey !== this.props.apiKey || ! this.state.apiKey }
 						>

--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -185,7 +185,6 @@ class PostCarousel extends Component {
 								<Button
 									className="components-placeholder__cancel-button"
 									title={ __( 'Retrieve an external feed', 'coblocks' ) }
-									isLarge
 									isSecondary
 									onClick={ () => {
 										setAttributes( { postFeedType: 'external' } );

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -289,7 +289,6 @@ class PostsEdit extends Component {
 								<Button
 									className="components-placeholder__cancel-button"
 									title={ __( 'Retrieve an External Feed', 'coblocks' ) }
-									isLarge
 									isSecondary
 									onClick={ () => {
 										setAttributes( { postFeedType: 'external' } );

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -162,7 +162,6 @@ class Edit extends Component {
 										<div className="components-coblocks-row-placeholder__button-wrapper">
 											<Button
 												className="components-coblocks-row-placeholder__button block-editor-inner-blocks__template-picker-option block-editor-block-pattern-picker__pattern"
-												isLarge
 												isSecondary
 												onClick={ () => {
 													setAttributes( {
@@ -200,7 +199,6 @@ class Edit extends Component {
 												<Button
 													key={ key }
 													className="components-coblocks-row-placeholder__button block-editor-inner-blocks__template-picker-option block-editor-block-pattern-picker__pattern"
-													isLarge
 													isSecondary
 													onClick={ () => {
 														setAttributes( {
@@ -294,14 +292,14 @@ class Edit extends Component {
 					) }
 					<div className={ classes }>
 						{ isBlobURL( backgroundImg ) && <Spinner /> }
-            <GutterWrapper { ...attributes }>
-              <div className={ innerClasses } style={ innerStyles }>
-                { BackgroundVideo( attributes ) }
-                { this.supportsBlockVariationPicker()
-                  ? variationInnerBlocks()
-                  : deprecatedInnerBlocks() }
-              </div>
-            </GutterWrapper>
+						<GutterWrapper { ...attributes }>
+							<div className={ innerClasses } style={ innerStyles }>
+								{ BackgroundVideo( attributes ) }
+								{ this.supportsBlockVariationPicker()
+									? variationInnerBlocks()
+									: deprecatedInnerBlocks() }
+							</div>
+						</GutterWrapper>
 					</div>
 				</Fragment>
 			);

--- a/src/components/crop-settings/index.js
+++ b/src/components/crop-settings/index.js
@@ -298,14 +298,12 @@ class CropSettings extends Component {
 				<div className="components-coblocks-rotate-control">
 					<ButtonGroup >
 						<Button
-							isLarge
 							isSecondary
 							icon={ rotateLeft }
 							label={ __( 'Rotate counter-clockwise', 'coblocks' ) }
 							onClick={ () => this.applyRotation( self.state.r - 90 ) }
 						/>
 						<Button
-							isLarge
 							isSecondary
 							icon={ rotateRight }
 							label={ __( 'Rotate clockwise', 'coblocks' ) }

--- a/src/components/size-control/index.js
+++ b/src/components/size-control/index.js
@@ -167,7 +167,6 @@ class SizeControl extends Component {
 						{ map( this.getSizes(), ( { size, shortName } ) => (
 							<Button
 								key={ size }
-								isLarge
 								isSecondary={ value !== size }
 								isPrimary={ value === size }
 								aria-pressed={ value === size }

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -70,7 +70,7 @@ const LayoutPreview = ( { layout, isSelected, registeredBlocks, onClick } ) => {
 			onMouseLeave={ () => setOverlay( false ) }>
 
 			<div className={ classnames( 'coblocks-layout-selector__layout--overlay', { 'is-active': overlay } ) }>
-				<Button isLarge isPressed>
+				<Button isPressed>
 					{ __( 'Select Layout', 'coblocks' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
### Description
The Button component provided by core had deprecated the prop `isLarge` over time. CoBlocks has a number of instances of the use of this deprecated prop resulting in warning notices within the browser console. This PR will remove all un-needed references to unused props to resolve these notices.

Reviewed all instances where this property has been removed in both 5.5.1 as well as 5.4.2 and have decided there are no aesthetic changes between these versions. These properties should be safe to remove without issues. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. Editor UI components only.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
