### PR TITLE
Remove ability to transform into Media Card block

### DIFF
--- a/src/blocks/media-card/test/transforms.spec.js
+++ b/src/blocks/media-card/test/transforms.spec.js
@@ -27,42 +27,6 @@ describe( 'coblocks/media-card transforms', () => {
 		registerBlockType( name, { category: 'common', ...settings } );
 	} );
 
-	it( 'should transform from core/image block', () => {
-		const coreImage = createBlock( 'core/image', { id: attributes.mediaId, url: attributes.mediaUrl, alt: attributes.mediaAlt } );
-		const transformed = switchToBlockType( coreImage, name );
-
-		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].name ).toBe( name );
-
-		expect( transformed[ 0 ].attributes.mediaUrl ).toBe( attributes.mediaUrl );
-		expect( transformed[ 0 ].attributes.mediaId ).toBe( attributes.mediaId );
-		expect( transformed[ 0 ].attributes.mediaAlt ).toBe( attributes.mediaAlt );
-	} );
-
-	it( 'should transform from core/video block', () => {
-		const coreImage = createBlock( 'core/video', { id: attributes.mediaId, src: attributes.mediaUrl } );
-		const transformed = switchToBlockType( coreImage, name );
-
-		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].name ).toBe( name );
-
-		expect( transformed[ 0 ].attributes.mediaUrl ).toBe( attributes.mediaUrl );
-		expect( transformed[ 0 ].attributes.mediaId ).toBe( attributes.mediaId );
-	} );
-
-	it( 'should transform from core/media-text block', () => {
-		const coreMediaText = createBlock( 'core/media-text', attributes );
-		const transformed = switchToBlockType( coreMediaText, name );
-
-		expect( transformed[ 0 ].isValid ).toBe( true );
-		expect( transformed[ 0 ].name ).toBe( name );
-
-		expect( transformed[ 0 ].attributes.mediaAlt ).toBe( attributes.mediaAlt );
-		expect( transformed[ 0 ].attributes.mediaUrl ).toBe( attributes.mediaUrl );
-		expect( transformed[ 0 ].attributes.mediaType ).toBe( attributes.mediaType );
-		expect( transformed[ 0 ].attributes.mediaPosition ).toBe( attributes.mediaPosition );
-	} );
-
 	it( 'should transform to core/image block', () => {
 		const block = createBlock( name, attributes );
 		const transformed = switchToBlockType( block, 'core/image' );
@@ -97,13 +61,5 @@ describe( 'coblocks/media-card transforms', () => {
 		expect( transformed[ 0 ].attributes.mediaUrl ).toBe( attributes.mediaUrl );
 		expect( transformed[ 0 ].attributes.mediaType ).toBe( attributes.mediaType );
 		expect( transformed[ 0 ].attributes.mediaPosition ).toBe( attributes.mediaPosition );
-	} );
-
-	it( 'should transform when :card prefix is seen', () => {
-		const prefix = ':card';
-		const block = helpers.performPrefixTransformation( name, prefix, prefix );
-
-		expect( block.isValid ).toBe( true );
-		expect( block.name ).toBe( name );
 	} );
 } );

--- a/src/blocks/media-card/transforms.js
+++ b/src/blocks/media-card/transforms.js
@@ -1,59 +1,10 @@
 /**
- * Internal dependencies
- */
-import metadata from './block.json';
-
-/**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
-	from: [
-		{
-			type: 'prefix',
-			prefix: ':card',
-			transform() {
-				return createBlock( metadata.name );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/image' ],
-			transform: ( { alt, url, id } ) => (
-				createBlock( metadata.name, {
-					mediaAlt: alt,
-					mediaId: id,
-					mediaUrl: url,
-					mediaType: 'image',
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/video' ],
-			transform: ( { src, id } ) => (
-				createBlock( metadata.name, {
-					mediaId: id,
-					mediaUrl: src,
-					mediaType: 'video',
-				} )
-			),
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/media-text' ],
-			transform: ( { mediaAlt, mediaUrl, mediaId, mediaType, mediaPosition } ) => (
-				createBlock( metadata.name, {
-					mediaAlt,
-					mediaId,
-					mediaUrl,
-					mediaType,
-					mediaPosition,
-				} )
-			),
-		},
-	],
+	from: [],
 	to: [
 		{
 			type: 'block',


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Simple changes here to remove transform functions as well as corresponding jest tests for those transforms. With the imminent deprecation of the Media-Card block, this change will ensure that users cannot unexpectedly use a Media-Card block.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Jest tests correctly failed when transforms are removed. This is the expected behavior for the tests. The tests have now been removed and behavior has been manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
