### PR TITLE
Add hint to the "Save Design Pattern" modal

### DIFF
--- a/src/components/info-popover/index.js
+++ b/src/components/info-popover/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import {
+	Button,
+	Popover,
+} from '@wordpress/components';
+import { info } from '@wordpress/icons';
+
+import './styles/editor.scss';
+
+export const InfoPopover = ( { title, children, popoverProps } ) => {
+	const [ isVisible, setIsVisible ] = useState( false );
+	return (
+		<Button
+			className="coblocks-info-popover__trigger"
+			icon={ info }
+			onClick={ () => setIsVisible( ! isVisible ) }
+			onMouseEnter={ () => setIsVisible( true ) }
+			onMouseLeave={ () => setIsVisible( false ) }
+		>
+			{ isVisible && (
+				<Popover
+					className="coblocks-info-popover"
+					headerTitle={ title }
+					focusOnMount={ false }
+					noArrow={ false }
+					{ ...popoverProps }
+				>
+					<h4 className="coblocks-info-popover__title">
+						{ title }
+					</h4>
+					<div className="coblocks-info-popover__content">
+						{ children }
+					</div>
+				</Popover>
+			) }
+		</Button>
+	);
+};

--- a/src/components/info-popover/styles/editor.scss
+++ b/src/components/info-popover/styles/editor.scss
@@ -1,0 +1,27 @@
+@import "node_modules/@wordpress/base-styles/variables";
+@import "node_modules/@wordpress/base-styles/colors";
+
+.coblocks-info-popover {
+
+    &.components-popover:not(.is-without-arrow)[data-y-axis="top"]::before,
+    &.components-popover:not(.is-without-arrow)[data-y-axis="top"]::after {
+        border-top-color: $gray-900 !important;
+    }
+
+    .components-popover__content {
+        color: $white;
+        background-color: $gray-900;
+        border-color: $gray-900;
+        border-radius: 7px;
+        padding: $grid-unit-20;
+    }
+
+    &__trigger.components-button.has-text svg {
+            margin-right: 0;
+    }
+
+    &__title {
+        margin: 0 0 $grid-unit-10 0;
+        font-size: 1rem;
+    }
+}

--- a/src/components/info-popover/styles/editor.scss
+++ b/src/components/info-popover/styles/editor.scss
@@ -3,25 +3,25 @@
 
 .coblocks-info-popover {
 
-    &.components-popover:not(.is-without-arrow)[data-y-axis="top"]::before,
-    &.components-popover:not(.is-without-arrow)[data-y-axis="top"]::after {
-        border-top-color: $gray-900 !important;
-    }
+	&.components-popover:not(.is-without-arrow)[data-y-axis="top"]::before,
+	&.components-popover:not(.is-without-arrow)[data-y-axis="top"]::after {
+		border-top-color: $gray-900 !important;
+	}
 
-    .components-popover__content {
-        color: $white;
-        background-color: $gray-900;
-        border-color: $gray-900;
-        border-radius: 7px;
-        padding: $grid-unit-20;
-    }
+	.components-popover__content {
+		background-color: $gray-900;
+		border-color: $gray-900;
+		border-radius: 7px;
+		color: $white;
+		padding: $grid-unit-20;
+	}
 
-    &__trigger.components-button.has-text svg {
-            margin-right: 0;
-    }
+	&__trigger.components-button.has-text svg {
+		margin-right: 0;
+	}
 
-    &__title {
-        margin: 0 0 $grid-unit-10 0;
-        font-size: 1rem;
-    }
+	&__title {
+		font-size: 1rem;
+		margin: 0 0 $grid-unit-10 0;
+	}
 }

--- a/src/extensions/block-patterns/modal.js
+++ b/src/extensions/block-patterns/modal.js
@@ -15,6 +15,11 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { InfoPopover } from '../../components/info-popover';
+
 class CoBlocksBlockPatternsModal extends Component {
 	constructor( props ) {
 		super( props );
@@ -111,7 +116,17 @@ class CoBlocksBlockPatternsModal extends Component {
 
 		return isOpen && (
 			<Modal
-				title={ __( 'Save Design Pattern', 'coblocks' ) }
+				title={ (
+					<>
+						{ __( 'Save Design Pattern', 'coblocks' ) }
+						<InfoPopover
+							title={ __( 'Design Patterns', 'coblocks' ) }
+							popoverProps={ { position: 'top center' } }
+						>
+							{ __( 'Create reusable content and designs that can be quickly added anywhere, but not be tied to other copies of itself (i.e. changing one will not affect the others).', 'coblocks' ) }
+						</InfoPopover>
+					</>
+				) }
 				onRequestClose={ closeModal }
 				className="coblocks-block-patterns__modal"
 			>

--- a/src/extensions/block-patterns/styles/style.scss
+++ b/src/extensions/block-patterns/styles/style.scss
@@ -4,8 +4,8 @@
 .coblocks-block-patterns__modal {
 
 	.components-modal__header-heading {
-		display: flex;
 		align-items: center;
+		display: flex;
 	}
 
 	.components-base-control__field {

--- a/src/extensions/block-patterns/styles/style.scss
+++ b/src/extensions/block-patterns/styles/style.scss
@@ -3,6 +3,11 @@
 
 .coblocks-block-patterns__modal {
 
+	.components-modal__header-heading {
+		display: flex;
+		align-items: center;
+	}
+
 	.components-base-control__field {
 		margin-bottom: $grid-unit-20;
 	}


### PR DESCRIPTION
### Description
Adds an icon button to the heading of the "Save Design Pattern" modal which displays a popover with helpful information on hover and on click.

This new icon button with popover has been added as the `InfoPopover` component so that it can be reused across CoBlocks.

### Screenshots
![Kapture 2020-11-11 at 17 19 20](https://user-images.githubusercontent.com/375788/98871372-d1b9fa80-2442-11eb-9bfb-fb045bc695b3.gif)

### Types of changes
Enhancement

### How has this been tested?
Manually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
