### PR TITLE
Use hooks for computed layout

### DIFF
--- a/.dev/config/webpack.config.js
+++ b/.dev/config/webpack.config.js
@@ -14,9 +14,12 @@ module.exports = {
 
 	entry: {
 		coblocks: path.resolve( process.cwd(), 'src/blocks.js' ),
+
+		// Styles
 		'coblocks-editor': path.resolve( process.cwd(), 'src/styles/editor.scss' ),
 		'coblocks-style': path.resolve( process.cwd(), 'src/styles/style.scss' ),
 
+		// Front-End Scripts
 		'js/coblocks-animation': path.resolve( process.cwd(), 'src/js/coblocks-animation.js' ),
 		'js/coblocks-accordion-polyfill': path.resolve( process.cwd(), 'src/js/coblocks-accordion-polyfill.js' ),
 		'js/coblocks-accordion-carousel': path.resolve( process.cwd(), 'src/js/coblocks-accordion-carousel.js' ),
@@ -31,6 +34,7 @@ module.exports = {
 		'js/coblocks-slick-initializer': path.resolve( process.cwd(), 'src/js/coblocks-slick-initializer.js' ),
 		'js/coblocks-slick-initializer-front': path.resolve( process.cwd(), 'src/js/coblocks-slick-initializer-front.js' ),
 
+		// Vendors
 		'js/vendors/flickity': path.resolve( process.cwd(), 'node_modules/flickity/dist/flickity.pkgd.js' ),
 		'js/vendors/slick': path.resolve( process.cwd(), 'node_modules/slick-carousel/slick/slick.js' ),
 	},

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -143,7 +143,7 @@ class CoBlocks_Block_Assets {
 		);
 
 		// Scripts.
-		$name       = 'coblocks';
+		$name       = 'coblocks'; // coblocks.js
 		$filepath   = 'dist/' . $name;
 		$asset_file = $this->get_asset_file( $filepath );
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -143,7 +143,7 @@ class CoBlocks_Block_Assets {
 		);
 
 		// Scripts.
-		$name       = 'coblocks'; // coblocks.js
+		$name       = 'coblocks'; // coblocks.js.
 		$filepath   = 'dist/' . $name;
 		$asset_file = $this->get_asset_file( $filepath );
 

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -226,7 +226,7 @@
 		background: $white;
 		flex-grow: 1;
 		overflow-y: auto;
-		padding: 12px 24px 24px 24px;
+		padding: 12px 48px 24px;
 
 		> span {
 			align-items: center;
@@ -240,16 +240,9 @@
 	}
 
 	&__layouts {
-		align-items: flex-start;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		padding: 3px;
-	}
-
-	&__layouts-column {
-		padding: 0 1rem;
-		width: 50%;
+		column-count: 2;
+		column-gap: 2em;
+		padding-top: 4px;
 	}
 
 	&__layout {
@@ -258,11 +251,11 @@
 		display: flex;
 		height: auto;
 		margin-bottom: 2rem;
+		min-height: 150px;
 		padding: 0;
 		position: relative;
 		text-decoration: none;
 		width: 100%;
-
 
 		@media (max-width: 1024px) {
 			margin-right: 0;
@@ -270,8 +263,15 @@
 		}
 
 		.block-editor-block-preview__container {
-			margin-bottom: 2rem;
-			margin-top: 2rem;
+			background-color: var(--go--color--background, $white);
+			margin: 2em;
+		}
+
+		.components-spinner {
+			left: 50%;
+			margin: 0;
+			position: absolute;
+			transform: translateX(-50%);
 		}
 
 		&::after {
@@ -291,36 +291,11 @@
 		&.is-placeholder {
 			align-items: center;
 			justify-content: center;
-			min-height: 150px;
-
-			.components-spinner {
-				margin: 0;
-			}
 		}
 
 		&:hover,
 		&:focus {
 			outline: none;
-		}
-	}
-
-	&__layout--overlay {
-		align-items: center;
-		background: rgba(255, 255, 255, 0.75);
-		bottom: 0;
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		left: 0;
-		opacity: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-		transition: opacity 0.1s linear;
-		z-index: 1;
-
-		&.is-active {
-			opacity: 1;
 		}
 	}
 }

--- a/src/extensions/layout-selector/hooks/useCategories.js
+++ b/src/extensions/layout-selector/hooks/useCategories.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+
+function useCategories( layouts ) {
+	const categories = useSelect( ( select ) => select( 'coblocks/template-selector' ).getCategories(), [] );
+
+	const getLayoutsInCategory = ( category ) => {
+		return layouts.filter( ( layout ) => layout.category === category ) || [];
+	};
+
+	const hasLayoutsInCategory = ( category ) => {
+		return !! getLayoutsInCategory( category ).length;
+	};
+
+	return useMemo(
+		() => categories.filter( ( category ) => hasLayoutsInCategory( category.slug ) ),
+		[ JSON.stringify( layouts ) ]
+	);
+}
+
+export default useCategories;

--- a/src/extensions/layout-selector/hooks/useComputedLayouts.js
+++ b/src/extensions/layout-selector/hooks/useComputedLayouts.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { orderBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { createBlock, rawHandler } from '@wordpress/blocks';
+import { useMemo } from '@wordpress/element';
+
+const MAX_SUGGESTED_ITEMS = 6;
+
+const getBlocksFromTemplate = ( name, attributes, innerBlocks = [] ) => {
+	return createBlock( name, attributes,
+		innerBlocks && innerBlocks.map( ( [ blockName, blockAttributes, blockInnerBlocks ] ) =>
+			getBlocksFromTemplate( blockName, blockAttributes, blockInnerBlocks )
+		)
+	);
+};
+
+function useComputedLayouts() {
+	const layouts = useSelect( ( select ) => select( 'coblocks/template-selector' ).getLayouts(), [] );
+
+	return useMemo( () => {
+		const computedLayouts = layouts.map(
+			( layout ) => {
+				let blocks;
+
+				if ( layout.blocks ) {
+					blocks = layout.blocks.map(
+						( block ) => Array.isArray( block ) ? getBlocksFromTemplate( block[ 0 ], block[ 1 ], block[ 2 ] ) : block
+					);
+				} else {
+					blocks = rawHandler( { HTML: layout.postContent } );
+				}
+
+				const computedLayout = { ...layout, blocks };
+
+				// Remove postContent because blocks retain original content
+				// and makes debugging object layout easier to read
+				delete computedLayout.postContent;
+
+				return computedLayout;
+			}
+		);
+
+		const mostUsedLayouts = orderBy( computedLayouts, [ 'frequency' ], [ 'desc' ] )
+			.slice( 0, MAX_SUGGESTED_ITEMS )
+			.map( ( layout ) => ( { ...layout, category: 'most-used' } ) );
+
+		computedLayouts.push( ...mostUsedLayouts );
+
+		return computedLayouts;
+	}, [ JSON.stringify( layouts ) ] );
+}
+
+export default useComputedLayouts;

--- a/src/extensions/layout-selector/hooks/useComputedLayouts.js
+++ b/src/extensions/layout-selector/hooks/useComputedLayouts.js
@@ -20,48 +20,43 @@ const getBlocksFromTemplate = ( name, attributes, innerBlocks = [] ) => {
 	);
 };
 
+let taskQueueId = null;
+let layoutsQueue = [];
+let computedLayouts = [];
+let computedCategories = [];
+
 function useComputedLayouts() {
 	const layouts = useSelect( ( select ) => select( 'coblocks/template-selector' ).getLayouts(), [] );
 	const computedLayoutsStore = useSelect( ( select ) => select( 'coblocks/template-selector' ).getComputedLayouts(), [] );
+	const selectedCategory = useSelect( ( select ) => select( 'coblocks/template-selector' ).getSelectedCategory(), [] );
 	const { updateComputedLayouts } = useDispatch( 'coblocks/template-selector' );
 
-	let taskQueueId = null;
-	let layoutsQueue = [];
-	let computedLayouts = [];
+	const parseBlocks = ( layout ) => {
+		if ( ! [ selectedCategory ].includes( layout.category ) ) {
+			return layout.parsedBlocks ? layout.parsedBlocks : [];
+		}
 
-	const computeLayouts = ( deadline ) => {
+		if ( layout.blocks ) {
+			return layout.blocks.map(
+				( block ) => Array.isArray( block ) ? getBlocksFromTemplate( block[ 0 ], block[ 1 ], block[ 2 ] ) : block
+			);
+		}
+
+		return rawHandler( { HTML: layout.postContent } );
+	};
+
+	const parseLayout = ( layout ) => ( { ...layout, parsedBlocks: parseBlocks( layout ) } );
+
+	const processLayoutsQueue = ( deadline ) => {
 		while ( ( deadline.timeRemaining() > 0 || deadline.didTimeout ) && layoutsQueue.length ) {
-			const layout = layoutsQueue.shift();
-			let blocks;
-
-			if ( layout.blocks ) {
-				blocks = layout.blocks.map(
-					( block ) => Array.isArray( block ) ? getBlocksFromTemplate( block[ 0 ], block[ 1 ], block[ 2 ] ) : block
-				);
-			} else {
-				blocks = rawHandler( { HTML: layout.postContent } );
-			}
-
-			const computedLayout = { ...layout, blocks };
-
-			// Remove postContent because blocks retain original content
-			// and makes debugging object layout easier to read
-			delete computedLayout.postContent;
-
-			computedLayouts.push( computedLayout );
+			computedLayouts.push( parseLayout( layoutsQueue.shift() ) );
 		}
 
 		// We still have layouts to compute, continue on next available idle time
 		if ( layoutsQueue.length ) {
-			window.requestIdleCallback( computeLayouts, { timeout: 1000 } );
+			window.requestIdleCallback( processLayoutsQueue, { timeout: 1000 } );
 			return;
 		}
-
-		const mostUsedLayouts = orderBy( computedLayouts, [ 'frequency' ], [ 'desc' ] )
-			.slice( 0, MAX_SUGGESTED_ITEMS )
-			.map( ( layout ) => ( { ...layout, category: 'most-used' } ) );
-
-		computedLayouts.push( ...mostUsedLayouts );
 
 		updateComputedLayouts( computedLayouts );
 	};
@@ -69,9 +64,31 @@ function useComputedLayouts() {
 	useEffect( () => {
 		window.cancelIdleCallback( taskQueueId );
 		computedLayouts = [];
-		layoutsQueue = layouts;
-		taskQueueId = window.requestIdleCallback( computeLayouts, { timeout: 1000 } );
+
+		const mostUsedLayouts = orderBy( layouts, [ 'frequency' ], [ 'desc' ] )
+			.slice( 0, MAX_SUGGESTED_ITEMS )
+			.map( ( layout ) => ( { ...layout, category: 'most-used' } ) );
+
+		layoutsQueue = [
+			...mostUsedLayouts,
+			...layouts,
+		];
+
+		computedCategories = [ selectedCategory ];
+		taskQueueId = window.requestIdleCallback( processLayoutsQueue, { timeout: 1000 } );
 	}, [ JSON.stringify( layouts ) ] );
+
+	// Compute layouts on category change to save cpu cycle.
+	useEffect( () => {
+		if ( computedCategories.includes( selectedCategory ) ) {
+			return;
+		}
+
+		computedCategories.push( selectedCategory );
+
+		// Here we loop through and parse blocks that weren't parsed before in the firstIdleCallback call.
+		updateComputedLayouts( computedLayoutsStore.map( parseLayout ) );
+	}, [ selectedCategory ] );
 
 	return computedLayoutsStore;
 }

--- a/src/extensions/layout-selector/hooks/useComputedLayouts.js
+++ b/src/extensions/layout-selector/hooks/useComputedLayouts.js
@@ -6,9 +6,9 @@ import { orderBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock, rawHandler } from '@wordpress/blocks';
-import { useMemo } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 const MAX_SUGGESTED_ITEMS = 6;
 
@@ -22,38 +22,58 @@ const getBlocksFromTemplate = ( name, attributes, innerBlocks = [] ) => {
 
 function useComputedLayouts() {
 	const layouts = useSelect( ( select ) => select( 'coblocks/template-selector' ).getLayouts(), [] );
+	const computedLayouts = useSelect( ( select ) => select( 'coblocks/template-selector' ).getComputedLayouts(), [] );
+	const { updateComputedLayouts } = useDispatch( 'coblocks/template-selector' );
 
-	return useMemo( () => {
-		const computedLayouts = layouts.map(
-			( layout ) => {
-				let blocks;
+	let taskQueueId = null;
+	let layoutsToProcess = [];
+	let processedLayouts = [];
 
-				if ( layout.blocks ) {
-					blocks = layout.blocks.map(
-						( block ) => Array.isArray( block ) ? getBlocksFromTemplate( block[ 0 ], block[ 1 ], block[ 2 ] ) : block
-					);
-				} else {
-					blocks = rawHandler( { HTML: layout.postContent } );
-				}
+	const processBlocks = ( deadline ) => {
+		while ( ( deadline.timeRemaining() > 0 || deadline.didTimeout ) && layoutsToProcess.length ) {
+			const layout = layoutsToProcess.shift();
+			let blocks;
 
-				const computedLayout = { ...layout, blocks };
-
-				// Remove postContent because blocks retain original content
-				// and makes debugging object layout easier to read
-				delete computedLayout.postContent;
-
-				return computedLayout;
+			if ( layout.blocks ) {
+				blocks = layout.blocks.map(
+					( block ) => Array.isArray( block ) ? getBlocksFromTemplate( block[ 0 ], block[ 1 ], block[ 2 ] ) : block
+				);
+			} else {
+				blocks = rawHandler( { HTML: layout.postContent } );
 			}
-		);
 
-		const mostUsedLayouts = orderBy( computedLayouts, [ 'frequency' ], [ 'desc' ] )
+			const computedLayout = { ...layout, blocks };
+
+			// Remove postContent because blocks retain original content
+			// and makes debugging object layout easier to read
+			delete computedLayout.postContent;
+
+			processedLayouts.push( computedLayout );
+		}
+
+		// We still have layouts to compute, continue on next available idle time
+		if ( layoutsToProcess.length ) {
+			window.requestIdleCallback( processBlocks, { timeout: 1000 } );
+			return;
+		}
+
+		const mostUsedLayouts = orderBy( processedLayouts, [ 'frequency' ], [ 'desc' ] )
 			.slice( 0, MAX_SUGGESTED_ITEMS )
 			.map( ( layout ) => ( { ...layout, category: 'most-used' } ) );
 
-		computedLayouts.push( ...mostUsedLayouts );
+		processedLayouts.push( ...mostUsedLayouts );
 
-		return computedLayouts;
+		updateComputedLayouts( processedLayouts );
+	};
+
+	useEffect( () => {
+		window.cancelIdleCallback( taskQueueId );
+		processedLayouts = [];
+		layoutsToProcess = layouts;
+		taskQueueId = window.requestIdleCallback( processBlocks, { timeout: 1000 } );
 	}, [ JSON.stringify( layouts ) ] );
+
+	return computedLayouts;
 }
 
 export default useComputedLayouts;

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, useMemo } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
 import { compose } from '@wordpress/compose';

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, useMemo } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
 import { compose } from '@wordpress/compose';
@@ -22,6 +22,7 @@ import './store';
 import { LayoutSelectorResults } from './layout-selector-results';
 import CoBlocksLayoutSelectorFill from './layout-selector-slot';
 import useComputedLayouts from './hooks/useComputedLayouts';
+import useCategories from './hooks/useCategories';
 
 const SidebarItem = ( { slug, title, isSelected, onClick } ) => {
 	return (
@@ -39,25 +40,11 @@ const SidebarItem = ( { slug, title, isSelected, onClick } ) => {
 };
 
 class LayoutSelector extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			selectedCategory: 'about',
-		};
-	}
-
-	getLayoutsInCategory( category ) {
-		return this.props.layouts.filter( ( layout ) => layout.category === category ) || [];
-	}
-
-	hasLayoutsInCategory( category ) {
-		return !! this.getLayoutsInCategory( category ).length;
-	}
-
 	render() {
-		const { selectedCategory } = this.state;
 		const {
+			categories,
+			selectedCategory,
+			updateSelectedCategory,
 			isActive,
 			layoutSelectorEnabled,
 			useEmptyTemplateLayout,
@@ -73,12 +60,12 @@ class LayoutSelector extends Component {
 		return ! isActive ? null : (
 			<Modal
 				title={ (
-					<Fragment>
+					<>
 						<div>{ __( 'Add New Page', 'coblocks' ) }</div>
 						<span>{ __( 'Pick one of these layouts or start with a blank page.', 'coblocks' ) }</span>
-					</Fragment>
+					</>
 				) }
-				onRequestClose={ () => useEmptyTemplateLayout() }
+				onRequestClose={ useEmptyTemplateLayout }
 				className="coblocks-layout-selector-modal">
 				<div className="coblocks-layout-selector">
 					<aside className="coblocks-layout-selector__sidebar">
@@ -91,20 +78,20 @@ class LayoutSelector extends Component {
 						) ) }
 
 						<ul className="coblocks-layout-selector__sidebar__items">
-							{ this.props.categories.filter( ( category ) => this.hasLayoutsInCategory( category.slug ) ).map( ( category, index ) => (
+							{ categories.map( ( category, index ) => (
 								<SidebarItem
 									key={ index }
 									slug={ category.slug }
 									title={ category.title }
 									isSelected={ category.slug === selectedCategory }
-									onClick={ () => this.setState( { selectedCategory: category.slug } ) }
+									onClick={ () => updateSelectedCategory( category.slug ) }
 								/>
 							) ) }
 						</ul>
 
 						<Button
 							className="coblocks-layout-selector__add-button"
-							onClick={ () => useEmptyTemplateLayout() }
+							onClick={ useEmptyTemplateLayout }
 							isLink>
 							<span><SVG width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><Path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z" /></SVG></span>
 							{ __( 'Add blank page', 'coblocks' ) }
@@ -116,27 +103,25 @@ class LayoutSelector extends Component {
 							<strong>{ __( 'Layouts', 'coblocks' ) }:</strong> { selectedCategory }
 							<DropdownMenu label="Select a layout category">
 								{ ( { onClose } ) => (
-									<Fragment>
+									<>
 										<MenuGroup onClick={ onClose }>
-											{ this.state.templates.map( ( category, index ) => {
-												return (
-													<MenuItem key={ index } onClick={ () => {
-														this.setState( { selectedCategory: category.label } );
-														onClose();
-													} }>
-														{ category.label }
-													</MenuItem>
-												);
-											} ) }
+											{ categories.map( ( category, index ) => (
+												<MenuItem key={ index } onClick={ () => {
+													updateSelectedCategory( category.slug );
+													onClose();
+												} }>
+													{ category.title }
+												</MenuItem>
+											) ) }
 										</MenuGroup>
-									</Fragment>
+									</>
 								) }
 							</DropdownMenu>
 						</div>
 						<div className="coblocks-layout-selector__topbar__right">
 							<Button
 								className="coblocks-layout-selector__add-button"
-								onClick={ () => useEmptyTemplateLayout() }
+								onClick={ useEmptyTemplateLayout }
 								isLink>
 								<span><Icon icon="plus" size={ 16 } /></span> { __( 'Add blank page', 'coblocks' ) }
 							</Button>
@@ -164,24 +149,25 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 					isTemplateSelectorActive,
 					hasLayouts,
 					hasCategories,
-					getCategories,
+					getSelectedCategory,
 				} = select( 'coblocks/template-selector' );
 				const { getLayoutSelector } = select( 'coblocks-settings' );
+
+				const layouts = useComputedLayouts();
 
 				return {
 					isActive: isTemplateSelectorActive(),
 					layoutSelectorEnabled: getLayoutSelector() && hasLayouts() && hasCategories(),
-					layouts: useComputedLayouts(),
-					categories: [
-						{ slug: 'most-used', title: __( 'Most Used', 'coblocks' ) },
-						...getCategories(),
-					],
+					layouts,
+					categories: useCategories( layouts ),
+					selectedCategory: getSelectedCategory(),
 				};
 			} ),
 			withDispatch( ( dispatch ) => {
 				const {
 					closeTemplateSelector,
 					incrementLayoutUsage,
+					updateSelectedCategory,
 				} = dispatch( 'coblocks/template-selector' );
 				const { editPost } = dispatch( 'core/editor' );
 				const { createWarningNotice } = dispatch( 'core/notices' );
@@ -190,6 +176,7 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 					closeTemplateSelector,
 					createWarningNotice,
 					editPost,
+					updateSelectedCategory,
 
 					// Replace any blocks with the selected layout.
 					useTemplateLayout: ( layout ) => {

--- a/src/extensions/layout-selector/index.php
+++ b/src/extensions/layout-selector/index.php
@@ -13,6 +13,10 @@
 function coblocks_layout_selector_categories() {
 	$categories = array(
 		array(
+			'slug'  => 'most-used',
+			'title' => __( 'Most Used', 'coblocks' ),
+		),
+		array(
 			'slug'  => 'about',
 			'title' => __( 'About', 'coblocks' ),
 		),

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -57,14 +57,10 @@ export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
  * Renders the layout's block preview.
  */
 export const LayoutPreview = ( { layout, onClick } ) => {
-	const [ setOverlay ] = useState( false );
-
 	return (
 		<Button
 			className={ classnames( 'coblocks-layout-selector__layout' ) }
-			onClick={ () => onClick( layout ) }
-			onMouseEnter={ () => setOverlay( true ) }
-			onMouseLeave={ () => setOverlay( false ) }>
+			onClick={ () => onClick( layout ) }>
 
 			<Spinner />
 

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -40,23 +40,14 @@ export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
 	// Needed to render our list of previews asynchronously for better performance.
 	const currentShowLayouts = useAsyncList( filteredLayouts );
 
-	const chunkedLayoutsList = [ [], [] ];
-	filteredLayouts.forEach( ( layout, index ) => chunkedLayoutsList[ index % 2 ].push( layout ) );
-
 	return category && !! filteredLayouts.length
 		? (
 			<div className="coblocks-layout-selector__layouts">
-				{ chunkedLayoutsList.map(
-					( theLayouts, columnIndex ) => (
-						<div key={ columnIndex } className="coblocks-layout-selector__layouts-column">
-							<LayoutPreviewList
-								layouts={ theLayouts }
-								shownLayouts={ currentShowLayouts }
-								onClickLayout={ onInsert }
-							/>
-						</div>
-					)
-				) }
+				<LayoutPreviewList
+					layouts={ filteredLayouts }
+					shownLayouts={ currentShowLayouts }
+					onClickLayout={ onInsert }
+				/>
 			</div>
 		)
 		: ( <p><em>{ __( 'No layouts are available for this category.', 'coblocks' ) }</em></p> );
@@ -66,7 +57,7 @@ export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
  * Renders the layout's block preview.
  */
 export const LayoutPreview = ( { layout, onClick } ) => {
-	const [ overlay, setOverlay ] = useState( false );
+	const [ setOverlay ] = useState( false );
 
 	return (
 		<Button
@@ -75,9 +66,7 @@ export const LayoutPreview = ( { layout, onClick } ) => {
 			onMouseEnter={ () => setOverlay( true ) }
 			onMouseLeave={ () => setOverlay( false ) }>
 
-			<div className={ classnames( 'coblocks-layout-selector__layout--overlay', { 'is-active': overlay } ) }>
-				{ __( 'Select Layout', 'coblocks' ) }
-			</div>
+			<Spinner />
 
 			<BlockPreview blocks={ layout.blocks } viewportWidth={ 700 } />
 		</Button>

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -24,16 +24,17 @@ export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
 
 	const filteredLayouts = useMemo(
 		() => layouts
-			.filter( ( layout ) => layout.category === category )
-			.map( ( layout ) => ( { ...layout,
+			.filter( ( layout ) => layout.category === category && !! layout.parsedBlocks?.length )
+			.map( ( layout ) => ( {
+				...layout,
 				/**
 				 * Filters the list of blocks within the layout preview.
 				 *
 				 * @param {Array} blocks The block objects of the layout.
 				 */
-				blocks: applyFilters( 'coblocks.layoutPreviewBlocks', layout.blocks ),
+				blocks: applyFilters( 'coblocks.layoutPreviewBlocks', layout.parsedBlocks ),
 			} ) ),
-		[ layouts, category, imageCategory ]
+		[ JSON.stringify( layouts ), category, imageCategory ]
 	);
 
 	// Needed to render our list of previews asynchronously for better performance.

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
 import { Button, Spinner } from '@wordpress/components';
 import { BlockPreview } from '@wordpress/block-editor';
@@ -17,6 +18,10 @@ import { applyFilters } from '@wordpress/hooks';
  * Render the layout previews into columns.
  */
 export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
+	const getEntityRecord = useSelect( ( select ) => select( 'core' ).getEntityRecord, [] );
+
+	const imageCategory = getEntityRecord( 'root', 'site' )?.image_category || '';
+
 	const filteredLayouts = useMemo(
 		() => layouts
 			.filter( ( layout ) => layout.category === category )
@@ -28,7 +33,7 @@ export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
 				 */
 				blocks: applyFilters( 'coblocks.layoutPreviewBlocks', layout.blocks ),
 			} ) ),
-		[ layouts, category ]
+		[ layouts, category, imageCategory ]
 	);
 
 	// Needed to render our list of previews asynchronously for better performance.

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
 import { Button, Spinner } from '@wordpress/components';

--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -16,6 +16,7 @@ const DEFAULT_STATE = {
 	layouts: coblocksLayoutSelector.layouts || [],
 	computedLayouts: [],
 	categories: coblocksLayoutSelector.categories || [],
+	selectedCategory: 'most-used',
 	layoutUsage: {},
 };
 
@@ -50,6 +51,7 @@ const actions = {
 	updateLayouts: ( layouts ) => ( { type: 'UPDATE_LAYOUTS', layouts } ),
 	updateComputedLayouts: ( computedLayouts ) => ( { type: 'UPDATE_COMPUTED_LAYOUTS', computedLayouts } ),
 	updateCategories: ( categories ) => ( { type: 'UPDATE_CATEGORIES', categories } ),
+	updateSelectedCategory: ( selectedCategory ) => ( { type: 'UPDATE_CATEGORY', selectedCategory } ),
 	incrementLayoutUsage: ( layout ) => ( { type: 'INCREMENT_LAYOUT_USAGE', layout, time: Date.now() } ),
 };
 
@@ -80,6 +82,11 @@ const store = registerStore( 'coblocks/template-selector', {
 				return {
 					...state,
 					categories: action.categories,
+				};
+			case 'UPDATE_CATEGORY':
+				return {
+					...state,
+					selectedCategory: action.selectedCategory,
 				};
 			case 'INCREMENT_LAYOUT_USAGE':
 				const layoutSlug = kebabCase( action.layout.label );
@@ -117,6 +124,7 @@ const store = registerStore( 'coblocks/template-selector', {
 		getComputedLayouts: ( state ) => state.computedLayouts,
 		getCategories: ( state ) => state.categories || [],
 		hasCategories: ( state ) => !! state.categories.length,
+		getSelectedCategory: ( state ) => state.selectedCategory,
 		getLayoutUsage: ( state ) => state.layoutUsage,
 	},
 

--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -14,6 +14,7 @@ import { controls, select } from '@wordpress/data-controls';
 const DEFAULT_STATE = {
 	templateSelector: false,
 	layouts: coblocksLayoutSelector.layouts || [],
+	computedLayouts: [],
 	categories: coblocksLayoutSelector.categories || [],
 	layoutUsage: {},
 };
@@ -47,6 +48,7 @@ const actions = {
 	openTemplateSelector: () => ( { type: 'OPEN_TEMPLATE_SELECTOR' } ),
 	closeTemplateSelector: () => ( { type: 'CLOSE_TEMPLATE_SELECTOR' } ),
 	updateLayouts: ( layouts ) => ( { type: 'UPDATE_LAYOUTS', layouts } ),
+	updateComputedLayouts: ( computedLayouts ) => ( { type: 'UPDATE_COMPUTED_LAYOUTS', computedLayouts } ),
 	updateCategories: ( categories ) => ( { type: 'UPDATE_CATEGORIES', categories } ),
 	incrementLayoutUsage: ( layout ) => ( { type: 'INCREMENT_LAYOUT_USAGE', layout, time: Date.now() } ),
 };
@@ -69,6 +71,11 @@ const store = registerStore( 'coblocks/template-selector', {
 					...state,
 					layouts: action.layouts,
 				};
+			case 'UPDATE_COMPUTED_LAYOUTS':
+				return {
+					...state,
+					computedLayouts: action.computedLayouts,
+				};
 			case 'UPDATE_CATEGORIES':
 				return {
 					...state,
@@ -82,9 +89,7 @@ const store = registerStore( 'coblocks/template-selector', {
 						...state.layoutUsage,
 						[ layoutSlug ]: {
 							time: action.time,
-							count: state.layoutUsage[ layoutSlug ]
-								? state.layoutUsage[ layoutSlug ].count + 1
-								: 1,
+							count: state.layoutUsage[ layoutSlug ] ? state.layoutUsage[ layoutSlug ].count + 1 : 1,
 						},
 					},
 				};
@@ -109,6 +114,7 @@ const store = registerStore( 'coblocks/template-selector', {
 				};
 			} );
 		},
+		getComputedLayouts: ( state ) => state.computedLayouts,
 		getCategories: ( state ) => state.categories || [],
 		hasCategories: ( state ) => !! state.categories.length,
 		getLayoutUsage: ( state ) => state.layoutUsage,

--- a/src/extensions/layout-selector/test/layout-preview.spec.js
+++ b/src/extensions/layout-selector/test/layout-preview.spec.js
@@ -27,16 +27,19 @@ describe( 'layout-selector-results', () => {
 				label: 'layout-one',
 				category: 'about',
 				blocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
+				parsedBlocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
 			},
 			{
 				label: 'layout-two',
 				category: 'about',
 				blocks: [ [ 'core/paragraph', { content: 'layout-two' }, [] ] ],
+				parsedBlocks: [ [ 'core/paragraph', { content: 'layout-two' }, [] ] ],
 			},
 			{
 				label: 'layout-three',
 				category: 'about',
 				blocks: [ [ 'core/paragraph', { content: 'layout-three' }, [] ] ],
+				parsedBlocks: [ [ 'core/paragraph', { content: 'layout-three' }, [] ] ],
 			},
 		];
 
@@ -99,6 +102,7 @@ describe( 'layout-selector-results', () => {
 				label: 'layout-one',
 				category: 'about',
 				blocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
+				parsedBlocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
 			},
 			onClick: jest.fn(),
 		};
@@ -145,16 +149,19 @@ describe( 'layout-selector-results', () => {
 					label: 'layout-one',
 					category: 'about',
 					blocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
+					parsedBlocks: [ [ 'core/paragraph', { content: 'layout-one' }, [] ] ],
 				},
 				{
 					label: 'layout-two',
 					category: 'about',
 					blocks: [ [ 'core/paragraph', { content: 'layout-two' }, [] ] ],
+					parsedBlocks: [ [ 'core/paragraph', { content: 'layout-two' }, [] ] ],
 				},
 				{
 					label: 'layout-three',
 					category: 'about',
 					blocks: [ [ 'core/paragraph', { content: 'layout-three' }, [] ] ],
+					parsedBlocks: [ [ 'core/paragraph', { content: 'layout-three' }, [] ] ],
 				},
 			],
 			category: 'about',

--- a/src/extensions/layout-selector/test/layout-preview.spec.js
+++ b/src/extensions/layout-selector/test/layout-preview.spec.js
@@ -123,16 +123,6 @@ describe( 'layout-selector-results', () => {
 			expect( wrapper.exists( '.coblocks-layout-selector__layout' ) ).toEqual( true );
 		} );
 
-		it( 'toggles overlay on mouse events "enter" and "leave"', () => {
-			expect( wrapper.find( '.coblocks-layout-selector__layout--overlay' ).hasClass( 'is-active' ) ).toEqual( false );
-
-			wrapper.find( '.coblocks-layout-selector__layout' ).invoke( 'onMouseEnter' )();
-			expect( wrapper.find( '.coblocks-layout-selector__layout--overlay' ).hasClass( 'is-active' ) ).toEqual( true );
-
-			wrapper.find( '.coblocks-layout-selector__layout' ).invoke( 'onMouseLeave' )();
-			expect( wrapper.find( '.coblocks-layout-selector__layout--overlay' ).hasClass( 'is-active' ) ).toEqual( false );
-		} );
-
 		it( 'should call onClick() on Button click', () => {
 			wrapper.find( '.coblocks-layout-selector__layout' ).invoke( 'onClick' )();
 			expect( defaultProps.onClick ).toHaveBeenCalled();

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -20,19 +20,19 @@ describe( 'Extension: Layout Selector', () => {
 
 		// Click "About" category.
 		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
-		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layouts-column' ).should( 'not.have.length', 0 );
+		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
 
 		// Click "Contact" category.
 		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(2)' ).find( 'a' ).click();
-		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layouts-column' ).should( 'not.have.length', 0 );
+		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
 
 		// Click "Home" category.
 		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(3)' ).find( 'a' ).click();
-		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layouts-column' ).should( 'not.have.length', 0 );
+		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
 
 		// Click "Portfolio" category.
 		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(4)' ).find( 'a' ).click();
-		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layouts-column' ).should( 'not.have.length', 0 );
+		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
 	} );
 
 	it( 'inserts layout into page', () => {


### PR DESCRIPTION
This PR introduce several mecanism to defer parsing of blocks to prevent the event loop from staling other procedures (as animation for instance).

- Uses new hook called useComputedLayouts to memoized blocks based on categories being showed. 
- On page load, process a queue of the "most-used" blocks on requestIdleCallback with timeout of 1s.
- Implement parsing of new category block as a side effect of changing a category (which is now in the redux store)