### PR TITLE
Introduce an image filter preview to the media-filter-control component

### DIFF
--- a/src/components/media-filter-control/index.js
+++ b/src/components/media-filter-control/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import _ from 'lodash';
 import {
 	FilterDarkIcon,
 	FilterGrayscaleIcon,
@@ -15,29 +16,81 @@ import {
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
+import { BlockPreview } from '@wordpress/block-editor';
 import {
+	MenuItem,
+	MenuGroup,
+	Popover,
 	Toolbar,
 	DropdownMenu,
 	Icon,
 } from '@wordpress/components';
 
+function PreviewImageFilterPopover( { hoveredFilter, selected } ) {
+	if ( ! hoveredFilter ) return null;
+
+	const block = _.cloneDeep( selected );
+
+	block.attributes.filter = hoveredFilter;
+
+	return (
+		<div className="block-editor-block-switcher__popover__preview__parent">
+			<div className="block-editor-block-switcher__popover__preview__container">
+				<Popover
+					className="block-editor-block-switcher__preview__popover"
+					position="bottom right"
+					focusOnMount={ false }
+				>
+					<div className="block-editor-block-switcher__preview coblocks__preview">
+						<div className="block-editor-block-switcher__preview-title">
+							{ __( 'Preview filter' ) }
+						</div>
+						<BlockPreview
+							autoHeight
+							blocks={ { ...block } }
+						/>
+					</div>
+				</Popover>
+			</div>
+		</div>
+	);
+}
+
 class MediaFilterControl extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			hoveredFilter: null
+		};
+	}
+
+	onChangeHoveredFilter = ( filter ) => {
+		this.setState( {
+			hoveredFilter: filter
+		} );
+	}
+
 	render() {
 		const {
 			attributes,
 			setAttributes,
+			selected,
 		} = this.props;
 
 		const {
 			filter,
 		} = attributes;
 
+		const { hoveredFilter } = this.state;
+
 		const filterControls = [
 			{
 				icon: <Icon icon={ FilterNoneIcon } />,
 				/* translators: image style */
 				title: __( 'Original', 'coblocks' ),
+				slug: 'original',
 				onClick: () => {
 					setAttributes( { filter: 'none' } );
 				},
@@ -47,6 +100,7 @@ class MediaFilterControl extends Component {
 				icon: <Icon icon={ FilterGrayscaleIcon } />,
 				/* translators: image style */
 				title: __( 'Grayscale filter', 'coblocks' ),
+				slug: 'grayscale',
 				onClick: () => {
 					setAttributes( { filter: 'grayscale' } );
 				},
@@ -56,6 +110,7 @@ class MediaFilterControl extends Component {
 				icon: <Icon icon={ FilterSepiaIcon } />,
 				/* translators: image style */
 				title: __( 'Sepia filter', 'coblocks' ),
+				slug: 'sepia',
 				onClick: () => {
 					setAttributes( { filter: 'sepia' } );
 				},
@@ -65,6 +120,7 @@ class MediaFilterControl extends Component {
 				icon: <Icon icon={ FilterSaturationIcon } />,
 				/* translators: image style */
 				title: __( 'Saturation filter', 'coblocks' ),
+				slug: 'saturation',
 				onClick: () => {
 					setAttributes( { filter: 'saturation' } );
 				},
@@ -74,6 +130,7 @@ class MediaFilterControl extends Component {
 				icon: <Icon icon={ FilterDarkIcon } />,
 				/* translators: image style */
 				title: __( 'Dim filter', 'coblocks' ),
+				slug: 'dim',
 				onClick: () => {
 					setAttributes( { filter: 'dim' } );
 				},
@@ -83,6 +140,7 @@ class MediaFilterControl extends Component {
 				icon: <Icon icon={ FilterVintageIcon } />,
 				/* translators: image style */
 				title: __( 'Vintage filter', 'coblocks' ),
+				slug: 'vintage',
 				onClick: () => {
 					setAttributes( { filter: 'vintage' } );
 				},
@@ -96,9 +154,31 @@ class MediaFilterControl extends Component {
 					hasArrowIndicator
 					icon={ <Icon icon={ FilterMainIcon } /> }
 					label={ __( 'Apply filter', 'coblocks' ) }
-					controls={ filterControls }
 					className="components-coblocks-media-filter"
-				/>
+				>
+				{ ( { onClose } ) => (
+						<Fragment>
+							<MenuGroup>
+								<PreviewImageFilterPopover hoveredFilter={ hoveredFilter } selected={ selected } />
+								{
+									filterControls.map( ( filter ) => (
+										<MenuItem
+											role="menuitemradio"
+											label={ filter.title }
+											onClick={ filter.onClick }
+											onMouseEnter={ () => this.onChangeHoveredFilter( filter.slug ) }
+											onMouseLeave={ () => this.onChangeHoveredFilter( null ) }
+											isSelected={ filter === filter.slug }
+											icon={ filter.icon }
+											key={ `coblocks-image-filter-${ filter.slug }` }>
+											{ filter.title }
+										</MenuItem>
+									) )
+								}
+							</MenuGroup>
+						</Fragment>
+					) }
+				</DropdownMenu>
 			</Toolbar>
 		);
 	}


### PR DESCRIPTION
### Description
Display a preview of the image filter when hovered.

### Screenshots
![image-filter-preview](https://user-images.githubusercontent.com/5321364/95237275-fc76ba80-07d5-11eb-98cc-d857762ad344.gif)


### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually. Probably needs tests.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
