### PR TITLE
Allow aligned images in CoBlocks Lightbox

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -184,7 +184,7 @@ export function viewPage() {
 		}
 	} );
 
-	cy.wait( 100 );
+	cy.get( 'button[data-label="Post"]' );
 
 	openSettingsPanel( /permalink/i );
 
@@ -343,7 +343,7 @@ export function setColorSetting( settingName, hexColor ) {
  * @param {string} panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
-	cy.get( '.components-panel__body-title' )
+	cy.get( '.components-panel__body' )
 		.contains( panelText )
 		.then( ( $panelTop ) => {
 			const $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );

--- a/src/components/block-gallery/styles/style/_lightbox.scss
+++ b/src/components/block-gallery/styles/style/_lightbox.scss
@@ -167,6 +167,13 @@
 	}
 }
 
+.has-lightbox {
+
+	figure[class^="align"]:hover {
+		cursor: zoom-in;
+	}
+}
+
 figure.has-lightbox:hover {
 	cursor: zoom-in;
 }

--- a/src/extensions/lightbox-controls/test/lightbox-controls.cypress.js
+++ b/src/extensions/lightbox-controls/test/lightbox-controls.cypress.js
@@ -36,6 +36,39 @@ describe( 'Test CoBlocks Lightbox Controls extension', function() {
 	} );
 
 	/**
+	 * Test that we can add a image block to the content add image,
+	 * and open Lightbox on Front-end when aligned
+	 */
+	[ 'left', 'center', 'right', 'wide', 'full' ].forEach( ( alignment ) => {
+		return it( `Test ${ alignment } alignment core/image block with Lightbox Controls component.`, function() {
+			const { imageBase } = helpers.upload.spec;
+			helpers.addBlockToPost( 'core/image', true );
+
+			helpers.upload.imageToBlock( 'core/image' );
+
+			cy.get( '[aria-label="Change alignment"]' ).click();
+
+			cy.get( '[aria-label="Change alignment"]' ).contains( new RegExp( alignment, 'i' ) ).click();
+
+			helpers.toggleSettingCheckbox( /Lightbox/ );
+
+			helpers.savePage();
+
+			helpers.viewPage();
+
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).should( 'have.attr', 'src' ).should( 'include', imageBase );
+
+			cy.get( '.coblocks-lightbox' ).should( 'be.hidden' );
+
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).click( { force: true } );
+
+			cy.get( '.coblocks-lightbox' ).should( 'be.visible' );
+
+			helpers.editPage();
+		} );
+	} );
+
+	/**
 	 * Test that we can add a gallery block to the content add image,
 	 * and alter image using the Lightbox Controls extension
 	 */
@@ -64,5 +97,38 @@ describe( 'Test CoBlocks Lightbox Controls extension', function() {
 		cy.get( '.has-lightbox' ).should( 'exist' );
 
 		helpers.editPage();
+	} );
+
+	/**
+	 * Test that we can add a gallery block to the content add image,
+	 * and open Lightbox on Front-end when aligned
+	 */
+	[ 'left', 'center', 'right', 'wide', 'full' ].forEach( ( alignment ) => {
+		return it( `Test ${ alignment } alignment core/gallery block with Lightbox Controls component.`, function() {
+			const { imageBase } = helpers.upload.spec;
+			helpers.addBlockToPost( 'core/gallery', true );
+
+			helpers.upload.imageToBlock( 'core/gallery' );
+
+			cy.get( '[aria-label="Change alignment"]' ).click();
+
+			cy.get( '[aria-label="Change alignment"]' ).contains( new RegExp( alignment, 'i' ) ).click();
+
+			helpers.toggleSettingCheckbox( /Lightbox/ );
+
+			helpers.savePage();
+
+			helpers.viewPage();
+
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).should( 'have.attr', 'src' ).should( 'include', imageBase );
+
+			cy.get( '.coblocks-lightbox' ).should( 'be.hidden' );
+
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).click( { force: true } );
+
+			cy.get( '.coblocks-lightbox' ).should( 'be.visible' );
+
+			helpers.editPage();
+		} );
 	} );
 } );

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -49,8 +49,18 @@
 		arrowLeft.setAttribute( 'class', 'arrow-left' );
 		arrowLeft.setAttribute( 'aria-label', leftLabel );
 
-		const images = document.querySelectorAll( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure img, figure.has-lightbox.lightbox-${ lightboxIndex } > img` );
-		const captions = document.querySelectorAll( `.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure figcaption` );
+		const imageSelector = [
+				`.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure img`,
+				`figure.has-lightbox.lightbox-${ lightboxIndex } > img`,
+				`.has-lightbox.lightbox-${ lightboxIndex } > figure[class^="align"] img`,
+			].join( ', ' ),
+
+			captionSelector = [
+				`.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure figcaption`,
+			].join( ', ' );
+
+		const images = document.querySelectorAll( imageSelector );
+		const captions = document.querySelectorAll( captionSelector );
 		let index;
 
 		modalHeading.append( counter, close );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Fixes #1782 
Aligned images are not working as expected with the CoBlocks lightbox. This PR introduces a fix to allow aligned images and captions to be displayed in the Lightbox.

### Screenshots
<!-- if applicable -->
![LightboxWithAlignment](https://user-images.githubusercontent.com/30462574/103573608-c48e1a80-4e8b-11eb-8b53-bfe157b5d6a8.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes. Improvements to readability.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.
New e2e tests written to test against aligned gallery blocks with Lightbox.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
