### PR TITLE
Disable animations when IntersectionObserver is not detected

### DIFF
--- a/src/js/coblocks-animation.js
+++ b/src/js/coblocks-animation.js
@@ -1,18 +1,26 @@
 const elems = document.querySelectorAll( '.coblocks-animate' );
 
-const observer = new IntersectionObserver( ( entries ) => {
-	entries.forEach( ( entry ) => {
-		if ( ! entry.isIntersecting ) {
-			return;
-		}
+if ( 'IntersectionObserver' in window ) {
+	const observer = new IntersectionObserver( ( entries ) => {
+		entries.forEach( ( entry ) => {
+			if ( ! entry.isIntersecting ) {
+				return;
+			}
 
-		entry.target.classList.add( entry.target.dataset.coblocksAnimation );
-		observer.unobserve( entry.target );
+			entry.target.classList.add( entry.target.dataset.coblocksAnimation );
+			observer.unobserve( entry.target );
+		} );
+	}, {
+		threshold: [ 0.15 ],
 	} );
-}, {
-	threshold: [ 0.15 ],
-} );
 
-elems.forEach( ( elem ) => {
-	observer.observe( elem );
-} );
+	elems.forEach( ( elem ) => {
+		observer.observe( elem );
+	} );
+} else {
+	// Disable animations if IntersectionObserver is not available.
+	elems.forEach( ( node ) => {
+		node.classList.remove( 'coblocks-animate' );
+		delete ( node.dataset.coblocksAnimation );
+	} );
+}


### PR DESCRIPTION
### Description
Resolves #1737 where animations failed if IntersectionObserver was not available in older browsers.

### Types of changes
Bug fix

### How has this been tested?
Manually with iOS Simulator based on reproduction steps provided in the bug report.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
