### PR TITLE
Introduce custom padding controls to core/group block

### DIFF
--- a/src/extensions/padding-controls/index.js
+++ b/src/extensions/padding-controls/index.js
@@ -63,15 +63,7 @@ const withPaddingControls = createHigherOrderComponent( ( BlockEdit ) => {
 		const { name, attributes, setAttributes, isSelected } = props;
 		const { padding, paddingCustom } = attributes;
 
-		const getMaxValue = () => {
-			const { maxValue = null } = props;
-
-			if ( ! maxValue ) {
-				return attributes.align === 'full' ? 10 : 5;
-			}
-
-			return maxValue;
-		};
+		const maxValue = attributes.align === 'full' ? 10 : 5;
 
 		const supportsPaddingControls = blocksWithPaddingSupport.includes( name );
 		const panelTitle = startCase( name.split( '/' )[ 1 ] );
@@ -100,7 +92,7 @@ const withPaddingControls = createHigherOrderComponent( ( BlockEdit ) => {
 									value={ parseFloat( paddingCustom ) || 0 }
 									onChange={ ( newPadding ) => setAttributes( { paddingCustom: newPadding.toString() } ) }
 									min={ 0 }
-									max={ getMaxValue() }
+									max={ maxValue }
 									withInputField
 								/>
 							}

--- a/src/extensions/padding-controls/padding-wrapper.js
+++ b/src/extensions/padding-controls/padding-wrapper.js
@@ -11,8 +11,6 @@ import { cloneElement, isValidElement } from '@wordpress/element';
 
 /**
  * Return an element Wrapped with padding Properties.
- *
- * @return {JSX.Element}  paddingWrapper component
  */
 function PaddingWrapper( { children, padding, paddingCustom, className } ) {
 	if ( ! isValidElement( children ) ) {

--- a/src/extensions/padding-controls/padding-wrapper.js
+++ b/src/extensions/padding-controls/padding-wrapper.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { cloneElement, isValidElement } from '@wordpress/element';
+
+/**
+ * Return an element Wrapped with padding Properties.
+ *
+ * @return {JSX.Element}  paddingWrapper component
+ */
+function PaddingWrapper( { children, padding, paddingCustom, className } ) {
+	if ( ! isValidElement( children ) ) {
+		return children;
+	}
+
+	const attributes = {
+		className: classnames(
+			className,
+			children.props.className,
+			{ [ `has-${ padding }-padding` ]: padding }
+		),
+	};
+
+	if ( children.props.style ) {
+		attributes.style = {
+			...children.props.style,
+		};
+	}
+
+	if ( 'custom' === padding ) {
+		attributes.style = {
+			...attributes.style,
+			'--coblocks-custom-padding': `${ paddingCustom }em`,
+		};
+	}
+
+	return cloneElement( children, attributes );
+}
+
+PaddingWrapper.propTypes = {
+	padding: PropTypes.string,
+	paddingCustom: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
+};
+
+export default PaddingWrapper;

--- a/src/extensions/padding-controls/test/padding-controls.cypress.js
+++ b/src/extensions/padding-controls/test/padding-controls.cypress.js
@@ -14,11 +14,16 @@ describe( 'Extension: CoBlocks Padding Controls', function() {
 		helpers.openSettingsPanel( /group settings/i );
 
 		cy.get( '.components-base-control' ).contains( /padding/i ).parent().find( `.components-button[aria-label="None"]` ).click();
+		cy.get( '[data-type="core/group"]' ).should( 'have.class', `has-no-padding` );
 
-		[ 'Small', 'Medium', 'Large', 'Huge' ].forEach( ( padding ) => {
+		[ 'Small', 'Medium', 'Large', 'Huge', 'Custom' ].forEach( ( padding ) => {
 			cy.get( '.components-base-control' ).contains( /padding/i ).parent().find( `.components-button[aria-label="${ padding }"]` ).click();
 			cy.get( '[data-type="core/group"]' ).should( 'have.class', `has-${ padding.toLowerCase() }-padding` );
 		} );
+
+		// Test custom padding
+		cy.get( '.components-base-control' ).contains( /padding/i ).closest( '.components-panel__body' ).find( 'input.components-input-control__input' ).click().type( 5 ); // Panel body.
+		cy.get( '[data-type="core/group"]' ).should( 'have.attr', 'style', '--coblocks-custom-padding:5em;' );
 
 		helpers.checkForBlockErrors( 'core/group' );
 	} );

--- a/src/styles/style/has-padding.scss
+++ b/src/styles/style/has-padding.scss
@@ -22,6 +22,12 @@
 	padding: var(--coblocks-spacing--4, map-get($spacing, 4));
 }
 
+.has-custom-padding,
+.has-custom-padding.wp-block-group,
+.has-custom-padding.wp-block-group.has-background {
+	padding: var(--coblocks-custom-padding);
+}
+
 .content-area__wrapper,
 .editor-styles-wrapper {
 
@@ -47,5 +53,11 @@
 	.has-huge-padding.wp-block-group,
 	.has-huge-padding.wp-block-group.has-background {
 		padding: var(--coblocks-spacing--4, map-get($spacing, 4));
+	}
+
+	.has-custom-padding,
+	.has-custom-padding.wp-block-group,
+	.has-custom-padding.wp-block-group.has-background {
+		padding: var(--coblocks-custom-padding);
 	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Modified Padding Controls extension to add custom controls.
Added styles and apply style variables to group elements.

### Screenshots
<!-- if applicable -->
![groupBlockCustomPadding](https://user-images.githubusercontent.com/30462574/104229579-aedba080-5409-11eb-8f8f-7db798efb471.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript and styles changes.
No Deprecations needed.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in the editor.
E2E. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
