### PR TITLE
Fix broken style previews

### DIFF
--- a/src/blocks/share/styles/editor.scss
+++ b/src/blocks/share/styles/editor.scss
@@ -58,13 +58,13 @@
 			.block-editor-block-preview__content {
 
 				.wp-block-coblocks-social {
-					margin: 10vh;
 					align-content: center;
 					align-items: center;
 					background: transparent !important;
 					display: flex;
 					height: 100%;
 					justify-content: center;
+					margin: 10vh;
 					text-align: center !important;
 
 					&.is-style-text,

--- a/src/blocks/share/styles/editor.scss
+++ b/src/blocks/share/styles/editor.scss
@@ -58,6 +58,7 @@
 			.block-editor-block-preview__content {
 
 				.wp-block-coblocks-social {
+					margin: 10vh;
 					align-content: center;
 					align-items: center;
 					background: transparent !important;

--- a/src/blocks/share/styles/editor.scss
+++ b/src/blocks/share/styles/editor.scss
@@ -54,10 +54,8 @@
 	.block-editor-block-styles {
 
 		.block-editor-block-preview__container {
-			height: 100% !important;
 
 			.block-editor-block-preview__content {
-				margin-top: 35%;
 
 				.wp-block-coblocks-social {
 					align-content: center;


### PR DESCRIPTION
### Description
In an attempt to fix style previews for the Shape Divider and Social blocks, we've introduced a bug that affects all other style previews. This reverts those misapplied styles.
Before:
<img width="731" alt="Screen Shot 2020-11-04 at 11 08 47 AM" src="https://user-images.githubusercontent.com/1813435/98142194-7d88a680-1e95-11eb-880c-15078c023eae.png">
After: 
<img width="504" alt="Screen Shot 2020-11-04 at 11 54 08 AM" src="https://user-images.githubusercontent.com/1813435/98142188-7a8db600-1e95-11eb-8c18-0d315cf2fd0d.png">
