### PR TITLE
Fix Row block and Typography Controls 

### DIFF
--- a/src/extensions/typography/index.js
+++ b/src/extensions/typography/index.js
@@ -81,8 +81,8 @@ const withFontSettings = createHigherOrderComponent( ( BlockListBlock ) => {
 		let wrapperProps 	= props.wrapperProps;
 		let customData 	 	= {};
 
-		const block = select( 'core/block-editor' ).getBlock( props.rootClientId || props.clientId );
-		const blockName	= select( 'core/block-editor' ).getBlockName( props.rootClientId || props.clientId );
+		const block = select( 'core/block-editor' ).getBlock( props.clientId );
+		const blockName	= select( 'core/block-editor' ).getBlockName( props.clientId );
 
 		if ( allowedBlocks.includes( blockName ) && block?.attributes ) {
 			const { customFontSize, fontFamily, lineHeight, fontWeight, letterSpacing, textTransform, customTextColor } = block.attributes;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Row block and Typography controls have integrated API using a utility function called `applyStyle`. The integrated controls ultimately result in increased confusion around the functionalities of both the Row block as well as the Typography controls. These controls should eventually be separated to avoid future situations where debugging either functionality is necessary.

This PR includes a logic fix to allow for properly applying both Row styles as well as Typography styles. Original logic introduced in https://github.com/godaddy-wordpress/coblocks/pull/1515 as a fix at the time.

### Screenshots
<!-- if applicable -->
![rowBlockFix](https://user-images.githubusercontent.com/30462574/94969287-49495100-04b7-11eb-8c0d-1b6b517e775a.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. 
Tested with 5.4.2 & Gutenberg 9.1.0. 
Tested with 5.5.1 & Gutenberg 9.1.0.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
