### PR TITLE
Fix Collage gallery captions and deprecations

### DIFF
--- a/src/blocks/gallery-collage/block.json
+++ b/src/blocks/gallery-collage/block.json
@@ -40,7 +40,7 @@
 					"attribute": "data-index"
 				},
 				"caption": {
-					"type": "array",
+					"type": "string",
 					"source": "children",
 					"selector": "figcaption"
 				}

--- a/src/blocks/gallery-collage/deprecated.js
+++ b/src/blocks/gallery-collage/deprecated.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { BackgroundAttributes } from '../../components/background';
 import { GalleryAttributes } from '../../components/block-gallery/shared';
 import metadata from './block.json';
+import GutterWrapper from '../../components/gutter-control/gutter-wrapper';
 
 /**
  * WordPress dependencies
@@ -158,6 +159,96 @@ const deprecated =
 					} ) }
 				</ul>
 			</div>
+		);
+	},
+},
+{
+	attributes: {
+		...GalleryAttributes,
+		...metadata.attributes,
+		images: {
+			...metadata.attributes.images,
+			query: {
+				...metadata.attributes.images.query,
+				caption: {
+					...metadata.attributes.images.query.caption,
+					type: 'array',
+				},
+			},
+		},
+		gutter: {
+			type: 'string',
+			default: 'small',
+		},
+		gutterCustom: {
+			type: 'string',
+			default: '3',
+		},
+	},
+	save( { attributes } ) {
+		const {
+			captions,
+			captionStyle,
+			filter,
+			images,
+			lightbox,
+			linkTo,
+			rel,
+			shadow,
+			target,
+		} = attributes;
+
+		const classes = classnames( 'wp-block-coblocks-gallery-collage__figure', {
+			[ `shadow-${ shadow }` ]: shadow && shadow !== 'none',
+		} );
+
+		return (
+			<GutterWrapper { ...attributes }>
+				<div className={ classnames( {
+					[ `has-filter-${ filter }` ]: filter !== 'none',
+					[ `has-caption-style-${ captionStyle }` ]: captions && captionStyle !== undefined,
+					'has-lightbox': lightbox,
+				} ) }>
+					<ul>
+						{ images.sort( ( a, b ) => parseInt( a.index ) - parseInt( b.index ) ).map( ( image, index ) => {
+							let href;
+
+							switch ( linkTo ) {
+								case 'media':
+									href = image.url;
+									break;
+								case 'attachment':
+									href = image.link;
+									break;
+							}
+
+							// If an image has a custom link, override the linkTo selection.
+							if ( image.imgLink ) {
+								href = image.imgLink;
+							}
+
+							const imgClasses = classnames( image.id && [ `wp-image-${ image.id }` ] );
+							const img = typeof image.url === 'undefined' ? null : ( <img src={ image.url } alt={ image.alt } data-index={ image.index } data-id={ image.id } data-imglink={ image.imgLink } data-link={ image.link } className={ imgClasses } /> );
+
+							return (
+								<li
+									key={ `image-${ index }` }
+									className={ classnames( 'wp-block-coblocks-gallery-collage__item', `item-${ index + 1 }` ) }
+								>
+									{ img &&
+										<figure className={ classes }>
+											{ href ? <a href={ href } target={ target } rel={ rel }>{ img }</a> : img }
+											{ captions && image.caption.length !== 0 && (
+												<RichText.Content tagName="figcaption" className="wp-block-coblocks-gallery-collage__caption" value={ image.caption } />
+											) }
+										</figure>
+									}
+								</li>
+							);
+						} ) }
+					</ul>
+				</div>
+			</GutterWrapper>
 		);
 	},
 } ];


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR resolves a few bugs around the use of captions with the Collage gallery block. The collage block uses an attribute schema for captions with a type of array. All other gallery blocks have a caption type of string. Because of the differing types, and the lack of deprecated save functions to correctly convert, it became possible to create conditions where the Collage block would fail block validation.

This PR introduces a deprecated save function to handle cases where the Collage block had been successfully configured with captions.


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested using Jest tests and manually in the browser.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
