### PR TITLE
Fix Gallery captions focus

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -127,7 +127,7 @@ export function addBlockToPost( blockName, clearEditor = false ) {
 		clearBlocks();
 	}
 
-	cy.get( '.edit-post-header-toolbar' ).find( '.edit-post-header-toolbar__inserter-toggle' ).then( ( inserterButton ) => {
+	cy.get( '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle' ).then( ( inserterButton ) => {
 		if ( ! Cypress.$( inserterButton ).hasClass( 'is-pressed' ) ) {
 			cy.get( inserterButton ).click();
 		}

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -127,11 +127,7 @@ export function addBlockToPost( blockName, clearEditor = false ) {
 		clearBlocks();
 	}
 
-	cy.get( '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle' ).then( ( inserterButton ) => {
-		if ( ! Cypress.$( inserterButton ).hasClass( 'is-pressed' ) ) {
-			cy.get( inserterButton ).click();
-		}
-	} );
+	cy.get( '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle' ).click();
 
 	cy.get( '.block-editor-inserter__search' ).find( 'input' ).clear();
 	cy.get( '.block-editor-inserter__search' ).click().type(

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -127,7 +127,11 @@ export function addBlockToPost( blockName, clearEditor = false ) {
 		clearBlocks();
 	}
 
-	cy.get( '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle' ).click();
+	cy.get( '.edit-post-header-toolbar' ).find( '.edit-post-header-toolbar__inserter-toggle' ).then( ( inserterButton ) => {
+		if ( ! Cypress.$( inserterButton ).hasClass( 'is-pressed' ) ) {
+			cy.get( inserterButton ).click();
+		}
+	} );
 
 	cy.get( '.block-editor-inserter__search' ).find( 'input' ).clear();
 	cy.get( '.block-editor-inserter__search' ).click().type(

--- a/src/blocks/gallery-carousel/test/gallery-carousel.cypress.js
+++ b/src/blocks/gallery-carousel/test/gallery-carousel.cypress.js
@@ -137,4 +137,37 @@ describe( 'Test CoBlocks Gallery Carousel Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test that we can add image captions with rich text options
+	 */
+	it( 'Test carousel captions allow rich text controls.', function() {
+		helpers.addBlockToPost( 'coblocks/gallery-carousel', true );
+
+		cy.get( '[data-type="coblocks/gallery-carousel"]' )
+			.click()
+			.contains( /media library/i )
+			.click();
+
+		cy.get( '.media-modal-content' ).contains( /media library/i ).click();
+
+		cy.get( '.media-modal-content' ).find( 'li.attachment' )
+			.first( 'li' )
+			.click();
+
+		cy.get( '.media-frame-toolbar .media-toolbar-primary' ).then( ( mediaToolbar ) => {
+			if ( mediaToolbar.prop( 'outerHTML' ).includes( 'Insert gallery' ) ) { // wp 5.4
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			} else { // pre wp 5.4
+				cy.get( 'button' ).contains( /create a new gallery/i ).click();
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			}
+		} );
+
+		cy.get( '.block-editor-format-toolbar' ).should( 'not.exist' );
+
+		cy.get( '[data-type="coblocks/gallery-carousel"]' ).find( 'figcaption' ).focus();
+
+		cy.get( '.block-editor-format-toolbar' );
+	} );
 } );

--- a/src/blocks/gallery-collage/test/gallery-collage.cypress.js
+++ b/src/blocks/gallery-collage/test/gallery-collage.cypress.js
@@ -162,15 +162,6 @@ describe( 'Test CoBlocks Gallery Collage Block', function() {
 	} );
 
 	it( 'can replace the existing image through the "Replace" button', () => {
-		helpers.addBlockToPost( 'coblocks/gallery-collage', true );
-
-		const { imageBase } = helpers.upload.spec;
-		helpers.upload.imageToBlock( 'coblocks/gallery-collage' );
-		cy.get( '.wp-block-coblocks-gallery-collage__item img[src*="http"]' ).should( 'have.attr', 'src' ).should( 'include', imageBase );
-
-		cy.get( '.wp-block-coblocks-gallery-collage__item' ).first().click();
-		cy.get( '.wp-block-coblocks-gallery-collage__item' ).first().find( '.coblocks-gallery-item__button-replace' ).click();
-
 		// Replace the image.
 		const newImageBase = '150x150-2';
 		/* eslint-disable */

--- a/src/blocks/gallery-collage/test/gallery-collage.cypress.js
+++ b/src/blocks/gallery-collage/test/gallery-collage.cypress.js
@@ -129,6 +129,38 @@ describe( 'Test CoBlocks Gallery Collage Block', function() {
 		helpers.editPage();
 	} );
 
+	/**
+	 * Test that we can add image captions with rich text options
+	 * No assertion that rich text options do not exist.
+	 * Collage block has always-focused rich text options.
+	 */
+	it( 'Test collage captions allow rich text controls.', function() {
+		helpers.addBlockToPost( 'coblocks/gallery-collage', true );
+
+		cy.get( '[data-type="coblocks/gallery-collage"]' )
+			.first()
+			.click()
+			.contains( /media library/i )
+			.click();
+
+		cy.get( '.media-modal-content' ).contains( /media library/i ).click();
+
+		cy.get( '.media-modal-content' ).find( 'li.attachment' )
+			.first( 'li' )
+			.click();
+
+		cy.get( '.media-modal-content' ).find( '.media-button-select' ).click();
+
+		helpers.toggleSettingCheckbox( /captions/i );
+
+		cy.get( '.wp-block-coblocks-gallery-collage__item' ).first().click()
+			.find( 'figcaption' ).focus();
+
+		cy.get( '[data-type="coblocks/gallery-collage"]' ).find( 'figcaption' ).focus();
+
+		cy.get( '.block-editor-format-toolbar' );
+	} );
+
 	it( 'can replace the existing image through the "Replace" button', () => {
 		helpers.addBlockToPost( 'coblocks/gallery-collage', true );
 

--- a/src/blocks/gallery-collage/test/gallery-collage.cypress.js
+++ b/src/blocks/gallery-collage/test/gallery-collage.cypress.js
@@ -162,6 +162,9 @@ describe( 'Test CoBlocks Gallery Collage Block', function() {
 	} );
 
 	it( 'can replace the existing image through the "Replace" button', () => {
+		cy.get( '.wp-block-coblocks-gallery-collage__item' ).first().click();
+		cy.get( '.wp-block-coblocks-gallery-collage__item' ).first().find( '.coblocks-gallery-item__button-replace' ).click();
+
 		// Replace the image.
 		const newImageBase = '150x150-2';
 		/* eslint-disable */

--- a/src/blocks/gallery-masonry/test/gallery-masonry.cypress.js
+++ b/src/blocks/gallery-masonry/test/gallery-masonry.cypress.js
@@ -140,4 +140,41 @@ describe( 'Test CoBlocks Gallery Masonry Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test that we can add image captions with rich text options
+	 */
+	it( 'Test masonry captions allow rich text controls.', function() {
+		helpers.addBlockToPost( 'coblocks/gallery-masonry', true );
+
+		cy.get( '[data-type="coblocks/gallery-masonry"]' )
+			.click()
+			.contains( /media library/i )
+			.click();
+
+		cy.get( '.media-modal-content' ).contains( /media library/i ).click();
+
+		cy.get( '.media-modal-content' ).find( 'li.attachment' )
+			.first( 'li' )
+			.click();
+
+		cy.get( '.media-frame-toolbar .media-toolbar-primary' ).then( ( mediaToolbar ) => {
+			if ( mediaToolbar.prop( 'outerHTML' ).includes( 'Insert gallery' ) ) { // wp 5.4
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			} else { // pre wp 5.4
+				cy.get( 'button' ).contains( /create a new gallery/i ).click();
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			}
+		} );
+
+		helpers.toggleSettingCheckbox( /captions/i );
+
+		cy.get( '.coblocks-gallery--item img[src*="http"]' ).click();
+
+		cy.get( '.block-editor-format-toolbar' ).should( 'not.exist' );
+
+		cy.get( 'figcaption[role="textbox"]' ).focus();
+
+		cy.get( '.block-editor-format-toolbar' );
+	} );
 } );

--- a/src/blocks/gallery-offset/test/gallery-offset.cypress.js
+++ b/src/blocks/gallery-offset/test/gallery-offset.cypress.js
@@ -137,4 +137,40 @@ describe( 'Test CoBlocks Gallery Offset Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test that we can add image captions with rich text options
+	 */
+	it( 'Test offset captions allow rich text controls.', function() {
+		helpers.addBlockToPost( 'coblocks/gallery-offset', true );
+
+		cy.get( '[data-type="coblocks/gallery-offset"]' )
+			.click()
+			.contains( /media library/i )
+			.click();
+
+		cy.get( '.media-modal-content' ).contains( /media library/i ).click();
+
+		cy.get( '.media-modal-content' ).find( 'li.attachment' )
+			.first( 'li' )
+			.click();
+
+		cy.get( '.media-frame-toolbar .media-toolbar-primary' ).then( ( mediaToolbar ) => {
+			if ( mediaToolbar.prop( 'outerHTML' ).includes( 'Insert gallery' ) ) { // wp 5.4
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			} else { // pre wp 5.4
+				cy.get( 'button' ).contains( /create a new gallery/i ).click();
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			}
+		} );
+
+		helpers.toggleSettingCheckbox( /captions/i );
+
+		cy.get( '.block-editor-format-toolbar' ).should( 'not.exist' );
+
+		cy.get( '.coblocks-gallery--item' ).first().click()
+			.find( 'figcaption' ).focus();
+
+		cy.get( '.block-editor-format-toolbar' );
+	} );
 } );

--- a/src/blocks/gallery-stacked/test/gallery-stacked.cypress.js
+++ b/src/blocks/gallery-stacked/test/gallery-stacked.cypress.js
@@ -137,4 +137,40 @@ describe( 'Test CoBlocks Gallery Stacked Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test that we can add image captions with rich text options
+	 */
+	it( 'Test stacked captions allow rich text controls.', function() {
+		helpers.addBlockToPost( 'coblocks/gallery-stacked', true );
+
+		cy.get( '[data-type="coblocks/gallery-stacked"]' )
+			.click()
+			.contains( /media library/i )
+			.click();
+
+		cy.get( '.media-modal-content' ).contains( /media library/i ).click();
+
+		cy.get( '.media-modal-content' ).find( 'li.attachment' )
+			.first( 'li' )
+			.click();
+
+		cy.get( '.media-frame-toolbar .media-toolbar-primary' ).then( ( mediaToolbar ) => {
+			if ( mediaToolbar.prop( 'outerHTML' ).includes( 'Insert gallery' ) ) { // wp 5.4
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			} else { // pre wp 5.4
+				cy.get( 'button' ).contains( /create a new gallery/i ).click();
+				cy.get( 'button' ).contains( /insert gallery/i ).click();
+			}
+		} );
+
+		helpers.toggleSettingCheckbox( /captions/i );
+
+		cy.get( '.block-editor-format-toolbar' ).should( 'not.exist' );
+
+		cy.get( '.coblocks-gallery--item' ).first().click()
+			.find( 'figcaption' ).focus();
+
+		cy.get( '.block-editor-format-toolbar' );
+	} );
 } );

--- a/src/components/block-gallery/gallery-image.js
+++ b/src/components/block-gallery/gallery-image.js
@@ -184,7 +184,7 @@ class GalleryImage extends Component {
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		return (
-			<figure className={ className } tabIndex="-1" ref={ this.bindContainer }>
+			<figure className={ className } tabIndex="-1" onKeyDown={ this.onKeyDown } ref={ this.bindContainer }>
 				{ isSelected &&
 					<Fragment>
 						{ supportsMoving &&

--- a/src/components/block-gallery/gallery-image.js
+++ b/src/components/block-gallery/gallery-image.js
@@ -184,7 +184,7 @@ class GalleryImage extends Component {
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		return (
-			<figure className={ className } onClick={ this.onImageClick } tabIndex="-1" onKeyDown={ this.onKeyDown } ref={ this.bindContainer }>
+			<figure className={ className } tabIndex="-1" ref={ this.bindContainer }>
 				{ isSelected &&
 					<Fragment>
 						{ supportsMoving &&


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1717 
This bug was originally introduced in this PR: https://github.com/godaddy-wordpress/coblocks/pull/1687

Changes here allow for gallery captions to be clicked and for the RichText typography options toolbar to remain present for user interactions.

### Screenshots
<!-- if applicable -->
![galleryCaptions](https://user-images.githubusercontent.com/30462574/107553194-b53c7400-6b91-11eb-9d8f-743140382298.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually within the editor.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
