### PR TITLE
Ensure layout selector modal is shown only when creating new pages

### DIFF
--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -118,14 +118,8 @@ const store = registerStore( 'coblocks/template-selector', {
 
 	resolvers: {
 		* isTemplateSelectorActive() {
-			const getCurrentPostAttributeStatus = yield select( 'core/editor', 'getCurrentPostAttribute', 'status' );
-			const hasEditorUndo = yield select( 'core/editor', 'hasEditorUndo' );
-			const isCurrentPostPublished = yield select( 'core/editor', 'isCurrentPostPublished' );
-
-			const isDraft = getCurrentPostAttributeStatus.includes( 'draft' );
-			const isCleanUnpublishedPost = ! isCurrentPostPublished && ! hasEditorUndo && isDraft;
-
-			return isCleanUnpublishedPost && actions.openTemplateSelector();
+			const isCleanNewPost = yield select( 'core/editor', 'isCleanNewPost' );
+			return isCleanNewPost && actions.openTemplateSelector();
 		},
 	},
 

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -110,18 +110,10 @@ describe( 'Extension: Layout Selector', () => {
 		cy.get( '[data-type="core/image"] img[src*="http"]' ).should( 'exist' );
 		cy.get( '.editor-post-save-draft' ).click();
 
-		// Reload the post.
-		let postID;
-		// eslint-disable-next-line jest/valid-expect-in-promise
-		cy.window()
-			.then( ( win ) => {
-				postID = win.wp.data.select( 'core/editor' ).getCurrentPostId();
-			} )
-			.then( () => {
-				helpers.goTo( `/wp-admin/post.php?post=${ postID }&action=edit` );
+		cy.reload();
+		cy.get( '.edit-post-visual-editor' );
 
-				helpers.disableGutenbergFeatures();
-				cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
-			} );
+		helpers.disableGutenbergFeatures();
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
 	} );
 } );

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -105,11 +105,14 @@ describe( 'Extension: Layout Selector', () => {
 		helpers.goTo( '/wp-admin/post-new.php?post_type=page' );
 		helpers.disableGutenbergFeatures();
 
-		cy.get( '[data-type="core/image"] img[src*="http"]' ); // Ensure layout is loaded
+		// Ensure the layout selector has loaded
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'exist' );
+		// Ensure the preview has rendered before clicking it.
+		cy.get( '.block-editor-block-preview__container' ).should( 'exist' );
 		cy.get( '.coblocks-layout-selector__layout' ).first().click();
-		cy.get( '[data-type="core/image"] img[src*="http"]' ).should( 'exist' );
-		cy.get( '.editor-post-save-draft' ).click();
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
 
+		cy.get( '.editor-post-save-draft' ).click();
 		cy.reload();
 		cy.get( '.edit-post-visual-editor' );
 


### PR DESCRIPTION
### Description
This PR removes a lot of the conditionals we used to determine when the layout selector is shown and simply checks the post's `isCleanNewPost` state.

The only downside to this currently is that there is no way to "reset" the page or show the layout selector again. With our old inconsistently behaving conditions, we attempted to display the layout selector if the post was unpublished and the undo states were removed (undo action was performed until no more were available).

I do think this wasn't a great experience because you could never perform a redo action if you mistakenly hit undo. The only way to close the layout selector was to use a "blank" layout changing the edit states permanently. If it makes sense we might want to think around this experience.

### Types of changes
- Bug fix

### How has this been tested?
Manual and E2E tests

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
