### PR TITLE
Remove search keywords from Media Card block

### DIFF
--- a/src/blocks/media-card/index.js
+++ b/src/blocks/media-card/index.js
@@ -36,13 +36,6 @@ const settings = {
 	/* translators: block description */
 	description: __( 'Add an image or video with an offset card side-by-side.', 'coblocks' ),
 	icon: <Icon icon={ icon } />,
-	keywords: [
-		'coblocks',
-		/* translators: block keyword */
-		__( 'image', 'coblocks' ),
-		/* translators: block keyword */
-		__( 'video', 'coblocks' ),
-	],
 	supports: {
 		align: [ 'wide', 'full' ],
 		stackedOnMobile: true,


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Remove keyword search terms from the Media Card block. Reducing searchability for the Media Card block but not yet making the block un-insertable.

Note: Since the name of the block is a searchable token, I would suggest registering Media Card block without the ability to insert if that behavior is desired. 
https://github.com/godaddy-wordpress/coblocks/blob/31938b07cf68b0910f408c5972ac794b5163e795/src/js/deprecations/deprecate-coblocks-buttons.js#L9-L25

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
