### PR TITLE
Fix image alignment within Lightbox when long captions exist

### DIFF
--- a/src/components/block-gallery/styles/style/_lightbox.scss
+++ b/src/components/block-gallery/styles/style/_lightbox.scss
@@ -51,6 +51,8 @@
 	z-index: 2;
 
 	img {
+		display: flex;
+		margin: auto;
 		max-height: 70vh;
 		max-width: 70vw;
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The Lightbox required minor style tweaks to ensure that an image would center on the screen while a lightbox is in use. In the case of extra long captions, the images would set to align with the left of the container.

### Screenshots
<!-- if applicable -->
**Before**
![lightboxImageAlignmentWithCaption](https://user-images.githubusercontent.com/30462574/94936338-f2298900-0482-11eb-97d1-b0e8739f81c7.gif)

**After**
![image](https://user-images.githubusercontent.com/30462574/94936552-3e74c900-0483-11eb-8f68-eb86f5dd553f.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor style updates

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the browser.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->

