### PR TITLE
Update Gist block styles to resemble ShortCode block

### DIFF
--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -88,7 +88,7 @@ class Edit extends Component {
 		const { handleErrors } = this;
 
 		return (
-			<Fragment>
+			<Fragment className={ classnames( className, meta ? null : 'no-meta' ) }>
 				{ url && url.length > 0 && isSelected && <Controls { ...this.props } /> }
 				{ url && url.length > 0 && isSelected && <Inspector { ...this.props } /> }
 				{ preview ? (
@@ -112,25 +112,18 @@ class Edit extends Component {
 				) : (
 					<Fragment>
 						{ noticeUI }
-						<div
-							className={ classnames(
-								className,
-								'wp-block-shortcode' // Use the same styling as the core shortcode block.
-							) }
-						>
 
-							<label htmlFor={ `gist-url-input-${ this.props.clientId }` }>
-								<Icon icon={ icon } />
-								{ __( 'Gist URL', 'coblocks' ) }
-							</label>
-							<PlainText
-								id={ `gist-url-input-${ this.props.clientId }` }
-								className="input-control"
-								value={ url }
-								placeholder={ __( 'Add GitHub Gist URL…', 'coblocks' ) }
-								onChange={ this.updateURL }
-							/>
-						</div>
+						<label htmlFor={ `gist-url-input-${ this.props.clientId }` }>
+							<Icon icon={ icon } />
+							{ __( 'Gist URL', 'coblocks' ) }
+						</label>
+						<PlainText
+							id={ `gist-url-input-${ this.props.clientId }` }
+							className="input-control"
+							value={ url }
+							placeholder={ __( 'Add GitHub Gist URL…', 'coblocks' ) }
+							onChange={ this.updateURL }
+						/>
 					</Fragment>
 				) }
 

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -16,7 +16,7 @@ import Gist from './gist';
  */
 import { __ } from '@wordpress/i18n';
 import { compose, withState } from '@wordpress/compose';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { PlainText, RichText } from '@wordpress/block-editor';
 import { withNotices, Icon } from '@wordpress/components';
 
@@ -88,7 +88,7 @@ class Edit extends Component {
 		const { handleErrors } = this;
 
 		return (
-			<Fragment>
+			<>
 				{ url && url.length > 0 && isSelected && <Controls { ...this.props } /> }
 				{ url && url.length > 0 && isSelected && <Inspector { ...this.props } /> }
 				{ preview ? (
@@ -110,24 +110,25 @@ class Edit extends Component {
 						</div>
 					)
 				) : (
-					<Fragment>
+					<>
 						{ noticeUI }
-
-						<label htmlFor={ `gist-url-input-${ this.props.clientId }` }>
-							<Icon icon={ icon } />
-							{ __( 'Gist URL', 'coblocks' ) }
-						</label>
-						<PlainText
-							id={ `gist-url-input-${ this.props.clientId }` }
-							className="input-control"
-							value={ url }
-							placeholder={ __( 'Add GitHub Gist URL…', 'coblocks' ) }
-							onChange={ this.updateURL }
-						/>
-					</Fragment>
+						<div className={ className }>
+							<label htmlFor={ `gist-url-input-${ this.props.clientId }` }>
+								<Icon icon={ icon } />
+								{ __( 'Gist URL', 'coblocks' ) }
+							</label>
+							<PlainText
+								id={ `gist-url-input-${ this.props.clientId }` }
+								className="input-control"
+								value={ url }
+								placeholder={ __( 'Add GitHub Gist URL…', 'coblocks' ) }
+								onChange={ this.updateURL }
+							/>
+						</div>
+					</>
 				) }
 
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -88,7 +88,7 @@ class Edit extends Component {
 		const { handleErrors } = this;
 
 		return (
-			<Fragment className={ classnames( className, meta ? null : 'no-meta' ) }>
+			<Fragment>
 				{ url && url.length > 0 && isSelected && <Controls { ...this.props } /> }
 				{ url && url.length > 0 && isSelected && <Inspector { ...this.props } /> }
 				{ preview ? (

--- a/src/blocks/gist/styles/editor.scss
+++ b/src/blocks/gist/styles/editor.scss
@@ -1,45 +1,45 @@
 [data-type="coblocks/gist"] {
+	align-items: flex-start;
+	background-color: #fff;
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px #1e1e1e;
+	box-sizing: border-box;
+	color: #1e1e1e;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	align-items: flex-start;
-	box-sizing: border-box;
-	position: relative;
-	padding: 1em;
 	min-height: 200px;
-	width: 100%;
-	text-align: left;
-	color: #1e1e1e;
-	border-radius: 2px;
-	background-color: #fff;
-	box-shadow: inset 0 0 0 1px #1e1e1e;
 	outline: 1px solid transparent;
+	padding: 1em;
+	position: relative;
+	text-align: left;
+	width: 100%;
 
 	label {
 		display: flex;
 		margin-bottom: 16px;
-		
+
 		svg {
 			margin-right: 1ch;
 		}
 	}
 
 	.wp-block-coblocks-gist {
-		width: 100%;
 		min-width: 100%;
+		width: 100%;
 	}
 
 	.block-editor-plain-text {
-		padding: 6px 8px;
-		box-shadow: 0 0 0 transparent;
-		transition: box-shadow 0.1s linear;
-		border-radius: 2px;
-		font-size: 16px;
 		border: 1px solid #757575;
+		border-radius: 2px;
+		box-shadow: 0 0 0 transparent;
+		font-size: 16px;
 		line-height: normal;
+		padding: 6px 8px;
+		transition: box-shadow 0.1s linear;
 
 		@media (min-width: 600px) {
-			font-size: 13px
+			font-size: 13px;
 		}
 	}
 

--- a/src/blocks/gist/styles/editor.scss
+++ b/src/blocks/gist/styles/editor.scss
@@ -1,20 +1,46 @@
-.wp-block-coblocks-gist {
+[data-type="coblocks/gist"] {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: flex-start;
+	box-sizing: border-box;
+	position: relative;
+	padding: 1em;
+	min-height: 200px;
+	width: 100%;
+	text-align: left;
+	color: #1e1e1e;
+	border-radius: 2px;
+	background-color: #fff;
+	box-shadow: inset 0 0 0 1px #1e1e1e;
+	outline: 1px solid transparent;
 
-	&.wp-block-shortcode {
+	label {
 		display: flex;
-		flex-direction: row;
-	}
-
-	> label {
-
+		margin-bottom: 16px;
+		
 		svg {
 			margin-right: 1ch;
 		}
 	}
 
+	.wp-block-coblocks-gist {
+		width: 100%;
+		min-width: 100%;
+	}
+
 	.block-editor-plain-text {
-		margin-left: 10px;
-		padding: 8px;
+		padding: 6px 8px;
+		box-shadow: 0 0 0 transparent;
+		transition: box-shadow 0.1s linear;
+		border-radius: 2px;
+		font-size: 16px;
+		border: 1px solid #757575;
+		line-height: normal;
+
+		@media (min-width: 600px) {
+			font-size: 13px
+		}
 	}
 
 	.gist {

--- a/src/blocks/gist/styles/editor.scss
+++ b/src/blocks/gist/styles/editor.scss
@@ -15,8 +15,18 @@
 	text-align: left;
 	width: 100%;
 
+	&[data-align="wide"] > .wp-block[data-align="wide"] {
+		height: 100%;
+		margin-bottom: 0;
+		margin-left: auto;
+		margin-right: auto;
+		// https://github.com/WordPress/gutenberg/blob/6c08026384a1dfd942d2e36e831544ce246d94ad/packages/base-styles/_variables.scss#L76
+		max-width: 1100px;
+		width: 100%;
+	}
+
 	label {
-		display: flex;
+		display: inline-flex;
 		margin-bottom: 16px;
 
 		svg {
@@ -25,7 +35,6 @@
 	}
 
 	.wp-block-coblocks-gist {
-		min-width: 100%;
 		width: 100%;
 	}
 
@@ -55,7 +64,7 @@
 
 	&__file-label {
 		align-items: center;
-		display: flex;
+		display: inline-flex;
 		flex-basis: 0;
 		font-size: 12px;
 		padding-left: 5px;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Tweak Gist block styles to more closely resemble the ShortCode block. Identified and fixed a bug with editor width when setting the Gist block to wide width and when Gist content is wide.

### Screenshots
<!-- if applicable -->
![GistWideWidth](https://user-images.githubusercontent.com/30462574/107239498-2808ec00-69e6-11eb-98ca-a77b5f0a8803.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Style changes. JS Markup changes - no deprecation needed.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
