### PR TITLE
Define Layout Selector visibility in store

### DIFF
--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -56,6 +56,14 @@ class LayoutSelector extends Component {
 		};
 	}
 
+	componentDidMount() {
+		const { isCleanUnpublishedPost, openTemplateSelector } = this.props;
+
+		if ( isCleanUnpublishedPost ) {
+			openTemplateSelector();
+		}
+	}
+
 	useEmptyTemplateLayout = () => {
 		const {
 			editPost,
@@ -234,18 +242,20 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 
 				return {
 					isActive: isCleanUnpublishedPost || isTemplateSelectorActive(),
+					isCleanUnpublishedPost,
 					layoutSelectorEnabled: getLayoutSelector() && hasLayouts() && hasCategories(),
 					layouts,
 					categories: getCategories(),
 				};
 			} ),
 			withDispatch( ( dispatch ) => {
-				const { closeTemplateSelector } = dispatch( 'coblocks/template-selector' );
+				const { closeTemplateSelector, openTemplateSelector } = dispatch( 'coblocks/template-selector' );
 				const { editPost } = dispatch( 'core/editor' );
 				const { createWarningNotice } = dispatch( 'core/notices' );
 
 				return {
 					closeTemplateSelector,
+					openTemplateSelector,
 					createWarningNotice,
 					editPost,
 				};

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import map from 'lodash/map';
 
 /**
  * WordPress dependencies
@@ -54,14 +53,6 @@ class LayoutSelector extends Component {
 		this.state = {
 			selectedCategory: 'about',
 		};
-	}
-
-	componentDidMount() {
-		const { isCleanUnpublishedPost, openTemplateSelector } = this.props;
-
-		if ( isCleanUnpublishedPost ) {
-			openTemplateSelector();
-		}
 	}
 
 	useEmptyTemplateLayout = () => {
@@ -215,15 +206,7 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 					hasCategories,
 					getCategories,
 				} = select( 'coblocks/template-selector' );
-				const {
-					getCurrentPostAttribute,
-					hasEditorUndo,
-					isCurrentPostPublished,
-				} = select( 'core/editor' );
 				const { getLayoutSelector } = select( 'coblocks-settings' );
-
-				const isDraft = [ 'draft' ].indexOf( getCurrentPostAttribute( 'status' ) ) !== -1;
-				const isCleanUnpublishedPost = ! isCurrentPostPublished() && ! hasEditorUndo() && ! isDraft;
 
 				// Get block objects before passing into the component.
 				const layouts = getLayouts().map(
@@ -241,21 +224,19 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 				);
 
 				return {
-					isActive: isCleanUnpublishedPost || isTemplateSelectorActive(),
-					isCleanUnpublishedPost,
+					isActive: isTemplateSelectorActive(),
 					layoutSelectorEnabled: getLayoutSelector() && hasLayouts() && hasCategories(),
 					layouts,
 					categories: getCategories(),
 				};
 			} ),
 			withDispatch( ( dispatch ) => {
-				const { closeTemplateSelector, openTemplateSelector } = dispatch( 'coblocks/template-selector' );
+				const { closeTemplateSelector } = dispatch( 'coblocks/template-selector' );
 				const { editPost } = dispatch( 'core/editor' );
 				const { createWarningNotice } = dispatch( 'core/notices' );
 
 				return {
 					closeTemplateSelector,
-					openTemplateSelector,
 					createWarningNotice,
 					editPost,
 				};

--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -65,7 +65,7 @@ const store = registerStore( 'coblocks/template-selector', {
 			const isCurrentPostPublished = yield select( 'core/editor', 'isCurrentPostPublished' );
 
 			const isDraft = getCurrentPostAttributeStatus.includes( 'draft' );
-			const isCleanUnpublishedPost = ! isCurrentPostPublished && ! hasEditorUndo && ! isDraft;
+			const isCleanUnpublishedPost = ! isCurrentPostPublished && ! hasEditorUndo && isDraft;
 
 			return isCleanUnpublishedPost && actions.openTemplateSelector();
 		},

--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -3,6 +3,7 @@
  * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
+import { controls, select } from '@wordpress/data-controls';
 
 const DEFAULT_STATE = {
 	templateSelector: false,
@@ -48,11 +49,26 @@ const store = registerStore( 'coblocks/template-selector', {
 	actions,
 
 	selectors: {
-		isTemplateSelectorActive: ( state ) => state.templateSelector || false,
+		isTemplateSelectorActive: ( state ) => state.templateSelector,
 		hasLayouts: ( state ) => !! state.layouts.length,
 		getLayouts: ( state ) => state.layouts || [],
 		getCategories: ( state ) => state.categories || [],
 		hasCategories: ( state ) => !! state.categories.length,
+	},
+
+	controls,
+
+	resolvers: {
+		* isTemplateSelectorActive() {
+			const getCurrentPostAttributeStatus = yield select( 'core/editor', 'getCurrentPostAttribute', 'status' );
+			const hasEditorUndo = yield select( 'core/editor', 'hasEditorUndo' );
+			const isCurrentPostPublished = yield select( 'core/editor', 'isCurrentPostPublished' );
+
+			const isDraft = getCurrentPostAttributeStatus.includes( 'draft' );
+			const isCleanUnpublishedPost = ! isCurrentPostPublished && ! hasEditorUndo && ! isDraft;
+
+			return isCleanUnpublishedPost && actions.openTemplateSelector();
+		},
 	},
 } );
 


### PR DESCRIPTION
### Description
We need to save the Layout Selector visibility in its store

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
