### PR TITLE
Fix Author block button removal and image placeholder alignment

### DIFF
--- a/src/blocks/author/edit.js
+++ b/src/blocks/author/edit.js
@@ -17,8 +17,17 @@ import { compose } from '@wordpress/compose';
 import { mediaUpload } from '@wordpress/editor';
 import { withSelect, select } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
-import { Button, Dashicon, DropZone } from '@wordpress/components';
-import { RichText, InnerBlocks, MediaUpload, MediaUploadCheck, withColors, withFontSizes } from '@wordpress/block-editor';
+import { Button, DropZone } from '@wordpress/components';
+import { image as icon } from '@wordpress/icons';
+import {
+	RichText,
+	InnerBlocks,
+	MediaUpload,
+	MediaUploadCheck,
+	withColors,
+	withFontSizes,
+	BlockIcon,
+} from '@wordpress/block-editor';
 
 class AuthorEdit extends Component {
 	constructor() {
@@ -111,7 +120,7 @@ class AuthorEdit extends Component {
 									render={ ( { open } ) => (
 										<Button onClick={ open }>
 											{ ! imgUrl
-												? <Dashicon icon="format-image" />
+												? <BlockIcon icon={ icon } />
 												: <img className="wp-block-coblocks-author__avatar-img" src={ imgUrl } alt="avatar" />
 											}
 										</Button>
@@ -153,7 +162,6 @@ class AuthorEdit extends Component {
 						/>
 						<InnerBlocks
 							template={ [ [ 'core/button', { placeholder: /* translators: content placeholder */ __( 'Author link…', 'coblocks' ) } ] ] }
-							templateLock="all"
 							allowedBlocks={ [ 'core/button' ] }
 							templateInsertUpdatesSelection={ false }
 							__experimentalCaptureToolbars={ true }

--- a/src/blocks/author/styles/editor.scss
+++ b/src/blocks/author/styles/editor.scss
@@ -54,7 +54,7 @@
 				box-shadow: 0 0 0 1px $white, 0 0 0 3px var(--wp-admin-theme-color);
 			}
 
-			.block-editor-block-icon { 
+			.block-editor-block-icon {
 				margin: auto;
 
 				svg {

--- a/src/blocks/author/styles/editor.scss
+++ b/src/blocks/author/styles/editor.scss
@@ -54,11 +54,15 @@
 				box-shadow: 0 0 0 1px $white, 0 0 0 3px var(--wp-admin-theme-color);
 			}
 
-			svg {
-				margin: auto auto;
-				pointer-events: none;
-				transform: translate3d(0, 0, 0);
-				transition: transform 100ms cubic-bezier(0.645, 0.045, 0.355, 1);
+			.block-editor-block-icon { 
+				margin: auto;
+
+				svg {
+					margin: auto auto;
+					pointer-events: none;
+					transform: translate3d(0, 0, 0);
+					transition: transform 100ms cubic-bezier(0.645, 0.045, 0.355, 1);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Author block had template lock in place preventing removal of Button block. This lock has been removed allowing adding and removal of button block.

### Screenshots
<!-- if applicable -->
![authorBlockImageAndButton](https://user-images.githubusercontent.com/30462574/107527179-d1cab300-6b75-11eb-9d13-d18ff7971644.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
CSS and minor JavasScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in the editor. No deprecation needed.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
