### PR TITLE
Extracting toggle control for Layout Selector into it's own component

### DIFF
--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -10,7 +10,6 @@ import CoBlocksSettingsModalControls from './coblocks-settings-slot';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
-import { getPlugin } from '@wordpress/plugins';
 import {
 	CheckboxControl,
 	Modal,
@@ -97,18 +96,13 @@ class CoBlocksSettingsModal extends Component {
 		setGradients();
 	}
 
-	updateLayoutSelectorSetting() {
-		const { setLayoutSelector } = this.props;
-		setLayoutSelector();
-	}
-
 	updateTypographyControlsSetting() {
 		const { setTypography } = this.props;
 		setTypography();
 	}
 
 	render() {
-		const { isOpen, closeModal, typography, customColors, gradientControls, getSettings, colorPanel, layoutSelector } = this.props;
+		const { isOpen, closeModal, typography, customColors, gradientControls, getSettings, colorPanel } = this.props;
 
 		if ( ! isOpen ) {
 			return null;
@@ -116,7 +110,6 @@ class CoBlocksSettingsModal extends Component {
 
 		const supportsGradients = getSettings().gradients !== undefined;
 		const colorPanelEnabled = !! colorPanel;
-		const showLayoutSelectorControl = applyFilters( 'coblocks-show-layout-selector', true ) && !! getPlugin( 'coblocks-layout-selector' );
 
 		const settings = applyFilters( 'coblocks-settings-modal-controls', [] );
 
@@ -129,18 +122,6 @@ class CoBlocksSettingsModal extends Component {
 					<Section title={ __( 'General' ) }>
 
 						<CoBlocksSettingsModalControls.Slot />
-
-						{ showLayoutSelectorControl &&
-							<CoBlocksSettingsModalControls>
-								<HorizontalRule />
-								<CheckboxControl
-									label={ __( 'Layout selector', 'coblocks' ) }
-									help={ __( 'Allow layout selection on new pages.', 'coblocks' ) }
-									onChange={ () => this.updateLayoutSelectorSetting() }
-									checked={ !! layoutSelector }
-								/>
-							</CoBlocksSettingsModalControls>
-						}
 
 						<CoBlocksSettingsModalControls>
 							<HorizontalRule />
@@ -202,7 +183,7 @@ class CoBlocksSettingsModal extends Component {
 }
 
 const applyWithSelect = withSelect( () => {
-	const { getTypography, getCustomColors, getGradients, getColorPanel, getLayoutSelector } = select( 'coblocks-settings' );
+	const { getTypography, getCustomColors, getGradients, getColorPanel } = select( 'coblocks-settings' );
 	const { getSettings } = select( 'core/block-editor' );
 
 	return {
@@ -210,20 +191,18 @@ const applyWithSelect = withSelect( () => {
 		customColors: getCustomColors(),
 		gradientControls: getGradients(),
 		colorPanel: getColorPanel(),
-		layoutSelector: getLayoutSelector(),
 		getSettings,
 	};
 } );
 
 const applyWithDispatch = withDispatch( ( dispatch ) => {
-	const { setTypography, setCustomColors, setGradients, setColorPanel, setLayoutSelector } = dispatch( 'coblocks-settings' );
+	const { setTypography, setCustomColors, setGradients, setColorPanel } = dispatch( 'coblocks-settings' );
 	const { updateSettings } = dispatch( 'core/block-editor' );
 
 	return {
 		setColorPanel,
 		setCustomColors,
 		setTypography,
-		setLayoutSelector,
 		setGradients,
 		updateSettings,
 	};

--- a/src/extensions/coblocks-settings/coblocks-settings-store.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-store.js
@@ -4,7 +4,6 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { applyFilters } from '@wordpress/hooks';
 
 export default function createCoBlocksStore() {
 	const settingsNonce = coblocksSettings.coblocksSettingsNonce;
@@ -16,10 +15,7 @@ export default function createCoBlocksStore() {
 		colorsPanel: true,
 		gradients: true,
 		typography: true,
-		layoutSelector: false, // default false to prevent screen flicker.
 	};
-
-	const layoutSelectorEnabled = applyFilters( 'coblocks-show-layout-selector', true )
 
 	apiFetch( {
 		path: '/wp/v2/settings/',
@@ -31,14 +27,10 @@ export default function createCoBlocksStore() {
 		settings.gradients = res.coblocks_gradient_presets_enabled || false;
 		settings.typography = res.coblocks_typography_controls_enabled || false;
 		settings.colorsPanel = res.coblocks_color_panel_controls_enabled || false;
-		settings.layoutSelector = layoutSelectorEnabled ? res.coblocks_layout_selector_controls_enabled || false : false;
 		storeChanged();
 	} );
 
 	const selectors = {
-		getLayoutSelector( ) {
-			return settings.layoutSelector;
-		},
 		getCustomColors( ) {
 			return settings.customColors;
 		},
@@ -101,21 +93,6 @@ export default function createCoBlocksStore() {
 				},
 				data: {
 					coblocks_gradient_presets_enabled: toggle,
-				},
-			} );
-		},
-		setLayoutSelector( ) {
-			const toggle = ! settings.layoutSelector;
-			settings.layoutSelector = toggle;
-			storeChanged();
-			apiFetch( {
-				path: '/wp/v2/settings/',
-				method: 'POST',
-				headers: {
-					'X-WP-Nonce': settingsNonce,
-				},
-				data: {
-					coblocks_layout_selector_controls_enabled: toggle,
 				},
 			} );
 		},

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -1,3 +1,4 @@
+/* eslint camelcase: ["error", {allow: ["coblocks_layout_selector_controls_enabled"]}] */
 /* global coblocksLayoutSelector */
 /**
  * External dependencies
@@ -402,13 +403,14 @@ registerPlugin( 'coblocks-layout-selector', {
 				hasEditorUndo,
 				isCurrentPostPublished,
 			} = select( 'core/editor' );
-			const { getLayoutSelector } = select( 'coblocks-settings' );
 			const {
 				getBlockAttributes,
 				getBlockName,
 				getClientIdsWithDescendants,
 				getSettings,
 			} = select( 'core/block-editor' );
+
+			const { coblocks_layout_selector_controls_enabled } = select( 'core' ).getEditedEntityRecord( 'root', 'site' );
 
 			const isDraft = [ 'draft' ].indexOf( getCurrentPostAttribute( 'status' ) ) !== -1;
 			const isCleanUnpublishedPost = ! isCurrentPostPublished() && ! hasEditorUndo() && ! isDraft;
@@ -418,7 +420,7 @@ registerPlugin( 'coblocks-layout-selector', {
 
 			return {
 				isActive: isCleanUnpublishedPost || isTemplateSelectorActive(),
-				layoutSelectorEnabled: getLayoutSelector() && !! layouts.length && !! categories.length,
+				layoutSelectorEnabled: !! coblocks_layout_selector_controls_enabled && !! layouts.length && !! categories.length,
 				layouts,
 				categories,
 				mediaUpload: getSettings().mediaUpload,

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -23,6 +23,7 @@ import { createBlock, rawHandler } from '@wordpress/blocks';
  * Internal dependencies
  */
 import './store';
+import LayoutSelectorControl from './settings-modal-control';
 
 const getBlocksFromTemplate = ( name, attributes, innerBlocks = [] ) => {
 	return createBlock( name, attributes,
@@ -303,142 +304,141 @@ class LayoutSelector extends Component {
 			layoutSelectorEnabled,
 		} = this.props;
 
-		if ( ! layoutSelectorEnabled ) {
-			return null;
-		}
+		return (
+			<Fragment>
+				<LayoutSelectorControl />
+				{ isActive && layoutSelectorEnabled &&
+					<Modal
+						title={ (
+							<Fragment>
+								{ __( 'Add new page', 'coblocks' ) }
+								<span>{ __( 'Pick one of these layouts or start with a blank page', 'coblocks' ) }</span>
+							</Fragment>
+						) }
+						onRequestClose={ () => {
+							this.useEmptyTemplateLayout();
+							closeTemplateSelector();
+						} }
+						className="coblocks-layout-selector-modal">
 
-		return ! isActive ? null : (
-			<Modal
-				title={ (
-					<Fragment>
-						{ __( 'Add new page', 'coblocks' ) }
-						<span>{ __( 'Pick one of these layouts or start with a blank page', 'coblocks' ) }</span>
-					</Fragment>
-				) }
-				onRequestClose={ () => {
-					this.useEmptyTemplateLayout();
-					closeTemplateSelector();
-				} }
-				className="coblocks-layout-selector-modal">
+						<div className="coblocks-layout-selector">
+							<aside className="coblocks-layout-selector__sidebar">
+								<ul className="coblocks-layout-selector__sidebar__items">
+									{ this.props.categories.filter( ( category ) => this.hasLayoutsInCategory( category.slug ) ).map( ( category, index ) => (
+										<SidebarItem
+											key={ index }
+											slug={ category.slug }
+											title={ category.title }
+											isSelected={ category.slug === selectedCategory }
+											onClick={ () => this.setState( { selectedCategory: category.slug } ) }
+										/>
+									) ) }
+								</ul>
 
-				<div className="coblocks-layout-selector">
-					<aside className="coblocks-layout-selector__sidebar">
-						<ul className="coblocks-layout-selector__sidebar__items">
-							{ this.props.categories.filter( ( category ) => this.hasLayoutsInCategory( category.slug ) ).map( ( category, index ) => (
-								<SidebarItem
-									key={ index }
-									slug={ category.slug }
-									title={ category.title }
-									isSelected={ category.slug === selectedCategory }
-									onClick={ () => this.setState( { selectedCategory: category.slug } ) }
-								/>
-							) ) }
-						</ul>
+								<Button
+									className="coblocks-layout-selector__add-button"
+									onClick={ () => {
+										this.useEmptyTemplateLayout();
+										closeTemplateSelector();
+									} }
+									isLink>
+									<span><SVG width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><Path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z" ></Path></SVG></span>
+									{ __( 'Add blank page', 'coblocks' ) }
+								</Button>
+							</aside>
 
-						<Button
-							className="coblocks-layout-selector__add-button"
-							onClick={ () => {
-								this.useEmptyTemplateLayout();
-								closeTemplateSelector();
-							} }
-							isLink>
-							<span><SVG width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><Path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z" ></Path></SVG></span>
-							{ __( 'Add blank page', 'coblocks' ) }
-						</Button>
-					</aside>
+							<div className="coblocks-layout-selector__topbar">
+								<div className="coblocks-layout-selector__topbar__left">
+									<strong>{ __( 'Layouts', 'coblocks' ) }:</strong> { selectedCategory }
+									<DropdownMenu label="Select a layout category">
+										{ ( { onClose } ) => (
+											<Fragment>
+												<MenuGroup onClick={ onClose }>
+													{ this.state.templates.map( ( category, index ) => {
+														return (
+															<MenuItem key={ index } onClick={ () => {
+																this.setState( { selectedCategory: category.label } );
+																onClose();
+															} }>
+																{ category.label }
+															</MenuItem>
+														);
+													} ) }
+												</MenuGroup>
+											</Fragment>
+										) }
+									</DropdownMenu>
+								</div>
+								<div className="coblocks-layout-selector__topbar__right">
+									<Button
+										className="coblocks-layout-selector__add-button"
+										onClick={ () => {
+											this.useEmptyTemplateLayout();
+											closeTemplateSelector();
+										} }
+										isLink>
+										<span><Icon icon="plus" size={ 16 } /></span> { __( 'Add blank page', 'coblocks' ) }
+									</Button>
+								</div>
+							</div>
 
-					<div className="coblocks-layout-selector__topbar">
-						<div className="coblocks-layout-selector__topbar__left">
-							<strong>{ __( 'Layouts', 'coblocks' ) }:</strong> { selectedCategory }
-							<DropdownMenu label="Select a layout category">
-								{ ( { onClose } ) => (
-									<Fragment>
-										<MenuGroup onClick={ onClose }>
-											{ this.state.templates.map( ( category, index ) => {
-												return (
-													<MenuItem key={ index } onClick={ () => {
-														this.setState( { selectedCategory: category.label } );
-														onClose();
-													} }>
-														{ category.label }
-													</MenuItem>
-												);
-											} ) }
-										</MenuGroup>
-									</Fragment>
-								) }
-							</DropdownMenu>
+							<div className="coblocks-layout-selector__content">
+								{ this.renderContent( selectedCategory ) }
+							</div>
 						</div>
-						<div className="coblocks-layout-selector__topbar__right">
-							<Button
-								className="coblocks-layout-selector__add-button"
-								onClick={ () => {
-									this.useEmptyTemplateLayout();
-									closeTemplateSelector();
-								} }
-								isLink>
-								<span><Icon icon="plus" size={ 16 } /></span> { __( 'Add blank page', 'coblocks' ) }
-							</Button>
-						</div>
-					</div>
-
-					<div className="coblocks-layout-selector__content">
-						{ this.renderContent( selectedCategory ) }
-					</div>
-				</div>
-			</Modal>
+					</Modal>
+				}
+			</Fragment>
 		);
 	}
 }
 
-if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.postTypeEnabled ) {
-	registerPlugin( 'coblocks-layout-selector', {
-		render: compose( [
-			withSelect( ( select ) => {
-				const { isTemplateSelectorActive } = select( 'coblocks/template-selector' );
-				const {
-					getCurrentPostAttribute,
-					hasEditorUndo,
-					isCurrentPostPublished,
-				} = select( 'core/editor' );
-				const { getLayoutSelector } = select( 'coblocks-settings' );
-				const {
-					getBlockAttributes,
-					getBlockName,
-					getClientIdsWithDescendants,
-					getSettings,
-				} = select( 'core/block-editor' );
+registerPlugin( 'coblocks-layout-selector', {
+	render: compose( [
+		withSelect( ( select ) => {
+			const { isTemplateSelectorActive } = select( 'coblocks/template-selector' );
+			const {
+				getCurrentPostAttribute,
+				hasEditorUndo,
+				isCurrentPostPublished,
+			} = select( 'core/editor' );
+			const { getLayoutSelector } = select( 'coblocks-settings' );
+			const {
+				getBlockAttributes,
+				getBlockName,
+				getClientIdsWithDescendants,
+				getSettings,
+			} = select( 'core/block-editor' );
 
-				const isDraft = [ 'draft' ].indexOf( getCurrentPostAttribute( 'status' ) ) !== -1;
-				const isCleanUnpublishedPost = ! isCurrentPostPublished() && ! hasEditorUndo() && ! isDraft;
+			const isDraft = [ 'draft' ].indexOf( getCurrentPostAttribute( 'status' ) ) !== -1;
+			const isCleanUnpublishedPost = ! isCurrentPostPublished() && ! hasEditorUndo() && ! isDraft;
 
-				const layouts = coblocksLayoutSelector.layouts || [];
-				const categories = coblocksLayoutSelector.categories || [];
+			const layouts = coblocksLayoutSelector.layouts || [];
+			const categories = coblocksLayoutSelector.categories || [];
 
-				return {
-					isActive: isCleanUnpublishedPost || isTemplateSelectorActive(),
-					layoutSelectorEnabled: getLayoutSelector() && !! layouts.length && !! categories.length,
-					layouts,
-					categories,
-					mediaUpload: getSettings().mediaUpload,
-					clientIds: getClientIdsWithDescendants(),
-					getBlockAttributes,
-					getBlockName,
-				};
-			} ),
-			withDispatch( ( dispatch ) => {
-				const { closeTemplateSelector } = dispatch( 'coblocks/template-selector' );
-				const { editPost } = dispatch( 'core/editor' );
-				const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-				const { createWarningNotice } = dispatch( 'core/notices' );
+			return {
+				isActive: isCleanUnpublishedPost || isTemplateSelectorActive(),
+				layoutSelectorEnabled: getLayoutSelector() && !! layouts.length && !! categories.length,
+				layouts,
+				categories,
+				mediaUpload: getSettings().mediaUpload,
+				clientIds: getClientIdsWithDescendants(),
+				getBlockAttributes,
+				getBlockName,
+			};
+		} ),
+		withDispatch( ( dispatch ) => {
+			const { closeTemplateSelector } = dispatch( 'coblocks/template-selector' );
+			const { editPost } = dispatch( 'core/editor' );
+			const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+			const { createWarningNotice } = dispatch( 'core/notices' );
 
-				return {
-					closeTemplateSelector,
-					createWarningNotice,
-					editPost,
-					updateBlockAttributes,
-				};
-			} ),
-		] )( LayoutSelector ),
-	} );
-}
+			return {
+				closeTemplateSelector,
+				createWarningNotice,
+				editPost,
+				updateBlockAttributes,
+			};
+		} ),
+	] )( LayoutSelector ),
+} );

--- a/src/extensions/layout-selector/settings-modal-control.js
+++ b/src/extensions/layout-selector/settings-modal-control.js
@@ -1,4 +1,4 @@
-/*eslint camelcase: ["error", {allow: ["coblocks_layout_selector_controls_enabled"]}]*/
+/* eslint camelcase: ["error", {allow: ["coblocks_layout_selector_controls_enabled"]}] */
 /**
  * WordPress dependencies
  */

--- a/src/extensions/layout-selector/settings-modal-control.js
+++ b/src/extensions/layout-selector/settings-modal-control.js
@@ -1,0 +1,40 @@
+/*eslint camelcase: ["error", {allow: ["coblocks_layout_selector_controls_enabled"]}]*/
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { useSelect, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import CoBlocksSettingsModalControls from '../coblocks-settings/coblocks-settings-slot';
+
+const SETTINGS_KEY = 'coblocks_layout_selector_controls_enabled';
+
+const LayoutSelectorControl = () => {
+	const {
+		coblocks_layout_selector_controls_enabled,
+	} = useSelect( ( select ) => {
+		return {
+			[ SETTINGS_KEY ]: select( 'core' ).getEntityRecord( 'root', 'site' )?.[ SETTINGS_KEY ],
+		};
+	}, [] );
+
+	const saveSetting = ( value ) => {
+		dispatch( 'core' ).saveEntityRecord( 'root', 'site', { [ SETTINGS_KEY ]: value } );
+	};
+
+	return (
+		<CoBlocksSettingsModalControls>
+			<CheckboxControl
+				label={ __( 'Layout selector', 'coblocks' ) }
+				help={ __( 'Allow layout selection on new pages.', 'coblocks' ) }
+				onChange={ ( value ) => saveSetting( value ) }
+				checked={ !! coblocks_layout_selector_controls_enabled }
+			/>
+		</CoBlocksSettingsModalControls>
+	);
+};
+export default LayoutSelectorControl;


### PR DESCRIPTION
### Description
Extracting an individual control into a new component inside the an individual extensions directory (abstraction and organization). This also migrates the API request from our manual `apiFetch` to utilizing the `getEntityRecord` method of the core data store.

### How has this been tested?
Manually and with existing end-to-end tests.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
