### PR TITLE
Add logic to prevent insertion of Media Card block

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -44,6 +44,7 @@ import { supportsCollections } from './utils/block-helpers';
 
 // Deprecate Blocks
 import './js/deprecations/deprecate-coblocks-buttons.js';
+import './js/deprecations/deprecate-coblocks-media-card.js';
 
 // Register Blocks
 import * as accordion from './blocks/accordion';

--- a/src/blocks/media-card/test/media-card.cypress.js
+++ b/src/blocks/media-card/test/media-card.cypress.js
@@ -1,115 +1,18 @@
-/*
- * Include our constants
- */
-import * as helpers from '../../../../.dev/tests/cypress/helpers';
-
 describe( 'Test CoBlocks Media Card Block', function() {
 	/**
-	 * Setup media-card data
+	 * Test that we can not insert a media-card block into the page.
+	 * Media-card blocks is deprecated and should not be usable.
 	 */
-	const mediaData = {
-		colorData: {
-			backgroundColor: '#ff0000',
-			backgroundColorRGB: 'rgb(255, 0, 0)',
-		},
-	};
+	it( 'Test media-card block in not insertable.', function() {
+		cy.get( '.edit-post-header-toolbar' ).find( '.edit-post-header-toolbar__inserter-toggle' ).then( ( inserterButton ) => {
+			if ( ! Cypress.$( inserterButton ).hasClass( 'is-pressed' ) ) {
+				cy.get( inserterButton ).click();
+			}
+		} );
 
-	/**
-	 * Test that we can add a media-card block to the content, not add any images or
-	 * alter any settings, and are able to successfully save the block without errors.
-	 */
-	it( 'Test media-card block saves with empty values.', function() {
-		helpers.addBlockToPost( 'coblocks/media-card', true );
+		cy.get( '.block-editor-inserter__search' ).find( 'input' ).clear();
+		cy.get( '.block-editor-inserter__search' ).click().type( 'media-card' );
 
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/media-card' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-media-card' ).should( 'exist' );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test that we can upload images to block and are able
-	 * to successfully save the block without errors.
-	 */
-	it( 'Test media-card block saves with image upload.', function() {
-		const { imageBase } = helpers.upload.spec;
-		helpers.addBlockToPost( 'coblocks/media-card', true );
-
-		cy.get( '[data-type="coblocks/media-card"]' ).click();
-
-		helpers.upload.imageToBlock( 'coblocks/media-card' );
-
-		cy.get( `img[src*="${imageBase}"]` );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/media-card' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-media-card' ).find( 'img' ).should( 'have.attr', 'src' ).should( 'include', imageBase );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test that we can add image from library and are able
-	 * to successfully save the block without errors.
-	 */
-	it( 'Test media-card block saves with images from media library.', function() {
-		helpers.addBlockToPost( 'coblocks/media-card', true );
-
-		cy.get( '[data-type="coblocks/media-card"]' )
-			.click()
-			.find( 'button' )
-			.contains( /media library/i )
-			.click( { force: true } );
-
-		cy.get( '.media-modal-content' ).contains( /media library/i ).click();
-
-		cy.get( '.media-modal-content' ).find( 'li.attachment' )
-			.first( 'li' )
-			.click();
-
-		cy.get( '.media-toolbar' ).find( 'button' ).click();
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/media-card' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-media-card' ).should( 'exist' );
-		cy.get( '.wp-block-coblocks-media-card' ).find( 'img' ).should( 'have.attr', 'src' );
-
-		helpers.editPage();
-	} );
-
-	/**
-	 * Test that we can add a media-card block to the content, adjust colors
-	 * and are able to successfully save the block without errors.
-	 */
-	it( 'Test media-card block saves with color values set.', function() {
-		const { backgroundColor, backgroundColorRGB } = mediaData.colorData;
-		helpers.addBlockToPost( 'coblocks/media-card', true );
-
-		helpers.setColorSetting( 'background color', backgroundColor );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/media-card' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-media-card' ).should( 'exist' );
-		cy.get( '.wp-block-coblocks-media-card__inner' )
-			.should( 'have.css', 'background-color', backgroundColorRGB );
-
-		helpers.editPage();
+		cy.get( '.block-editor-inserter__block-list .editor-block-list-item-coblocks-media-card' ).should( 'not.exist' );
 	} );
 } );

--- a/src/js/deprecations/deprecate-coblocks-media-card.js
+++ b/src/js/deprecations/deprecate-coblocks-media-card.js
@@ -31,14 +31,7 @@ function deprecateCoBlocksMediaCardSettings() {
  * @return {boolean} True or false if block is deprecated.
  */
 export function mediaCardBlockDeprecated( coreMediaText, coBlocksMediaCard ) {
-	if ( ! coreMediaText ) {
-		return false;
-	}
-
-	if ( ! coBlocksMediaCard ) {
-		return false;
-	}
-	return true;
+	return ( ! coreMediaText || ! coBlocksMediaCard ) ? false : true;
 }
 
 domReady( deprecateCoBlocksMediaCardSettings );

--- a/src/js/deprecations/deprecate-coblocks-media-card.js
+++ b/src/js/deprecations/deprecate-coblocks-media-card.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Prevents the CoBlocks Media Card block from being insertable.
+ */
+function deprecateCoBlocksMediaCardSettings() {
+	const coreMediaText = getBlockType( 'core/media-text' );
+	const coBlocksMediaCard = getBlockType( 'coblocks/media-card' );
+	if ( mediaCardBlockDeprecated( coreMediaText, coBlocksMediaCard ) ) {
+		unregisterBlockType( 'coblocks/media-card' );
+		registerBlockType( 'coblocks/media-card', {
+			...coBlocksMediaCard,
+			supports: {
+				...coBlocksMediaCard.supports,
+				inserter: false,
+			},
+		} );
+	}
+}
+
+/**
+ * Check whether or not core/media-card is available for use.
+ *
+ * @param {Object} coreMediaText The results of getBlockType.
+ * @param {Object} coBlocksMediaCard The results of getBlockType.
+ *
+ * @return {boolean} True or false if block is deprecated.
+ */
+export function mediaCardBlockDeprecated( coreMediaText, coBlocksMediaCard ) {
+	if ( ! coreMediaText ) {
+		return false;
+	}
+
+	if ( ! coBlocksMediaCard ) {
+		return false;
+	}
+	return true;
+}
+
+domReady( deprecateCoBlocksMediaCardSettings );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Add logic to deprecate CoBlocks media-card block by preventing common block insertion. Since the block is still registered a user is allowed to duplicate or copy existing media-card blocks without issue. Another thing to consider here is that the media-card does not automatically transform to a media-text block as does happen from the `coblocks/buttons` -> `core/buttons` deprecation. 

### Screenshots
<!-- if applicable -->
![mediaCardDeprecated](https://user-images.githubusercontent.com/30462574/99406283-f4b53600-28aa-11eb-8049-679825398295.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes to allow for block deprecation of the media-card block.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
