### PR TITLE
Try new focus styles for the Layout Selector

### DIFF
--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -172,9 +172,8 @@
 				&:hover,
 				&:focus,
 				&.is-selected {
-					box-shadow: none;
-					color: var(--wp-admin-theme-color, #007cba);
-					outline: none;
+					box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color);
+					outline: 1px solid transparent;
 				}
 			}
 		}

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -172,7 +172,7 @@
 				&:hover,
 				&:focus,
 				&.is-selected {
-					box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color);
+					box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color, #007cba);
 					outline: 1px solid transparent;
 				}
 			}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Some buttons on the Layout selector have a barely visible `:focus` state. Accessibility can be improved by mirroring existing button component `:focus` styles.

### Screenshots
<!-- if applicable -->
![LayoutSelectorWithFocusCoblocks](https://user-images.githubusercontent.com/30462574/107265900-0ae21680-6a02-11eb-8a8a-257d099d8a5a.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor CSS changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in Firefox and Chrome.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
