### PR TITLE
Layout Selector Mobile friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
 		],
 		"*.js": [
 			"jest --config .dev/tests/jest/jest.config.js --silent --findRelatedTests",
-			"wp-scripts lint-js"
+			"yarn lint:js"
 		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
 			"stylelint src/**/*.scss --fix"
 		],
 		"*.js": [
-			"jest --config .dev/tests/jest/jest.config.js --silent --findRelatedTests"
+			"jest --config .dev/tests/jest/jest.config.js --silent --findRelatedTests",
+			"wp-scripts lint-js"
 		]
 	}
 }

--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import Section from './section';
-import CoBlocksSettingsModalControls from './coblocks-settings-slot';
+import CoBlocksSettingsModalControls, { Slot } from './coblocks-settings-slot';
 
 /**
  * WordPress dependencies
@@ -133,7 +133,7 @@ class CoBlocksSettingsModal extends Component {
 				<div className="coblocks-modal__content">
 					<Section title={ __( 'General' ) }>
 
-						<CoBlocksSettingsModalControls.Slot />
+						<Slot />
 
 						{ showLayoutSelectorControl &&
 							<CoBlocksSettingsModalControls>

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -11,5 +11,5 @@ function CoBlocksSettingsModalControls( { children } ) {
 
 export {
 	CoBlocksSettingsModalControls as default,
-	Slot
-}
+	Slot,
+};

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -9,5 +9,7 @@ function CoBlocksSettingsModalControls( { children } ) {
 	return <Fill>{ children }</Fill>;
 }
 
-CoBlocksSettingsModalControls.Slot = Slot;
-export default CoBlocksSettingsModalControls;
+export {
+	CoBlocksSettingsModalControls as default,
+	Slot
+}

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -143,6 +143,8 @@
 	}
 
 	&__sidebar {
+		// Display only on desktop (>= 782px) using isViewportMatch
+
 		display: none;
 		padding: 0 0 0 24px;
 		position: -webkit-sticky;
@@ -179,7 +181,7 @@
 	}
 
 	&__topbar {
-		// Display only on mobile using isViewportMatch
+		// Display only on mobile (< 782px) using isViewportMatch
 
 		align-items: flex-end;
 		display: flex;

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -294,11 +294,9 @@
 			column-count: 2;
 			column-gap: 2em;
 		}
-
 		@include break-medium() {
 			column-count: 1;
 		}
-
 		@include break-large() {
 			column-count: 2;
 		}

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -36,7 +36,11 @@
 	background-color: $gray-100;
 	height: 85vh;
 	position: relative;
-	width: 1200px;
+	width: 100%;
+
+	@include break-medium() {
+		max-width: 1200px;
+	}
 
 	.components-modal__content {
 		height: auto;
@@ -44,15 +48,24 @@
 	}
 
 	.components-modal__header {
+		background-color: $gray-100;
 		border-bottom: none;
 		height: 96px;
 		margin: 0;
 		padding: 0;
 
+		@include break-medium() {
+			background-color: $white;
+		}
+
 		.components-button {
 			left: inherit;
 			position: relative;
-			right: 3%;
+			right: 1em;
+
+			@include break-medium() {
+				right: 3em;
+			}
 		}
 
 		.components-modal__header-heading-container {
@@ -61,31 +74,42 @@
 			.components-modal__header-heading {
 				background-color: $gray-100;
 				display: flex;
-				flex-direction: row;
+				flex-direction: column;
 				font-size: 1rem;
 				height: 100%;
-				justify-content: start;
+				justify-content: center;
 				margin: 0;
-				padding: 0;
-				width: 250px;
+				padding: 0 24px;
+				width: 100%;
 
-				> div {
-					align-self: center;
-					flex: 1 0 auto;
-					padding: 0 0 0 24px;
+				@include break-medium() {
+					flex-direction: row;
+					justify-content: start;
+					padding: 0;
+					width: 250px;
 				}
 
+				> div {
+					@include break-medium() {
+						align-self: center;
+						flex: 1 0 auto;
+						padding: 0 0 0 24px;
+					}
+				}
 
 				> span {
-					align-self: center;
 					display: block;
-					flex: 1 0 auto;
 					font-size: 14px;
 					font-weight: 400;
-					left: calc(150px + 5%);
-					margin-bottom: 13px;
 					margin-top: 0.8em;
-					position: relative;
+
+					@include break-medium() {
+						align-self: center;
+						flex: 1 0 auto;
+						left: calc(150px + 5%);
+						margin-bottom: 13px;
+						position: relative;
+					}
 				}
 			}
 		}
@@ -111,21 +135,23 @@
 .coblocks-layout-selector {
 	align-items: flex-start;
 	display: flex;
+	flex-direction: column;
 	justify-content: space-around;
 
-	@media (max-width: 782px) {
-		flex-direction: column;
+	@include break-medium() {
+		flex-direction: row;
 	}
 
 	&__sidebar {
+		display: none;
 		padding: 0 0 0 24px;
 		position: -webkit-sticky;
 		position: sticky;
 		top: 12px;
 		width: 250px;
 
-		@media (max-width: 782px) {
-			display: none;
+		@include break-medium() {
+			display: block;
 		}
 
 		&__items {
@@ -153,24 +179,34 @@
 	}
 
 	&__topbar {
-		display: none;
+		// Display only on mobile using isViewportMatch
 
-		@media (max-width: 782px) {
-			align-items: center;
+		align-items: flex-end;
+		display: flex;
+		justify-content: space-between;
+		padding: 12px 24px;
+		width: 100%;
+
+		.components-dropdown-menu__toggle {
+
+			&:hover {
+				border: 0;
+				box-shadow: none !important;
+			}
+		}
+
+		&__left {
 			display: flex;
-			justify-content: space-between;
-			margin-bottom: 1em;
-			width: 100%;
+			flex-direction: column;
 
-			.components-dropdown-menu__toggle {
-
-				&:hover {
-					border: 0;
-					box-shadow: none !important;
+			&__settings {
+				.coblocks-layout-selector__dropdown-button.is-link {
+					font-size: 1.1em;
+					margin-top: 0;
 				}
 			}
 
-			&__left {
+			&__category {
 				align-items: center;
 				display: flex;
 
@@ -179,6 +215,11 @@
 					margin-right: 0.5em;
 				}
 			}
+		}
+
+		&__right {
+			position: relative;
+			top: -4px;
 		}
 	}
 
@@ -226,7 +267,13 @@
 		background: $white;
 		flex-grow: 1;
 		overflow-y: auto;
-		padding: 12px 48px 24px;
+		padding: 24px !important;
+		width: 100%;
+
+		@include break-medium() {
+			padding: 0 48px 24px !important;
+			width: auto;
+		}
 
 		> span {
 			align-items: center;
@@ -234,15 +281,27 @@
 			flex-wrap: wrap;
 			justify-content: space-between;
 			margin: 0 0 0 6%;
-			padding: 20px 0 20px 0;
-
+			padding: 20px 0;
 		}
 	}
 
 	&__layouts {
-		column-count: 2;
-		column-gap: 2em;
+		column-count: 1;
+		column-gap: 1em;
 		padding-top: 4px;
+
+		@include break-small() {
+			column-count: 2;
+			column-gap: 2em;
+		}
+
+		@include break-medium() {
+			column-count: 1;
+		}
+
+		@include break-large() {
+			column-count: 2;
+		}
 	}
 
 	&__layout {

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -90,7 +90,7 @@ class LayoutSelector extends Component {
 									{ coblocksCustomLayoutsSettings }
 								</div>
 								<div className="coblocks-layout-selector__topbar__left__category">
-									<strong>{ __( 'Layouts', 'coblocks' ) }:</strong> { categories.find( category => category.slug === selectedCategory )?.title }
+									<strong>{ __( 'Layouts', 'coblocks' ) }:</strong> { categories.find( ( category ) => category.slug === selectedCategory )?.title }
 									<DropdownMenu label="Select a layout category">
 										{ ( { onClose } ) => (
 											<>

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -62,7 +62,7 @@ class LayoutSelector extends Component {
 			<>
 				<Slot />
 
-				{ settings && settings.map( ( Control, index ) => (
+				{ Array.isArray( settings ) && settings.map( ( Control, index ) => (
 					<CoBlocksLayoutSelectorFill key={ `layout-control-${ index }` }>
 						<Control />
 					</CoBlocksLayoutSelectorFill>

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, isValidElement } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
 import { compose } from '@wordpress/compose';
@@ -62,11 +62,26 @@ class LayoutSelector extends Component {
 			<>
 				<Slot />
 
-				{ Array.isArray( settings ) && settings.map( ( Control, index ) => (
-					<CoBlocksLayoutSelectorFill key={ `layout-control-${ index }` }>
-						<Control />
-					</CoBlocksLayoutSelectorFill>
-				) ) }
+				{
+					Array.isArray( settings ) &&
+					settings.map( ( Control, index ) => {
+						let ControlElem = Control;
+
+						if ( ! [ 'function', 'object' ].includes( typeof ControlElem ) ) {
+							return null;
+						}
+
+						if ( ! isValidElement( ControlElem ) ) {
+							ControlElem = <ControlElem />;
+						}
+
+						return (
+							<CoBlocksLayoutSelectorFill key={ `layout-control-${ index }` }>
+								{ ControlElem }
+							</CoBlocksLayoutSelectorFill>
+						);
+					} )
+				}
 			</>
 		);
 

--- a/src/extensions/layout-selector/layout-selector-slot.js
+++ b/src/extensions/layout-selector/layout-selector-slot.js
@@ -11,5 +11,5 @@ function CoBlocksLayoutSelectorFill( { children } ) {
 
 export {
 	CoBlocksLayoutSelectorFill as default,
-	Slot
-}
+	Slot,
+};

--- a/src/extensions/layout-selector/layout-selector-slot.js
+++ b/src/extensions/layout-selector/layout-selector-slot.js
@@ -9,5 +9,7 @@ function CoBlocksLayoutSelectorFill( { children } ) {
 	return <Fill>{ children }</Fill>;
 }
 
-CoBlocksLayoutSelectorFill.Slot = Slot;
-export default CoBlocksLayoutSelectorFill;
+export {
+	CoBlocksLayoutSelectorFill as default,
+	Slot
+}


### PR DESCRIPTION
### Description
I should be able to use the layout selector on my mobile device

### Screenshots
![image](https://user-images.githubusercontent.com/2584073/105234928-b30a6b00-5b39-11eb-9077-cd7b24da71cd.png)

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
