### PR TITLE
Add logic to deprecate typography controls from Click-To-Tweet block

### DIFF
--- a/src/blocks/click-to-tweet/deprecated.js
+++ b/src/blocks/click-to-tweet/deprecated.js
@@ -12,11 +12,16 @@ import { RichText, getColorClassName, getFontSizeClass } from '@wordpress/block-
  * Internal dependencies
  */
 import { attributes } from './block.json';
-
+import { deprecateTypographyControls } from '../../extensions/typography';
+import save from './save';
 const deprecated = [
 	{
+		attributes: deprecateTypographyControls( attributes ),
+		save,
+	},
+	{
 		attributes,
-		save( { attributes } ) {
+		save( props ) {
 			const {
 				buttonColor,
 				buttonText,
@@ -29,7 +34,7 @@ const deprecated = [
 				textAlign,
 				url,
 				via,
-			} = attributes;
+			} = props.attributes;
 
 			const viaUrl = via ? `&via=${ via }` : '';
 

--- a/src/extensions/typography/index.js
+++ b/src/extensions/typography/index.js
@@ -22,10 +22,14 @@ const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/pullquote', 'cor
 const deprecatedBlocks = [ 'coblocks/click-to-tweet' ];
 
 /**
- * Compares against list of blocks with deprecated typography controls and prepares attributes for deprecation when needed.
+ * Compares against list of blocks with deprecated typography controls and prepares
+ * attributes for deprecation when needed.
  *
- * @param {Object} attributes Original block attributes.
- * @return {Object} Filtered block attributes.
+ * Does not modify settings for registered block - Will only modify attributes
+ * used within the deprecated function.
+ *
+ * @param {Object} attributes Original registered block attributes.
+ * @return {Object} Block attributes filtered for deprecation .
  */
 export function deprecateTypographyControls( attributes ) {
 	addFilter(
@@ -33,7 +37,7 @@ export function deprecateTypographyControls( attributes ) {
 		'coblocks/inspector/attributes',
 		( settings ) => {
 			if ( deprecatedBlocks.includes( settings.name ) ) {
-				settings.attributes = Object.assign( settings.attributes, TypographyAttributes );
+				attributes = Object.assign( attributes, TypographyAttributes );
 			}
 			return settings;
 		}

--- a/src/extensions/typography/index.js
+++ b/src/extensions/typography/index.js
@@ -18,7 +18,28 @@ import { addFilter } from '@wordpress/hooks';
 import { Fragment }	from '@wordpress/element';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 
-const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/pullquote', 'core/cover', 'core/quote', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/click-to-tweet', 'coblocks/alert', 'coblocks/highlight', 'coblocks/pricing-table', 'coblocks/features' ];
+const allowedBlocks = [ 'core/paragraph', 'core/heading', 'core/pullquote', 'core/cover', 'core/quote', 'core/button', 'core/list', 'coblocks/row', 'coblocks/column', 'coblocks/accordion', 'coblocks/accordion-item', 'coblocks/alert', 'coblocks/highlight', 'coblocks/pricing-table', 'coblocks/features' ];
+const deprecatedBlocks = [ 'coblocks/click-to-tweet' ];
+
+/**
+ * Compares against list of blocks with deprecated typography controls and prepares attributes for deprecation when needed.
+ *
+ * @param {Object} attributes Original block attributes.
+ * @return {Object} Filtered block attributes.
+ */
+export function deprecateTypographyControls( attributes ) {
+	addFilter(
+		'blocks.registerBlockType',
+		'coblocks/inspector/attributes',
+		( settings ) => {
+			if ( deprecatedBlocks.includes( settings.name ) ) {
+				settings.attributes = Object.assign( settings.attributes, TypographyAttributes );
+			}
+			return settings;
+		}
+	);
+	return attributes;
+}
 
 /**
  * Filters registered block settings, extending attributes with settings
@@ -136,7 +157,7 @@ const withFontSettings = createHigherOrderComponent( ( BlockListBlock ) => {
  * @return {Object} Filtered props applied to save element.
  */
 function applyFontSettings( extraProps, blockType, attributes ) {
-	if ( allowedBlocks.includes( blockType.name ) ) {
+	if ( allowedBlocks.includes( blockType.name ) || deprecatedBlocks.includes( blockType.name ) ) {
 		if ( typeof extraProps.style !== 'undefined' ) {
 			extraProps.style = Object.assign( extraProps.style, applyStyle( attributes, blockType.name ) );
 		} else {


### PR DESCRIPTION
### Description
Add logic to deprecate Typography controls from Click-To-Tweet block. Invalid block content will occur unless the typography attributes are registered with a deprecated save function.

### Screenshots
<!-- if applicable -->
**Configured Typograhy Controls**
![clickToTweetTypography](https://user-images.githubusercontent.com/30462574/99271373-1c8d9680-27e4-11eb-8161-8af2eb2a89d5.gif)

**Disabled Controls**
![clickToTweetTypographyDisabled](https://user-images.githubusercontent.com/30462574/99271909-68404000-27e4-11eb-8f24-cce38345c7f2.gif)

**Deprecated Controls**
![clickToTweetTypographyDeprecated](https://user-images.githubusercontent.com/30462574/99272132-aa698180-27e4-11eb-93dd-14b0bf5248d8.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript and new logic changes around click-to-tweet block deprecation.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
