### PR TITLE
Add aria-labels to the CoBlocks Lightbox utility

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -403,6 +403,16 @@ class CoBlocks_Block_Assets {
 				true
 			);
 		}
+
+		wp_localize_script(
+			'coblocks-lightbox',
+			'coblocksLigthboxData',
+			array(
+				'closeLabel' => __( 'Close Gallery', 'coblocks' ),
+				'leftLabel' => __( 'Previous', 'coblocks' ),
+				'rightLabel' => __( 'Next', 'coblocks' ),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -409,7 +409,7 @@ class CoBlocks_Block_Assets {
 			'coblocksLigthboxData',
 			array(
 				'closeLabel' => __( 'Close Gallery', 'coblocks' ),
-				'leftLabel' => __( 'Previous', 'coblocks' ),
+				'leftLabel'  => __( 'Previous', 'coblocks' ),
 				'rightLabel' => __( 'Next', 'coblocks' ),
 			)
 		);

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -1,6 +1,8 @@
+/*global coblocksLigthboxData */
 ( function( ) {
 	'use strict';
 
+	const { closeLabel, leftLabel, rightLabel } = coblocksLigthboxData;
 	const lightboxModals = document.getElementsByClassName( 'has-lightbox' );
 
 	Array.from( lightboxModals ).forEach( function( lightbox, index ) {
@@ -20,6 +22,7 @@
 
 		const close = document.createElement( 'button' );
 		close.setAttribute( 'class', 'coblocks-lightbox__close' );
+		close.setAttribute( 'aria-label', closeLabel );
 
 		const counter = document.createElement( 'span' );
 		counter.setAttribute( 'class', 'coblocks-lightbox__count' );
@@ -40,9 +43,11 @@
 
 		const arrowRight = document.createElement( 'div' );
 		arrowRight.setAttribute( 'class', 'arrow-right' );
+		arrowRight.setAttribute( 'aria-label', rightLabel );
 
 		const arrowLeft = document.createElement( 'div' );
 		arrowLeft.setAttribute( 'class', 'arrow-left' );
+		arrowLeft.setAttribute( 'aria-label', leftLabel );
 
 		const images = document.querySelectorAll( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure img, figure.has-lightbox.lightbox-${ lightboxIndex } > img` );
 		const captions = document.querySelectorAll( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure figcaption` );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The Lightbox had been missing `aria-labels` for the interactive buttons on screen. This PR introduces the needed `aria-labels` for the `left`, `right`, and `close` buttons.

```html
<button class="coblocks-lightbox__close" aria-label="Close Gallery"></button>
...
<div class="arrow-left" aria-label="Previous"></div>
...
<div class="arrow-right" aria-label="Next"></div>
```

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor changes in Lightbox Markup. No deprecation needed. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in the browser.


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
