### PR TITLE
Preserve gallery animations on transform

### DIFF
--- a/src/components/block-gallery/shared/transforms.js
+++ b/src/components/block-gallery/shared/transforms.js
@@ -12,6 +12,7 @@ import * as helper from './../../../utils/helper';
 function GalleryTransforms( props ) {
 	const transforms = {
 		align: props.align,
+		animation: props.animation,
 		autoPlay: props.autoPlay,
 		autoPlaySpeed: props.autoPlaySpeed,
 		captionColor: props.captionColor,


### PR DESCRIPTION
### Description
Preserve gallery animations whenever you transform between blocks.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested by adding an animation to a gallery block and transformed it to other blocks.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
