### PR TITLE
PR to allow Gallery Collage tests to pass

### DIFF
--- a/src/blocks/gallery-collage/test/gallery-collage.cypress.js
+++ b/src/blocks/gallery-collage/test/gallery-collage.cypress.js
@@ -115,7 +115,7 @@ describe( 'Test CoBlocks Gallery Collage Block', function() {
 		helpers.toggleSettingCheckbox( /captions/i );
 
 		cy.get( '.wp-block-coblocks-gallery-collage__item' ).first().click()
-			.find( 'figcaption' ).click( { force: true } ).type( caption );
+			.find( 'figcaption' ).focus().type( caption, { force: true } );
 
 		helpers.savePage();
 


### PR DESCRIPTION
### Description
Working this PR I found a bug with the Gallery Collage block and its parsing of caption attribute when transforming. Bug report for that issue here: https://github.com/godaddy-wordpress/coblocks/issues/1707

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor test changes to properly focus on the text inputs.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and E2E.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
