### PR TITLE
Fix duplicated and remove deprecated gallery transforms

### DIFF
--- a/src/blocks/gallery-carousel/test/transforms.spec.js
+++ b/src/blocks/gallery-carousel/test/transforms.spec.js
@@ -15,7 +15,7 @@ import { name } from '../index';
 describe( 'coblocks/gallery-carousel transforms', () => {
 	// Shared attributes
 	const attributes = {
-		gutter: 5,
+		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +31,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +43,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +55,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +67,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -79,7 +79,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( coreGallery, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -91,7 +91,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( coreImage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		expect( transformed[ 0 ].attributes.images.length ).toBeGreaterThan( 0 );
 
 		expect( transformed[ 0 ].attributes.images[ 0 ].index ).toBe( coreImage.attributes.id );
@@ -103,7 +103,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -115,7 +115,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -127,7 +127,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -139,7 +139,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-carousel/test/transforms.spec.js
+++ b/src/blocks/gallery-carousel/test/transforms.spec.js
@@ -15,7 +15,6 @@ import { name } from '../index';
 describe( 'coblocks/gallery-carousel transforms', () => {
 	// Shared attributes
 	const attributes = {
-		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +30,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +41,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +52,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +63,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -79,7 +74,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( coreGallery, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -91,7 +85,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( coreImage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		expect( transformed[ 0 ].attributes.images.length ).toBeGreaterThan( 0 );
 
 		expect( transformed[ 0 ].attributes.images[ 0 ].index ).toBe( coreImage.attributes.id );
@@ -103,7 +96,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -115,7 +107,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -127,7 +118,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -139,7 +129,6 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-carousel/transforms.js
+++ b/src/blocks/gallery-carousel/transforms.js
@@ -23,9 +23,6 @@ const transforms = {
 				'coblocks/gallery-masonry',
 				'coblocks/gallery-stacked',
 				'coblocks/gallery-offset',
-				'blockgallery/carousel',
-				'blockgallery/masonry',
-				'blockgallery/stacked',
 				'core/gallery',
 			],
 			transform: ( attributes ) => (
@@ -41,10 +38,13 @@ const transforms = {
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
 				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
+				const hasCaption = !! filter( attributes, ( { caption } ) => !! caption );
+
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
+						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { index, id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
+						captions: hasCaption,
 					} );
 				}
 				return createBlock( metadata.name );
@@ -60,23 +60,15 @@ const transforms = {
 			},
 		},
 	],
-	to: ( function() {
-		return [
-			'coblocks/gallery-collage',
-			'coblocks/gallery-masonry',
-			'coblocks/gallery-stacked',
-			'coblocks/gallery-offset',
-			'core/gallery',
-		].map( ( x ) => {
-			return {
-				type: 'block',
-				blocks: [ x ],
-				transform: ( attributes ) => createBlock( x, {
-					...GalleryTransforms( attributes ),
-				} ),
-			};
-		} );
-	}() ),
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/gallery' ],
+			transform: ( attributes ) => createBlock( 'core/gallery', {
+				...GalleryTransforms( attributes ),
+			} ),
+		},
+	],
 };
 
 export default transforms;

--- a/src/blocks/gallery-collage/test/transforms.spec.js
+++ b/src/blocks/gallery-collage/test/transforms.spec.js
@@ -15,7 +15,6 @@ import { name } from '../index';
 describe( 'coblocks/gallery-collage transforms', () => {
 	// Shared attributes
 	const attributes = {
-		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +30,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +41,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +52,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +63,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +96,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +107,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +118,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +129,6 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-collage/test/transforms.spec.js
+++ b/src/blocks/gallery-collage/test/transforms.spec.js
@@ -15,7 +15,7 @@ import { name } from '../index';
 describe( 'coblocks/gallery-collage transforms', () => {
 	// Shared attributes
 	const attributes = {
-		gutter: 5,
+		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +31,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +43,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +55,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +67,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +101,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +113,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +125,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +137,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-collage/transforms.js
+++ b/src/blocks/gallery-collage/transforms.js
@@ -23,9 +23,6 @@ const transforms = {
 				'coblocks/gallery-masonry',
 				'coblocks/gallery-stacked',
 				'coblocks/gallery-offset',
-				'blockgallery/carousel',
-				'blockgallery/masonry',
-				'blockgallery/stacked',
 				'core/gallery',
 			],
 			transform: ( attributes ) => createBlock( metadata.name, GalleryTransforms( attributes ) ),
@@ -36,10 +33,13 @@ const transforms = {
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
 				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
+				const hasCaption = !! filter( attributes, ( { caption } ) => !! caption );
+
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
+						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { index, id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
+						captions: hasCaption,
 					} );
 				}
 				return createBlock( metadata.name );
@@ -51,23 +51,15 @@ const transforms = {
 			transform: ( content ) => createBlock( metadata.name, { content } ),
 		},
 	],
-	to: ( function() {
-		return [
-			'coblocks/gallery-carousel',
-			'coblocks/gallery-masonry',
-			'coblocks/gallery-stacked',
-			'coblocks/gallery-offset',
-			'core/gallery',
-		].map( ( x ) => {
-			return {
-				type: 'block',
-				blocks: [ x ],
-				transform: ( attributes ) => createBlock( x, {
-					...GalleryTransforms( attributes ),
-				} ),
-			};
-		} );
-	}() ),
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/gallery' ],
+			transform: ( attributes ) => createBlock( 'core/gallery', {
+				...GalleryTransforms( attributes ),
+			} ),
+		},
+	],
 };
 
 export default transforms;

--- a/src/blocks/gallery-masonry/test/transforms.spec.js
+++ b/src/blocks/gallery-masonry/test/transforms.spec.js
@@ -15,7 +15,7 @@ import { name } from '../index';
 describe( 'coblocks/gallery-masonry transforms', () => {
 	// Shared attributes
 	const attributes = {
-		gutter: 5,
+		// gutter: 5,
 		images: [
 			{ id: 0, index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ id: 1, index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +31,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +43,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +55,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +67,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryCarousel, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +101,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +113,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +125,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +137,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-masonry/test/transforms.spec.js
+++ b/src/blocks/gallery-masonry/test/transforms.spec.js
@@ -15,7 +15,6 @@ import { name } from '../index';
 describe( 'coblocks/gallery-masonry transforms', () => {
 	// Shared attributes
 	const attributes = {
-		// gutter: 5,
 		images: [
 			{ id: 0, index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ id: 1, index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +30,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +41,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +52,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +63,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( galleryCarousel, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +96,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +107,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +118,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +129,6 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-masonry/transforms.js
+++ b/src/blocks/gallery-masonry/transforms.js
@@ -23,9 +23,6 @@ const transforms = {
 				'coblocks/gallery-collage',
 				'coblocks/gallery-stacked',
 				'coblocks/gallery-offset',
-				'blockgallery/carousel',
-				'blockgallery/masonry',
-				'blockgallery/stacked',
 				'core/gallery',
 			],
 			transform: ( attributes ) => createBlock( metadata.name, GalleryTransforms( attributes ) ),
@@ -36,10 +33,13 @@ const transforms = {
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
 				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
+				const hasCaption = !! filter( attributes, ( { caption } ) => !! caption );
+
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
+						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { index, id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
+						captions: hasCaption,
 					} );
 				}
 				return createBlock( metadata.name );
@@ -55,23 +55,15 @@ const transforms = {
 			},
 		},
 	],
-	to: ( function() {
-		return [
-			'coblocks/gallery-collage',
-			'coblocks/gallery-masonry',
-			'coblocks/gallery-stacked',
-			'coblocks/gallery-offset',
-			'core/gallery',
-		].map( ( x ) => {
-			return {
-				type: 'block',
-				blocks: [ x ],
-				transform: ( attributes ) => createBlock( x, {
-					...GalleryTransforms( attributes ),
-				} ),
-			};
-		} );
-	}() ),
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/gallery' ],
+			transform: ( attributes ) => createBlock( 'core/gallery', {
+				...GalleryTransforms( attributes ),
+			} ),
+		},
+	],
 };
 
 export default transforms;

--- a/src/blocks/gallery-offset/test/gallery-offset.cypress.js
+++ b/src/blocks/gallery-offset/test/gallery-offset.cypress.js
@@ -124,7 +124,7 @@ describe( 'Test CoBlocks Gallery Offset Block', function() {
 		helpers.toggleSettingCheckbox( /captions/i );
 
 		cy.get( '.coblocks-gallery--item' ).first().click()
-			.find( 'figcaption' ).click( { force: true } ).type( caption );
+			.find( 'figcaption' ).focus().type( caption );
 
 		helpers.savePage();
 

--- a/src/blocks/gallery-offset/test/transforms.spec.js
+++ b/src/blocks/gallery-offset/test/transforms.spec.js
@@ -15,7 +15,6 @@ import { name } from '../index';
 describe( 'coblocks/gallery-offset transforms', () => {
 	// Shared attributes
 	const attributes = {
-		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +30,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +41,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +52,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryCarousel, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +63,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +96,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +107,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +118,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +129,6 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-offset/test/transforms.spec.js
+++ b/src/blocks/gallery-offset/test/transforms.spec.js
@@ -15,7 +15,7 @@ import { name } from '../index';
 describe( 'coblocks/gallery-offset transforms', () => {
 	// Shared attributes
 	const attributes = {
-		gutter: 5,
+		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +31,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryStacked, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +43,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +55,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryCarousel, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +67,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +101,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-stacked' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +113,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +125,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +137,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-offset/transforms.js
+++ b/src/blocks/gallery-offset/transforms.js
@@ -23,9 +23,6 @@ const transforms = {
 				'coblocks/gallery-masonry',
 				'coblocks/gallery-stacked',
 				'coblocks/gallery-carousel',
-				'blockgallery/carousel',
-				'blockgallery/masonry',
-				'blockgallery/stacked',
 				'core/gallery',
 			],
 			transform: ( attributes ) => (
@@ -40,10 +37,13 @@ const transforms = {
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
 				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
+				const hasCaption = !! filter( attributes, ( { caption } ) => !! caption );
+
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
+						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { index, id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
+						captions: hasCaption,
 					} );
 				}
 				return createBlock( metadata.name );
@@ -59,23 +59,15 @@ const transforms = {
 			},
 		},
 	],
-	to: ( function() {
-		return [
-			'coblocks/gallery-collage',
-			'coblocks/gallery-masonry',
-			'coblocks/gallery-stacked',
-			'coblocks/gallery-carousel',
-			'core/gallery',
-		].map( ( x ) => {
-			return {
-				type: 'block',
-				blocks: [ x ],
-				transform: ( attributes ) => createBlock( x, {
-					...GalleryTransforms( attributes ),
-				} ),
-			};
-		} );
-	}() ),
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/gallery' ],
+			transform: ( attributes ) => createBlock( 'core/gallery', {
+				...GalleryTransforms( attributes ),
+			} ),
+		},
+	],
 };
 
 export default transforms;

--- a/src/blocks/gallery-stacked/test/transforms.spec.js
+++ b/src/blocks/gallery-stacked/test/transforms.spec.js
@@ -15,7 +15,7 @@ import { name } from '../index';
 describe( 'coblocks/gallery-stacked transforms', () => {
 	// Shared attributes
 	const attributes = {
-		gutter: 5,
+		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +31,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +43,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +55,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryCarousel, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +67,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +101,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +113,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +125,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +137,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
+		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-stacked/test/transforms.spec.js
+++ b/src/blocks/gallery-stacked/test/transforms.spec.js
@@ -15,7 +15,6 @@ import { name } from '../index';
 describe( 'coblocks/gallery-stacked transforms', () => {
 	// Shared attributes
 	const attributes = {
-		// gutter: 5,
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
@@ -31,7 +30,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryOffset, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -43,7 +41,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryMasonry, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -55,7 +52,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryCarousel, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -67,7 +63,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( galleryCollage, name );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -101,7 +96,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-offset' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -113,7 +107,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -125,7 +118,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-carousel' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
@@ -137,7 +129,6 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'coblocks/gallery-collage' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		// expect( transformed[ 0 ].attributes.gutter ).toBe( attributes.gutter );
 		for ( let i = 0; i < attributes.images.length; i++ ) {
 			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
 			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );

--- a/src/blocks/gallery-stacked/transforms.js
+++ b/src/blocks/gallery-stacked/transforms.js
@@ -23,9 +23,6 @@ const transforms = {
 				'coblocks/gallery-masonry',
 				'coblocks/gallery-offset',
 				'coblocks/gallery-carousel',
-				'blockgallery/carousel',
-				'blockgallery/masonry',
-				'blockgallery/stacked',
 				'core/gallery',
 			],
 			transform: ( attributes ) => (
@@ -40,10 +37,13 @@ const transforms = {
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
 				const validImages = filter( attributes, ( { id, url } ) => Number.isInteger( id ) && url );
+				const hasCaption = !! filter( attributes, ( { caption } ) => !! caption );
+
 				if ( validImages.length > 0 ) {
 					return createBlock( metadata.name, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( { index: id, url, alt: alt || '', caption: caption || '' } ) ),
+						images: validImages.map( ( { id, url, alt, caption }, index ) => ( { index, id, url, alt: alt || '', caption: caption || '' } ) ),
 						ids: validImages.map( ( { id } ) => id ),
+						captions: hasCaption,
 					} );
 				}
 				return createBlock( metadata.name );
@@ -59,23 +59,15 @@ const transforms = {
 			},
 		},
 	],
-	to: ( function() {
-		return [
-			'coblocks/gallery-collage',
-			'coblocks/gallery-masonry',
-			'coblocks/gallery-offset',
-			'coblocks/gallery-carousel',
-			'core/gallery',
-		].map( ( x ) => {
-			return {
-				type: 'block',
-				blocks: [ x ],
-				transform: ( attributes ) => createBlock( x, {
-					...GalleryTransforms( attributes ),
-				} ),
-			};
-		} );
-	}() ),
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/gallery' ],
+			transform: ( attributes ) => createBlock( 'core/gallery', {
+				...GalleryTransforms( attributes ),
+			} ),
+		},
+	],
 };
 
 export default transforms;

--- a/src/components/block-gallery/shared/transforms.js
+++ b/src/components/block-gallery/shared/transforms.js
@@ -22,7 +22,6 @@ function GalleryTransforms( props ) {
 		filter: props.filter,
 		fontSize: props.fontSize,
 		gridSize: props.gridSize,
-		// gutter: props.gutter, // Disabled while gallery blocks use multiple gutter controls.
 		gutterMobile: props.gutterMobile,
 		height: props.height,
 		images: props.images.map( ( image, index ) => {

--- a/src/components/block-gallery/shared/transforms.js
+++ b/src/components/block-gallery/shared/transforms.js
@@ -22,7 +22,7 @@ function GalleryTransforms( props ) {
 		filter: props.filter,
 		fontSize: props.fontSize,
 		gridSize: props.gridSize,
-		gutter: props.gutter,
+		// gutter: props.gutter, // Disabled while gallery blocks use multiple gutter controls.
 		gutterMobile: props.gutterMobile,
 		height: props.height,
 		images: props.images.map( ( image, index ) => {
@@ -40,7 +40,6 @@ function GalleryTransforms( props ) {
 		noBottomMargin: props.noBottomMargin,
 		noTopMargin: props.noTopMargin,
 	};
-
 	return transforms;
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Changes over time in the way that transforms are registered by core has resulted in duplicate instances of registered block transforms. This PR removes duplicate transform registrations as well as removes some of the older deprecated transforms from gallery blocks. 

Working this PR I discovered a few Gallery transform bugs that should be addressed in scoped pull requests. 

https://github.com/godaddy-wordpress/coblocks/issues/1719 - Transformed galleries result in invalid gutter content.
 https://github.com/godaddy-wordpress/coblocks/issues/1707 - Transformed galleries result in invalid caption content.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/95219147-e4894180-07a9-11eb-84ec-125f3b3f5fdf.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and with Jest.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
