### PR TITLE
Allow Logos & Badges block to behave responsively

### DIFF
--- a/src/blocks/logos/styles/style.scss
+++ b/src/blocks/logos/styles/style.scss
@@ -24,7 +24,7 @@
 		}
 
 		> div {
-			padding: 0 1.5em;
+			padding: 0 1.5vw;
 		}
 
 		img {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Try switching from `em` based CSS to `vw`. This should allow the element size to be based on viewport size.

Closes #1808

### Screenshots
<!-- if applicable -->
![logosVWCssFix](https://user-images.githubusercontent.com/30462574/106508499-b252cc80-6489-11eb-91e7-fa7431ff3909.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor CSS change. Should this be `%`, `vmax` or `vmin` instead? 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the responsive viewport browser.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
