### PR TITLE
Fix initial image hidden on carousel initialization

### DIFF
--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -212,6 +212,7 @@ class GalleryCarouselEdit extends Component {
 		);
 
 		const flickityOptions = {
+			initialIndex: 1,
 			draggable: false,
 			pageDots: true,
 			prevNextButtons: true,

--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -212,7 +212,6 @@ class GalleryCarouselEdit extends Component {
 		);
 
 		const flickityOptions = {
-			initialIndex: 1,
 			draggable: false,
 			pageDots: true,
 			prevNextButtons: true,
@@ -297,7 +296,7 @@ class GalleryCarouselEdit extends Component {
 						<div className={ innerClasses }>
 							<Flickity
 								className={ flickityClasses }
-								disableImagesLoaded={ false }
+								disableImagesLoaded={ true }
 								flickityRef={ ( c ) => this.flkty = c }
 								options={ flickityOptions }
 								reloadOnUpdate={ true }


### PR DESCRIPTION
Resolves https://github.com/godaddy-wordpress/coblocks/issues/1773

### Description
The first carousel image is hidden on initial load. Related:

It looks like the final image is being placed at the end of the carousel, and not in the proper location before the first. When a new image is added, or the developer console is brought up, the carousel reinitializes and the issue fixes itself.

Without re-initializing the carousel again, the easiest fix is to set the `initialIndex` in `flickityOptions` resolves the issue. However, this means that the second selected image will now be the first image shown in the carousel on initialization.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/5321364/105103527-bdb3fa00-5a7e-11eb-8596-b530dbbcde09.png)

#### After
![image](https://user-images.githubusercontent.com/5321364/105102898-9ad51600-5a7d-11eb-87aa-f979f0acaa85.png)

### Types of changes
Non-breaking change

### How has this been tested?
Manually checked.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
