### PR TITLE
Introduce editor preferences slot to CoBlocks Settings

### DIFF
--- a/src/extensions/coblocks-settings/coblocks-settings-modal.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-modal.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import Section from './section';
-import CoBlocksSettingsModalControls, { Slot } from './coblocks-settings-slot';
+import {
+	SettingsSlot,
+	CoBlocksSettingsModalControls,
+	PreferenceSlot,
+	CoBlocksSettingsEditorPreference,
+} from './coblocks-settings-slot';
 
 /**
  * WordPress dependencies
@@ -125,15 +130,29 @@ class CoBlocksSettingsModal extends Component {
 
 		const settings = applyFilters( 'coblocks-settings-modal-controls', [] );
 
+		const editorPreference = applyFilters( 'coblocks-settings-editor-controls', [] );
+
 		return (
 			<Modal
 				title={ applyFilters( 'coblocks-settings-title', __( 'Editor settings', 'coblocks' ) ) }
 				onRequestClose={ closeModal }
 			>
-				<div className="coblocks-modal__content">
-					<Section title={ __( 'General' ) }>
+				{ !! editorPreference.length &&
+					<div className="coblocks-modal__content">
+						<Section title={ __( 'Editor Preference', 'coblocks' ) }>
+							<PreferenceSlot />
 
-						<Slot />
+							{ editorPreference.map( ( Control, index ) => (
+								<CoBlocksSettingsEditorPreference key={ `modal-preference-${ index }` }>
+									<Control />
+								</CoBlocksSettingsEditorPreference>
+							) ) }
+						</Section>
+					</div>
+				}
+				<div className="coblocks-modal__content">
+					<Section title={ __( 'General', 'coblocks' ) }>
+						<SettingsSlot />
 
 						{ showLayoutSelectorControl &&
 							<CoBlocksSettingsModalControls>

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -2,14 +2,25 @@
  * WordPress dependencies
  */
 import { createSlotFill } from '@wordpress/components';
+const createSettings = createSlotFill( 'CoBlocksSettingsModalControls' );
+const createPreferences = createSlotFill( 'CoBlocksSettingsEditorPreference' );
 
-const { Fill, Slot } = createSlotFill( 'CoBlocksSettingsModalControls' );
+const SettingsFill = createSettings.Fill,
+	SettingsSlot = createSettings.Slot,
+	PreferenceFill = createPreferences.Fill,
+	PreferenceSlot = createPreferences.Slot;
 
 function CoBlocksSettingsModalControls( { children } ) {
-	return <Fill>{ children }</Fill>;
+	return <SettingsFill>{ children }</SettingsFill>;
+}
+
+function CoBlocksSettingsEditorPreference( { children } ) {
+	return <PreferenceFill>{ children }</PreferenceFill>;
 }
 
 export {
-	CoBlocksSettingsModalControls as default,
-	Slot,
+	CoBlocksSettingsModalControls,
+	CoBlocksSettingsEditorPreference,
+	SettingsSlot,
+	PreferenceSlot,
 };

--- a/src/extensions/coblocks-settings/coblocks-settings-store.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-store.js
@@ -18,6 +18,7 @@ export default function createCoBlocksStore() {
 		typography: true,
 		animation: true,
 		layoutSelector: false, // default false to prevent screen flicker.
+		settingsModalOpen: false,
 	};
 
 	const layoutSelectorEnabled = applyFilters( 'coblocks-show-layout-selector', true );
@@ -55,6 +56,9 @@ export default function createCoBlocksStore() {
 		},
 		getColorPanel( ) {
 			return settings.colorsPanel;
+		},
+		getSettingsModalState( ) {
+			return settings.settingsModalOpen;
 		},
 	};
 
@@ -153,6 +157,12 @@ export default function createCoBlocksStore() {
 					coblocks_animation_controls_enabled: toggle,
 				},
 			} );
+		},
+		toggleSettingsModal( setting ) {
+			if ( settings.settingsModalOpen !== setting ) {
+				settings.settingsModalOpen = setting;
+				storeChanged();
+			}
 		},
 	};
 

--- a/src/extensions/coblocks-settings/index.js
+++ b/src/extensions/coblocks-settings/index.js
@@ -10,9 +10,9 @@ import './styles/style.scss';
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { PluginMoreMenuItem } from '@wordpress/edit-post';
-import { registerGenericStore } from '@wordpress/data';
+import { registerGenericStore, useSelect, useDispatch } from '@wordpress/data';
 import { registerPlugin, getPlugin, unregisterPlugin } from '@wordpress/plugins';
 
 /**
@@ -23,13 +23,12 @@ import createCoBlocksStore from './coblocks-settings-store.js';
 
 if ( typeof coblocksSettings !== 'undefined' && coblocksSettings.coblocksSettingsEnabled ) {
 	const CoBlocksSettingsMenuItem = () => {
-		const [
-			isOpen,
-			setOpen,
-		] = useState( false );
+		const isOpen = useSelect( ( select ) => select( 'coblocks-settings' ).getSettingsModalState(), [] );
 
-		const openModal = () => setOpen( true );
-		const closeModal = () => setOpen( false );
+		const { toggleSettingsModal } = useDispatch( 'coblocks-settings' );
+
+		const openModal = () => toggleSettingsModal( true );
+		const closeModal = () => toggleSettingsModal( false );
 
 		const props = {
 			isOpen,


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
These changes improve extensibility of the CoBlocks Settings componnet by introducing new store actions and SlotFill area for new controls.


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the browser.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
