### PR TITLE
Use a symlink instead of copy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands:
       - run:
           name: Activate CoBlocks
           command: |
-            cp -a $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
+            ln -s $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
             ./vendor/bin/wp plugin activate coblocks --path=/tmp/wordpress
 
   # Disable the xdebug PHP extension.


### PR DESCRIPTION
### Description
Simple change and optimization of install job in CI pipeline. Instead of copying the plugin files, we should create a symlink to those files.


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Configuration changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in the CI-CD pipeline.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
