### PR TITLE
Use a static php container in E2E pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
 
   e2e_chrome:
     docker:
-      - image: circleci/php:latest-node-browsers
+      - image: circleci/php:7.3.23-node-browsers
       - image: circleci/mysql:5.7
     parallelism: 4
     steps:
@@ -481,7 +481,7 @@ jobs:
 
   e2e_firefox:
     docker:
-      - image: circleci/php:latest-node-browsers
+      - image: circleci/php:7.3.23-node-browsers
       - image: circleci/mysql:5.7
     parallelism: 4
     steps:


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR changes the PHP image used for E2E jobs in the CoBlocks CI-CD pipeline.

**Original**
`- image: circleci/php:latest-node-browsers`
**Changed to**
`- image: circleci/php:7.3.23-node-browsers`


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Configuration changes for Circle Ci

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in the CI pipeline

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
