### PR TITLE
Allow Stacked Gallery tests to pass

### DIFF
--- a/src/blocks/gallery-stacked/test/gallery-stacked.cypress.js
+++ b/src/blocks/gallery-stacked/test/gallery-stacked.cypress.js
@@ -124,7 +124,7 @@ describe( 'Test CoBlocks Gallery Stacked Block', function() {
 		helpers.toggleSettingCheckbox( /captions/i );
 
 		cy.get( '.coblocks-gallery--item' ).first().click()
-			.find( 'figcaption' ).click( { force: true } ).type( caption );
+			.find( 'figcaption' ).focus().type( caption );
 
 		helpers.savePage();
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR introduces fixes to the Stacked Gallery block tests to allow for properly setting caption inputs on all tested browsers.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript change to tests.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Manually and E2E.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
