### PR TITLE
Fix Features block column count controls

### DIFF
--- a/src/blocks/features/inspector.js
+++ b/src/blocks/features/inspector.js
@@ -42,6 +42,7 @@ class Inspector extends Component {
 			setBackgroundColor,
 			setTextColor,
 			textColor,
+			selectBlock,
 		} = this.props;
 
 		const {
@@ -92,7 +93,7 @@ class Inspector extends Component {
 							value={ columns }
 							onChange={ ( nextCount ) => {
 								setAttributes( {
-									columns: parseInt( nextCount ),
+									columns: Math.min( parseInt( nextCount ) || 1, 4 ),
 								} );
 
 								if ( parseInt( nextCount ) < 2 ) {
@@ -105,7 +106,7 @@ class Inspector extends Component {
 									} );
 								}
 
-								wp.data.dispatch( 'core/block-editor' ).selectBlock( clientId );
+								selectBlock( clientId );
 							} }
 							min={ 1 }
 							max={ 4 }

--- a/src/blocks/features/test/features.cypress.js
+++ b/src/blocks/features/test/features.cypress.js
@@ -43,15 +43,15 @@ describe( 'Test CoBlocks Features Block', function() {
 
 		cy.get( '.wp-block-coblocks-feature' ).should( 'have.length', 2 );
 
-		cy.get( '.edit-post-sidebar' ).find( 'input[aria-label="Columns"][type="number"]' ).click( { force: true } ).clear().type( 1 );
+		cy.get( '.edit-post-sidebar' ).find( 'input[aria-label="Columns"][type="number"]' ).focus().type( '{selectall}' ).type( 1 );
 
-		cy.get( '.wp-block-coblocks-feature' ).should( 'have.length', 1 );
+		cy.get( '.wp-block-coblocks-feature' ).should( 'have.length', 2 ); // Children should never decrease with column count
 
-		cy.get( '.edit-post-sidebar' ).find( 'input[aria-label="Columns"][type="number"]' ).click( { force: true } ).clear().type( 3 );
+		cy.get( '.edit-post-sidebar' ).find( 'input[aria-label="Columns"][type="number"]' ).focus().type( '{selectall}' ).type( 3 );
 
 		cy.get( '.wp-block-coblocks-feature' ).should( 'have.length', 3 );
 
-		cy.get( '.edit-post-sidebar' ).find( 'input[aria-label="Columns"][type="number"]' ).click( { force: true } ).clear().type( 4 );
+		cy.get( '.edit-post-sidebar' ).find( 'input[aria-label="Columns"][type="number"]' ).focus().type( '{selectall}' ).type( 4 );
 
 		cy.get( '.wp-block-coblocks-feature' ).should( 'have.length', 4 );
 
@@ -112,23 +112,23 @@ describe( 'Test CoBlocks Features Block', function() {
 
 	it( 'Updates the inner core/heading blocks when the "Heading Level" control is changed.', function() {
 		helpers.addBlockToPost( 'coblocks/features', true );
-		cy.get( '.wp-block-coblocks-feature h4' ).should('exist');
+		cy.get( '.wp-block-coblocks-feature h4' ).should( 'exist' );
 
 		cy.get( '.wp-block-coblocks-features' ).click();
 		helpers.openHeadingToolbarAndSelect( 2 );
-		cy.get( '.wp-block-coblocks-feature h2' ).should('exist');
+		cy.get( '.wp-block-coblocks-feature h2' ).should( 'exist' );
 
 		cy.get( '.wp-block-coblocks-features' ).click();
 		helpers.openHeadingToolbarAndSelect( 3 );
-		cy.get( '.wp-block-coblocks-feature h3' ).should('exist');
+		cy.get( '.wp-block-coblocks-feature h3' ).should( 'exist' );
 
 		cy.get( '.wp-block-coblocks-features' ).click();
 		helpers.openHeadingToolbarAndSelect( 4 );
-		cy.get( '.wp-block-coblocks-feature h4' ).should('exist');
+		cy.get( '.wp-block-coblocks-feature h4' ).should( 'exist' );
 
 		cy.get( '.wp-block-coblocks-features' ).click();
 		helpers.openHeadingToolbarAndSelect( 5 );
-		cy.get( '.wp-block-coblocks-feature h5' ).should('exist');
+		cy.get( '.wp-block-coblocks-feature h5' ).should( 'exist' );
 
 		helpers.savePage();
 		helpers.checkForBlockErrors( 'coblocks/features' );

--- a/src/blocks/features/test/features.cypress.js
+++ b/src/blocks/features/test/features.cypress.js
@@ -114,19 +114,19 @@ describe( 'Test CoBlocks Features Block', function() {
 		helpers.addBlockToPost( 'coblocks/features', true );
 		cy.get( '.wp-block-coblocks-feature h4' ).should( 'exist' );
 
-		cy.get( '.wp-block-coblocks-features' ).click();
+		cy.get( '.wp-block-coblocks-features' ).click( { force: true } );
 		helpers.openHeadingToolbarAndSelect( 2 );
 		cy.get( '.wp-block-coblocks-feature h2' ).should( 'exist' );
 
-		cy.get( '.wp-block-coblocks-features' ).click();
+		cy.get( '.wp-block-coblocks-features' ).click( { force: true } );
 		helpers.openHeadingToolbarAndSelect( 3 );
 		cy.get( '.wp-block-coblocks-feature h3' ).should( 'exist' );
 
-		cy.get( '.wp-block-coblocks-features' ).click();
+		cy.get( '.wp-block-coblocks-features' ).click( { force: true } );
 		helpers.openHeadingToolbarAndSelect( 4 );
 		cy.get( '.wp-block-coblocks-feature h4' ).should( 'exist' );
 
-		cy.get( '.wp-block-coblocks-features' ).click();
+		cy.get( '.wp-block-coblocks-features' ).click( { force: true } );
 		helpers.openHeadingToolbarAndSelect( 5 );
 		cy.get( '.wp-block-coblocks-feature h5' ).should( 'exist' );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The columns count controls had a few situations which could result in either `undefined` or a number > 4 being set for the columns attribute. This caused a number of strange behaviors most notably broken classnames. Another bug is that the inner-block count is not tied to the column count as it has been in the past. This is due to changes with core InnerBlocks component over time. 

This PR includes fixes for both of the bugs described above.

### Screenshots
<!-- if applicable -->
![featuresBlockColumnsCount](https://user-images.githubusercontent.com/30462574/96046995-3fb1d880-0e29-11eb-97bd-0f5bf291ec82.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes. Should not require any deprecations.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
E2E. Manually. With Gutenberg. Tested with 5.4.2 as well as 5.5.1.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
