### PR TITLE
Define which version of composer to use within CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ jobs:
       - run:
           name: Install Composer dependencies
           command: |
+            sudo composer self-update --1
             composer validate --strict
             composer install
       - save_cache:
@@ -233,6 +234,10 @@ jobs:
             - composer-deps-{{ .Branch }}-{{ checksum "composer.lock" }}
             - composer-deps-{{ .Branch }}
             - composer-deps
+      - run:
+          name: Install Composer v1
+          command: |
+            sudo composer self-update --1
       - run:
           name: "Linting PHP"
           command: composer run lint $FILES
@@ -307,6 +312,10 @@ jobs:
             - composer-deps-{{ .Branch }}
             - composer-deps
       - run:
+          name: Install Composer v1
+          command: |
+            sudo composer self-update --1
+      - run:
           name: Waiting for MySQL to be ready
           command: |
             for i in `seq 1 10`;
@@ -348,6 +357,10 @@ jobs:
             - composer-deps-{{ .Branch }}-{{ checksum "composer.lock" }}
             - composer-deps-{{ .Branch }}
             - composer-deps
+      - run:
+          name: Install Composer v1
+          command: |
+            sudo composer self-update --1
       - run:
           name: Waiting for MySQL to be ready
           command: |
@@ -627,7 +640,7 @@ jobs:
           name: Install Composer
           command: |
             wget https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer -O composer-setup.php
-            php composer-setup.php
+            php composer-setup.php --version=1
             php -r "unlink('composer-setup.php');"
             sudo mv composer.phar /usr/local/bin/composer
       - run:
@@ -692,7 +705,7 @@ jobs:
           name: Install Composer
           command: |
             wget https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer -O composer-setup.php
-            php composer-setup.php
+            php composer-setup.php --version=1
             php -r "unlink('composer-setup.php');"
             sudo mv composer.phar /usr/local/bin/composer
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Install Composer dependencies
           command: |
-            sudo composer self-update --1
+            sudo composer self-update 1
             composer validate --strict
             composer install
       - save_cache:
@@ -237,7 +237,7 @@ jobs:
       - run:
           name: Install Composer v1
           command: |
-            sudo composer self-update --1
+            sudo composer self-update 1
       - run:
           name: "Linting PHP"
           command: composer run lint $FILES
@@ -314,7 +314,7 @@ jobs:
       - run:
           name: Install Composer v1
           command: |
-            sudo composer self-update --1
+            sudo composer self-update 1
       - run:
           name: Waiting for MySQL to be ready
           command: |
@@ -360,7 +360,7 @@ jobs:
       - run:
           name: Install Composer v1
           command: |
-            sudo composer self-update --1
+            sudo composer self-update 1
       - run:
           name: Waiting for MySQL to be ready
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,10 +312,6 @@ jobs:
             - composer-deps-{{ .Branch }}
             - composer-deps
       - run:
-          name: Install Composer v1
-          command: |
-            sudo composer self-update --1
-      - run:
           name: Waiting for MySQL to be ready
           command: |
             for i in `seq 1 10`;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Install Composer dependencies
           command: |
-            sudo composer self-update 1
+            sudo composer self-update --1
             composer validate --strict
             composer install
       - save_cache:
@@ -237,7 +237,7 @@ jobs:
       - run:
           name: Install Composer v1
           command: |
-            sudo composer self-update 1
+            sudo composer self-update --1
       - run:
           name: "Linting PHP"
           command: composer run lint $FILES
@@ -314,7 +314,7 @@ jobs:
       - run:
           name: Install Composer v1
           command: |
-            sudo composer self-update 1
+            sudo composer self-update --1
       - run:
           name: Waiting for MySQL to be ready
           command: |
@@ -360,7 +360,7 @@ jobs:
       - run:
           name: Install Composer v1
           command: |
-            sudo composer self-update 1
+            sudo composer self-update --1
       - run:
           name: Waiting for MySQL to be ready
           command: |


### PR DESCRIPTION
### Description
Currently we've only tested with Composer v1 and until we test against v2 (for which builds are currently failing), we need to force v1.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
