### PR TITLE
Introduce image filters to core image block

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -178,11 +178,7 @@ export function viewPage() {
 		}
 	} );
 
-	cy.get( 'button[data-label="Document"]' ).then( ( documentButton ) => {
-		if ( ! Cypress.$( documentButton ).hasClass( 'is-active' ) ) {
-			cy.get( documentButton ).click();
-		}
-	} );
+	cy.wait( 100 );
 
 	openSettingsPanel( /permalink/i );
 

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -27,6 +27,7 @@ import './extensions/media-text-styles';
 import './extensions/lightbox-controls';
 import './extensions/replace-image';
 import './extensions/image-crop';
+import './extensions/image-filter';
 import './extensions/coblocks-settings/';
 import './extensions/layout-selector';
 import './extensions/block-patterns';

--- a/src/components/media-filter-control/index.js
+++ b/src/components/media-filter-control/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import {
 	FilterDarkIcon,
 	FilterGrayscaleIcon,
@@ -15,12 +16,23 @@ import {
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	Toolbar,
 	DropdownMenu,
 	Icon,
 } from '@wordpress/components';
+
+import { addFilter } from '@wordpress/hooks';
+
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+import { BlockControls } from '@wordpress/block-editor';
+
+const allowedBlocks = [
+	'core/image',
+	'core/gallery',
+];
 
 class MediaFilterControl extends Component {
 	render() {
@@ -105,3 +117,98 @@ class MediaFilterControl extends Component {
 }
 
 export default MediaFilterControl;
+
+/**
+ * Add the MediaFilterControl component to the core/image block
+ */
+const coreImageFilter = createHigherOrderComponent( BlockEdit => {
+	return ( props ) => {
+		if ( ! allowedBlocks.includes( props.name ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<BlockControls>
+					<MediaFilterControl
+						{ ...props }
+					/>
+				</BlockControls>
+			</Fragment>
+		);
+	};
+}, 'withGalleryExtension' );
+
+addFilter( 'editor.BlockEdit', 'coblocks/coreImageFilter', coreImageFilter );
+
+/**
+ * Add custom `has-filter-${ filter }` class to the core/image block
+ */
+const coreImageEditorStyles = createHigherOrderComponent( ( BlockListBlock ) => {
+	return ( props ) => {
+		console.log( props.name );
+		if ( ! allowedBlocks.includes( props.name ) ) {
+			return <BlockListBlock { ...props } />
+		}
+
+		const {
+			filter,
+		} = props.attributes;
+
+		let className = classnames(
+			{
+				[ `has-filter-${ filter }` ]: filter !== 'none',
+			}
+		)
+
+		return <BlockListBlock { ...props } className={ className } />;
+	};
+}, 'withStyleClasses' );
+
+addFilter( 'editor.BlockListBlock', 'coblocks/with-style-classes', coreImageEditorStyles );
+
+/**
+ * Add custom attribute to the core/image block
+ *
+ * @param {Object} settings Settings for the block.
+ *
+ * @return {Object} settings Modified settings.
+ */
+function imageFilterAttributes( settings ) {
+	if ( allowedBlocks.includes( settings.name ) && typeof settings.attributes !== 'undefined' ) {
+		settings.attributes = Object.assign( settings.attributes, {
+			filter: {
+				type: 'strig',
+				default: 'none',
+			}
+		} );
+	}
+
+	return settings;
+}
+
+addFilter( 'blocks.registerBlockType', 'coblocks/imageFilterAttributes', imageFilterAttributes );
+
+/**
+ * Add custom class in save element.
+ *
+ * @param {Object} extraProps Block element.
+ * @param {Object} blockType  Blocks object.
+ * @param {Object} attributes Blocks attributes.
+ *
+ * @return {Object} extraProps Modified block element.
+ */
+function imageBlockClass( extraProps, blockType, attributes ) {
+	if ( allowedBlocks.includes( blockType.name ) && typeof attributes.filter !== 'undefined' ) {
+		extraProps.className = classnames(
+			extraProps.className,
+			{
+				[ `has-filter-${ attributes.filter }` ]: attributes.filter !== 'none',
+			}
+		);
+	}
+	return extraProps;
+}
+
+addFilter( 'blocks.getSaveContent.extraProps', 'coblocks/imageApplyExtraClass', imageBlockClass );

--- a/src/components/media-filter-control/index.js
+++ b/src/components/media-filter-control/index.js
@@ -22,17 +22,9 @@ import {
 	DropdownMenu,
 	Icon,
 } from '@wordpress/components';
-
 import { addFilter } from '@wordpress/hooks';
-
 import { createHigherOrderComponent } from '@wordpress/compose';
-
 import { BlockControls } from '@wordpress/block-editor';
-
-const allowedBlocks = [
-	'core/image',
-	'core/gallery',
-];
 
 class MediaFilterControl extends Component {
 	render() {
@@ -117,98 +109,3 @@ class MediaFilterControl extends Component {
 }
 
 export default MediaFilterControl;
-
-/**
- * Add the MediaFilterControl component to the core/image block
- */
-const coreImageFilter = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
-		if ( ! allowedBlocks.includes( props.name ) ) {
-			return <BlockEdit { ...props } />;
-		}
-
-		return (
-			<Fragment>
-				<BlockEdit { ...props } />
-				<BlockControls>
-					<MediaFilterControl
-						{ ...props }
-					/>
-				</BlockControls>
-			</Fragment>
-		);
-	};
-}, 'withGalleryExtension' );
-
-addFilter( 'editor.BlockEdit', 'coblocks/coreImageFilter', coreImageFilter );
-
-/**
- * Add custom `has-filter-${ filter }` class to the core/image block
- */
-const coreImageEditorStyles = createHigherOrderComponent( ( BlockListBlock ) => {
-	return ( props ) => {
-		console.log( props.name );
-		if ( ! allowedBlocks.includes( props.name ) ) {
-			return <BlockListBlock { ...props } />
-		}
-
-		const {
-			filter,
-		} = props.attributes;
-
-		let className = classnames(
-			{
-				[ `has-filter-${ filter }` ]: filter !== 'none',
-			}
-		)
-
-		return <BlockListBlock { ...props } className={ className } />;
-	};
-}, 'withStyleClasses' );
-
-addFilter( 'editor.BlockListBlock', 'coblocks/with-style-classes', coreImageEditorStyles );
-
-/**
- * Add custom attribute to the core/image block
- *
- * @param {Object} settings Settings for the block.
- *
- * @return {Object} settings Modified settings.
- */
-function imageFilterAttributes( settings ) {
-	if ( allowedBlocks.includes( settings.name ) && typeof settings.attributes !== 'undefined' ) {
-		settings.attributes = Object.assign( settings.attributes, {
-			filter: {
-				type: 'strig',
-				default: 'none',
-			}
-		} );
-	}
-
-	return settings;
-}
-
-addFilter( 'blocks.registerBlockType', 'coblocks/imageFilterAttributes', imageFilterAttributes );
-
-/**
- * Add custom class in save element.
- *
- * @param {Object} extraProps Block element.
- * @param {Object} blockType  Blocks object.
- * @param {Object} attributes Blocks attributes.
- *
- * @return {Object} extraProps Modified block element.
- */
-function imageBlockClass( extraProps, blockType, attributes ) {
-	if ( allowedBlocks.includes( blockType.name ) && typeof attributes.filter !== 'undefined' ) {
-		extraProps.className = classnames(
-			extraProps.className,
-			{
-				[ `has-filter-${ attributes.filter }` ]: attributes.filter !== 'none',
-			}
-		);
-	}
-	return extraProps;
-}
-
-addFilter( 'blocks.getSaveContent.extraProps', 'coblocks/imageApplyExtraClass', imageBlockClass );

--- a/src/components/media-filter-control/test/media-filter-control.cypress.js
+++ b/src/components/media-filter-control/test/media-filter-control.cypress.js
@@ -1,0 +1,196 @@
+/*
+ * Include our constants
+ */
+import * as helpers from '../../../../.dev/tests/cypress/helpers';
+
+let filters = [
+	'Original',
+	'Grayscale',
+	'Sepia',
+	'Saturation',
+	'Dim',
+	'Vintage',
+];
+
+describe( 'Test CoBlocks Media Filter Control component', function() {
+	/**
+	 * Test that we can add a image block to the content add image,
+	 * and alter image using the media filter control component
+	 */
+	it( 'Test core/image block extends with Media Filter Control component.', function() {
+		const { imageBase } = helpers.upload.spec;
+		helpers.addBlockToPost( 'core/image', true );
+
+		helpers.upload.imageToBlock( 'core/image' );
+
+		cy.get( '.block-editor-block-toolbar__slot .components-coblocks-media-filter' )
+			.should( 'exist' )
+			.click();
+
+		var childIteration = 1;
+
+		// Check the menu contains the expected filters
+		for ( var i = 0; i < filters.length; i++ ) {
+			cy.get( '.components-dropdown-menu__menu button:nth-child(' + childIteration + ')' )
+				.contains( filters[ i ] );
+				childIteration++;
+		}
+
+		i = 0;
+		childIteration = 1;
+
+		// Check the classes are applied correctly to the block
+		for ( var i = 0; i < filters.length; i++ ) {
+			cy.get( '.components-dropdown-menu__menu button:nth-child(' + childIteration + ')' )
+				.click();
+
+			// 'Original' filter does not add any class to the element
+			if ( 1 === childIteration ) {
+				cy.get( '.wp-block-image' )
+					.should( 'not.have.class', 'has-filter-original' )
+					.and( 'not.have.class', 'has-filter-grayscale' )
+					.and( 'not.have.class', 'has-filter-sepia' )
+					.and( 'not.have.class', 'has-filter-saturation' )
+					.and( 'not.have.class', 'has-filter-dim' )
+					.and( 'not.have.class', 'has-filter-vintage' );
+
+				helpers.savePage();
+				helpers.checkForBlockErrors( 'core/image' );
+				helpers.viewPage();
+
+				cy.get( 'figure.wp-block-image' )
+					.should( 'not.have.class', 'has-filter-original' )
+					.and( 'not.have.class', 'has-filter-grayscale' )
+					.and( 'not.have.class', 'has-filter-sepia' )
+					.and( 'not.have.class', 'has-filter-saturation' )
+					.and( 'not.have.class', 'has-filter-dim' )
+					.and( 'not.have.class', 'has-filter-vintage' );
+
+				helpers.editPage();
+
+				cy.get( '.wp-block-image' )
+					.click();
+
+				cy.get( '.block-editor-block-toolbar__slot .components-coblocks-media-filter' )
+					.click();
+
+				childIteration++;
+
+				continue;
+			}
+
+			let filterSlug = filters[ i ].toLowerCase();
+
+			cy.get( '.wp-block-image' )
+				.should( 'have.class', 'has-filter-' + filterSlug );
+
+			helpers.savePage();
+			helpers.checkForBlockErrors( 'core/image' );
+			helpers.viewPage();
+
+			cy.get( 'figure.wp-block-image' )
+				.should( 'have.class', 'has-filter-' + filterSlug );
+
+			helpers.editPage();
+
+			cy.get( '.wp-block-image' )
+				.click();
+
+			cy.get( '.block-editor-block-toolbar__slot .components-coblocks-media-filter' )
+				.click();
+
+			childIteration++;
+		}
+	} );
+
+	/**
+	 * Test that we can add a gallery block to the content add image,
+	 * and alter image using the Lightbox Controls extension
+	 */
+	it( 'Test core/gallery block extends with Media Filter Control component.', function() {
+		const { imageBase } = helpers.upload.spec;
+		helpers.addBlockToPost( 'core/gallery', true );
+
+		helpers.upload.imageToBlock( 'core/gallery' );
+
+		cy.get( '.block-editor-block-toolbar__slot .components-coblocks-media-filter' )
+			.should( 'exist' )
+			.click();
+
+		var childIteration = 1;
+
+		// Check the menu contains the expected filters
+		for ( var i = 0; i < filters.length; i++ ) {
+			cy.get( '.components-dropdown-menu__menu button:nth-child(' + childIteration + ')' )
+				.contains( filters[ i ] );
+				childIteration++;
+		}
+
+		i = 0;
+		childIteration = 1;
+
+		// Check the classes are applied correctly to the block
+		for ( var i = 0; i < filters.length; i++ ) {
+			cy.get( '.components-dropdown-menu__menu button:nth-child(' + childIteration + ')' )
+				.click();
+
+			// 'Original' filter does not add any class to the element
+			if ( 1 === childIteration ) {
+				cy.get( '.wp-block-gallery' )
+					.should( 'not.have.class', 'has-filter-original' )
+					.and( 'not.have.class', 'has-filter-grayscale' )
+					.and( 'not.have.class', 'has-filter-sepia' )
+					.and( 'not.have.class', 'has-filter-saturation' )
+					.and( 'not.have.class', 'has-filter-dim' )
+					.and( 'not.have.class', 'has-filter-vintage' );
+
+				helpers.savePage();
+				helpers.checkForBlockErrors( 'core/gallery' );
+				helpers.viewPage();
+
+				cy.get( 'figure.wp-block-gallery' )
+					.should( 'not.have.class', 'has-filter-original' )
+					.and( 'not.have.class', 'has-filter-grayscale' )
+					.and( 'not.have.class', 'has-filter-sepia' )
+					.and( 'not.have.class', 'has-filter-saturation' )
+					.and( 'not.have.class', 'has-filter-dim' )
+					.and( 'not.have.class', 'has-filter-vintage' );
+
+				helpers.editPage();
+
+				cy.get( '.wp-block-gallery' )
+					.click();
+
+				cy.get( '.block-editor-block-toolbar__slot .components-coblocks-media-filter' )
+					.click();
+
+				childIteration++;
+
+				continue;
+			}
+
+			let filterSlug = filters[ i ].toLowerCase();
+
+			cy.get( 'div[data-type="core/gallery"]' )
+				.should( 'have.class', 'has-filter-' + filterSlug );
+
+			helpers.savePage();
+			helpers.checkForBlockErrors( 'core/gallery' );
+			helpers.viewPage();
+
+			cy.get( 'figure.wp-block-gallery' )
+				.should( 'have.class', 'has-filter-' + filterSlug );
+
+			helpers.editPage();
+
+			cy.get( 'div[data-type="core/gallery"]' )
+				.click();
+
+			cy.get( '.block-editor-block-toolbar__slot .components-coblocks-media-filter' )
+				.click();
+
+			childIteration++;
+		}
+	} );
+
+} );

--- a/src/extensions/image-filter/index.js
+++ b/src/extensions/image-filter/index.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import MediaFilterControl from '../../components/media-filter-control';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { BlockControls } from '@wordpress/block-editor';
+
+const allowedBlocks = [
+	'core/image',
+	'core/gallery',
+];
+
+/**
+ * Add the MediaFilterControl component to the core/image and core/gallery block
+ */
+const coreImageFilter = createHigherOrderComponent( (BlockEdit) => {
+	return ( props ) => {
+		if ( ! allowedBlocks.includes( props.name ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<BlockControls>
+					<MediaFilterControl
+						{ ...props }
+					/>
+				</BlockControls>
+			</Fragment>
+		);
+	};
+}, 'withGalleryExtension' );
+
+addFilter( 'editor.BlockEdit', 'coblocks/coreImageFilter', coreImageFilter );
+
+/**
+ * Add custom `has-filter-${ filter }` class to the core/image block
+ */
+const coreImageEditorStyles = createHigherOrderComponent( ( BlockListBlock ) => {
+	return ( props ) => {
+		if ( ! allowedBlocks.includes( props.name ) ) {
+			return <BlockListBlock { ...props } />;
+		}
+
+		const {
+			filter,
+		} = props.attributes;
+
+		let className = classnames(
+			{
+				[ `has-filter-${ filter }` ]: filter !== 'none',
+			}
+		);
+
+		return <BlockListBlock { ...props } className={ className } />;
+	};
+}, 'withStyleClasses' );
+
+addFilter( 'editor.BlockListBlock', 'coblocks/with-style-classes', coreImageEditorStyles );
+
+/**
+ * Add custom attribute to the core/image block
+ *
+ * @param {Object} settings Settings for the block.
+ *
+ * @return {Object} settings Modified settings.
+ */
+function imageFilterAttributes( settings ) {
+	if ( allowedBlocks.includes( settings.name ) && typeof settings.attributes !== 'undefined' ) {
+		settings.attributes = Object.assign( settings.attributes, {
+			filter: {
+				type: 'strig',
+				default: 'none',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+addFilter( 'blocks.registerBlockType', 'coblocks/imageFilterAttributes', imageFilterAttributes );
+
+/**
+ * Add custom class in save element.
+ *
+ * @param {Object} extraProps Block element.
+ * @param {Object} blockType  Blocks object.
+ * @param {Object} attributes Blocks attributes.
+ *
+ * @return {Object} extraProps Modified block element.
+ */
+function imageBlockClass( extraProps, blockType, attributes ) {
+	if ( allowedBlocks.includes( blockType.name ) && typeof attributes.filter !== 'undefined' ) {
+		extraProps.className = classnames(
+			extraProps.className,
+			{
+				[ `has-filter-${ attributes.filter }` ]: attributes.filter !== 'none',
+			}
+		);
+	}
+	return extraProps;
+}
+
+addFilter( 'blocks.getSaveContent.extraProps', 'coblocks/imageApplyExtraClass', imageBlockClass );


### PR DESCRIPTION
### Description
Introduce image filters to the core/image block.

Note: Currently the gallery block filter changes _all_ images. It's not possible to change the filter of individual images, with this current implementation. I am going to revisit this in the morning.

### Screenshots
TBA

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested. May need to introduce jest tests.

### Checklist:
- [ ] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
