### PR TITLE
Remove unintentional limit on block patterns

### DIFF
--- a/includes/class-block-patterns.php
+++ b/includes/class-block-patterns.php
@@ -199,6 +199,7 @@ class CoBlocks_Block_Patterns {
 	public function load_block_patterns() {
 		$query_args = array(
 			'post_type'              => self::POST_TYPE,
+			'posts_per_page'         => -1,
 
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,


### PR DESCRIPTION
Resolves #1775 

### Description
Remove the limit we have inside of `load_block_patterns()`.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
