### PR TITLE
Add "most used" section to the layout selector.

### DIFF
--- a/src/extensions/animation/index.js
+++ b/src/extensions/animation/index.js
@@ -46,7 +46,7 @@ const withControls = createHigherOrderComponent( ( BlockEdit ) => {
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ props.isSelected && allowedBlocks.some( block => block.blockType === props.name ) && <Controls { ...{ ...props, selectedBlock: block } } /> }
+				{ props.isSelected && allowedBlocks.some( ( allowedBlock ) => allowedBlock.blockType === props.name ) && <Controls { ...{ ...props, selectedBlock: block } } /> }
 			</>
 		);
 	} );
@@ -65,7 +65,7 @@ addFilter(
  * @return {Object} Filtered block settings.
  */
 function addAttributes( settings ) {
-	if ( allowedBlocks.some( block => block.blockType === settings.name ) ) {
+	if ( allowedBlocks.some( ( block ) => block.blockType === settings.name ) ) {
 		settings.attributes = {
 			...settings.attributes,
 			animation: {
@@ -93,8 +93,7 @@ addFilter(
  * @return {Object} Filtered props applied to save element.
  */
 function applyAnimationSettings( extraProps, blockType, attributes ) {
-
-	if ( ! allowedBlocks.some( block => block.blockType === blockType.name && ! block.animateChildren ) ) {
+	if ( ! allowedBlocks.some( ( block ) => block.blockType === blockType.name && ! block.animateChildren ) ) {
 		return extraProps;
 	}
 
@@ -138,7 +137,7 @@ const withAnimationSettings = createHigherOrderComponent( ( BlockListBlock ) => 
 		const block = select( 'core/block-editor' ).getBlock( props.rootClientId || props.clientId );
 		const blockName	= select( 'core/block-editor' ).getBlockName( props.rootClientId || props.clientId );
 
-		if ( ! allowedBlocks.some( block => block.blockType === blockName && ! block.animateChildren ) || ! block?.attributes?.animation ) {
+		if ( ! allowedBlocks.some( ( allowedBlock ) => allowedBlock.blockType === blockName && ! allowedBlock.animateChildren ) || ! block?.attributes?.animation ) {
 			return <BlockListBlock { ...props } />;
 		}
 

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +23,8 @@ import { createBlock, rawHandler } from '@wordpress/blocks';
 import './store';
 import { LayoutSelectorResults } from './layout-selector-results';
 import CoBlocksLayoutSelectorFill from './layout-selector-slot';
+
+const MAX_SUGGESTED_ITEMS = 6;
 
 const getBlocksFromTemplate = ( name, attributes, innerBlocks = [] ) => {
 	return createBlock( name, attributes,
@@ -55,26 +58,6 @@ class LayoutSelector extends Component {
 		};
 	}
 
-	useEmptyTemplateLayout = () => {
-		const {
-			editPost,
-		} = this.props;
-
-		editPost( { title: '', blocks: [] } );
-	}
-
-	// Replace any blocks with the selected layout.
-	useTemplateLayout = ( layout ) => {
-		const {
-			editPost,
-		} = this.props;
-
-		editPost( {
-			title: layout.label,
-			blocks: layout.blocks,
-		} );
-	}
-
 	getLayoutsInCategory( category ) {
 		return this.props.layouts.filter( ( layout ) => layout.category === category ) || [];
 	}
@@ -87,8 +70,9 @@ class LayoutSelector extends Component {
 		const { selectedCategory } = this.state;
 		const {
 			isActive,
-			closeTemplateSelector,
 			layoutSelectorEnabled,
+			useEmptyTemplateLayout,
+			useTemplateLayout,
 		} = this.props;
 
 		if ( ! layoutSelectorEnabled ) {
@@ -105,10 +89,7 @@ class LayoutSelector extends Component {
 						<span>{ __( 'Pick one of these layouts or start with a blank page.', 'coblocks' ) }</span>
 					</Fragment>
 				) }
-				onRequestClose={ () => {
-					this.useEmptyTemplateLayout();
-					closeTemplateSelector();
-				} }
+				onRequestClose={ () => useEmptyTemplateLayout() }
 				className="coblocks-layout-selector-modal">
 				<div className="coblocks-layout-selector">
 					<aside className="coblocks-layout-selector__sidebar">
@@ -134,10 +115,7 @@ class LayoutSelector extends Component {
 
 						<Button
 							className="coblocks-layout-selector__add-button"
-							onClick={ () => {
-								this.useEmptyTemplateLayout();
-								closeTemplateSelector();
-							} }
+							onClick={ () => useEmptyTemplateLayout() }
 							isLink>
 							<span><SVG width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><Path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z" /></SVG></span>
 							{ __( 'Add blank page', 'coblocks' ) }
@@ -169,10 +147,7 @@ class LayoutSelector extends Component {
 						<div className="coblocks-layout-selector__topbar__right">
 							<Button
 								className="coblocks-layout-selector__add-button"
-								onClick={ () => {
-									this.useEmptyTemplateLayout();
-									closeTemplateSelector();
-								} }
+								onClick={ () => useEmptyTemplateLayout() }
 								isLink>
 								<span><Icon icon="plus" size={ 16 } /></span> { __( 'Add blank page', 'coblocks' ) }
 							</Button>
@@ -183,10 +158,7 @@ class LayoutSelector extends Component {
 						<LayoutSelectorResults
 							layouts={ this.props.layouts }
 							category={ selectedCategory }
-							onInsert={ ( layout ) => {
-								this.useTemplateLayout( layout );
-								this.props.closeTemplateSelector();
-							} }
+							onInsert={ ( layout ) => useTemplateLayout( layout ) }
 						/>
 					</div>
 				</div>
@@ -223,15 +195,26 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 					}
 				);
 
+				const mostUsedLayouts = orderBy( layouts, [ 'frequency' ], [ 'desc' ] )
+					.slice( 0, MAX_SUGGESTED_ITEMS )
+					.map( ( layout ) => ( { ...layout, category: 'most-used' } ) );
+				layouts.push( ...mostUsedLayouts );
+
 				return {
 					isActive: isTemplateSelectorActive(),
 					layoutSelectorEnabled: getLayoutSelector() && hasLayouts() && hasCategories(),
 					layouts,
-					categories: getCategories(),
+					categories: [
+						{ slug: 'most-used', title: __( 'Most Used', 'coblocks' ) },
+						...getCategories(),
+					],
 				};
 			} ),
 			withDispatch( ( dispatch ) => {
-				const { closeTemplateSelector } = dispatch( 'coblocks/template-selector' );
+				const {
+					closeTemplateSelector,
+					incrementLayoutUsage,
+				} = dispatch( 'coblocks/template-selector' );
 				const { editPost } = dispatch( 'core/editor' );
 				const { createWarningNotice } = dispatch( 'core/notices' );
 
@@ -239,6 +222,21 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 					closeTemplateSelector,
 					createWarningNotice,
 					editPost,
+
+					// Replace any blocks with the selected layout.
+					useTemplateLayout: ( layout ) => {
+						editPost( {
+							title: layout.label,
+							blocks: layout.blocks,
+						} );
+						closeTemplateSelector();
+						incrementLayoutUsage( layout );
+					},
+
+					useEmptyTemplateLayout: () => {
+						editPost( { title: '', blocks: [] } );
+						closeTemplateSelector();
+					},
 				};
 			} ),
 		] )( LayoutSelector ),

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -81,7 +81,7 @@ export const LayoutPreview = ( { layout, onClick } ) => {
 /**
  * Renders the layout's loading placeholder.
  */
-const LayoutPreviewPlaceholder = () => {
+export const LayoutPreviewPlaceholder = () => {
 	return (
 		<div className="coblocks-layout-selector__layout is-placeholder">
 			<Spinner />

--- a/src/extensions/layout-selector/test/layout-preview.spec.js
+++ b/src/extensions/layout-selector/test/layout-preview.spec.js
@@ -3,8 +3,6 @@
  */
 import { shallow } from 'enzyme';
 import '@testing-library/jest-dom/extend-expect';
-import '@wordpress/hooks';
-import { addFilter } from '@wordpress/hooks';
 
 import { registerCoreBlocks } from '@wordpress/block-library';
 registerCoreBlocks();
@@ -13,46 +11,180 @@ registerCoreBlocks();
  * Internal dependencies.
  */
 import {
-	LayoutSelectorResults,
+	LayoutPreview,
 	LayoutPreviewList,
+	LayoutPreviewPlaceholder,
+	LayoutSelectorResults,
 } from '../layout-selector-results';
 
-describe( name, () => {
+describe( 'layout-selector-results', () => {
 
-	it( 'should render layout results', () => {
-		const componentProps = {
-			layouts: [ {
-				label: 'About',
+	describe( 'LayoutPreviewList', () => {
+		let wrapper;
+
+		const layouts = [
+			{
+				label: 'layout-one',
 				category: 'about',
-				blocks: [ [ 'core/paragraph', { content: 'Paragraph Block' }, [] ] ],
-			} ],
-			registeredBlocks: [ 'core/paragraph' ],
-			category: 'about',
-			onInsert: () => {},
+				blocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
+			},
+			{
+				label: 'layout-two',
+				category: 'about',
+				blocks: [ [ 'core/paragraph', { content: 'layout-two' }, [] ] ],
+			},
+			{
+				label: 'layout-three',
+				category: 'about',
+				blocks: [ [ 'core/paragraph', { content: 'layout-three' }, [] ] ],
+			},
+		];
+
+		const defaultProps = {
+			layouts,
+			shownLayouts: layouts,
+			onClickLayout: jest.fn(),
 		};
 
-		const combineLayoutsProps = ( shallowRender ) => {
-			return shallowRender
-				.find( LayoutPreviewList )
-				.map( ( node ) =>
-					node.prop( 'layouts' ).map(
-						( layout ) => layout.blocks
-					)
-				)
-				.flat( 2 );
-		}
+		const setup = ( props = {} ) => {
+			const setupProps = { ...defaultProps, ...props };
+			return shallow( <LayoutPreviewList { ...setupProps } /> );
+		};
 
-		const renderOne = shallow( <LayoutSelectorResults { ...componentProps } /> );
-		expect( combineLayoutsProps( renderOne ) ).toHaveLength( 1 );
+		beforeEach( () => {
+			wrapper = setup();
+		} );
 
-		addFilter(
-			'coblocks.layoutPreviewBlocks',
-			'tests/coblocks/layoutPreviewBlocks',
-			() => ( [] ) // remove all blocks.
-		);
+		afterEach( () => {
+			jest.clearAllMocks();
+		} );
 
-		const renderTwo = shallow( <LayoutSelectorResults { ...componentProps } /> );
-		expect( combineLayoutsProps( renderTwo ) ).toHaveLength( 0 );
+		it( 'renders shown layouts', () => {
+			expect( wrapper ).toHaveLength( layouts.length );
+			expect( wrapper.find( 'LayoutPreview' ) ).toHaveLength( layouts.length );
+			expect( wrapper.find( 'LayoutPreviewPlaceholder' ) ).toHaveLength( 0 );
+		} );
+
+		it( 'renders layout placeholders', () => {
+			wrapper = setup( { shownLayouts: [] } );
+			expect( wrapper ).toHaveLength( layouts.length );
+			expect( wrapper.find( 'LayoutPreview' ) ).toHaveLength( 0 );
+			expect( wrapper.find( 'LayoutPreviewPlaceholder' ) ).toHaveLength( layouts.length );
+		} );
+
+	} );
+
+	describe( 'LayoutPreviewPlaceholder', () => {
+		let wrapper;
+
+		beforeEach( () => {
+			wrapper = shallow( <LayoutPreviewPlaceholder /> );
+		} );
+
+		afterEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'renders', () => {
+			expect( wrapper.exists( '.coblocks-layout-selector__layout' ) ).toEqual( true );
+		} );
+
+	} );
+
+	describe( 'LayoutPreview', () => {
+		let wrapper;
+
+		const defaultProps = {
+			layout: {
+				label: 'layout-one',
+				category: 'about',
+				blocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
+			},
+			onClick: jest.fn(),
+		};
+
+		const setup = ( props = {} ) => {
+			return shallow( <LayoutPreview { ...props } /> );
+		};
+
+		beforeEach( () => {
+			wrapper = setup( defaultProps );
+		} );
+
+		afterEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'renders', () => {
+			expect( wrapper.exists( '.coblocks-layout-selector__layout' ) ).toEqual( true );
+		} );
+
+		it( 'toggles overlay on mouse events "enter" and "leave"', () => {
+			expect( wrapper.find( '.coblocks-layout-selector__layout--overlay' ).hasClass( 'is-active' ) ).toEqual( false );
+
+			wrapper.find( '.coblocks-layout-selector__layout' ).invoke( 'onMouseEnter' )();
+			expect( wrapper.find( '.coblocks-layout-selector__layout--overlay' ).hasClass( 'is-active' ) ).toEqual( true );
+
+			wrapper.find( '.coblocks-layout-selector__layout' ).invoke( 'onMouseLeave' )();
+			expect( wrapper.find( '.coblocks-layout-selector__layout--overlay' ).hasClass( 'is-active' ) ).toEqual( false );
+		} );
+
+		it( 'should call onClick() on Button click', () => {
+			wrapper.find( '.coblocks-layout-selector__layout' ).invoke( 'onClick' )();
+			expect( defaultProps.onClick ).toHaveBeenCalled();
+		} );
+
+	} );
+
+	describe( 'LayoutSelectorResults', () => {
+		let wrapper;
+
+		const defaultProps = {
+			layouts: [
+				{
+					label: 'layout-one',
+					category: 'about',
+					blocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
+				},
+				{
+					label: 'layout-two',
+					category: 'about',
+					blocks: [ [ 'core/paragraph', { content: 'layout-two' }, [] ] ],
+				},
+				{
+					label: 'layout-three',
+					category: 'about',
+					blocks: [ [ 'core/paragraph', { content: 'layout-three' }, [] ] ],
+				},
+			],
+			category: 'about',
+			onInsert: jest.fn(),
+		};
+
+
+		const setup = ( props = {} ) => {
+			const setupProps = { ...defaultProps, ...props };
+			return shallow( <LayoutSelectorResults { ...setupProps } /> );
+		};
+
+		beforeEach( () => {
+			wrapper = setup();
+		} );
+
+		afterEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'renders', () => {
+			expect( wrapper.exists( '.coblocks-layout-selector__layouts' ) ).toEqual( true );
+		} );
+
+		it( 'renders message when no layouts are available for the selected category', () => {
+			wrapper = setup( { category: 'doesnotexist' } );
+			expect( wrapper.find( '.coblocks-layout-selector__layout' ) ).toHaveLength( 0 );
+			expect( wrapper.text() ).toContain( 'No layouts are available for this category.' );
+		} );
+
 	} );
 
 } );

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -66,8 +66,8 @@ describe( 'Extension: Layout Selector', () => {
 		cy.get( '.editor-post-title__block' ).find( 'textarea' ).should( 'be.empty' );
 
 		// The first block should be the default prompt.
-		cy.get( '.wp-block' ).should( 'have.length', 2 );
-		cy.get( '.wp-block' ).last().find( 'textarea' ).should( 'have.value', 'Start writing or type / to choose a block' );
+		cy.get( '.edit-post-visual-editor .block-editor-block-list__layout' ).find( '> .wp-block' ).should( 'have.length', 1 );
+		cy.get( '.block-editor-default-block-appender' ).find( 'textarea' ).should( 'have.value', 'Start writing or type / to choose a block' );
 	} );
 
 	it( 'does not show modal on add new "post" post_type', () => {


### PR DESCRIPTION
### Description
A "most used" section has been added to the sidebar of the layout selector. This section works similar to how the most used blocks section of the block inserter

### Screenshots
![image](https://user-images.githubusercontent.com/375788/103559290-e7b4cc00-4e83-11eb-9b69-2b352e20c272.png)


### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Unit tests.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
