### PR TITLE
Fix Posts block layout

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -123,6 +123,9 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 			require_once COBLOCKS_PLUGIN_DIR . 'src/components/gutter-control/gutter-wrapper.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'src/components/form-label-colors/label-color-wrapper.php';
 
+			// Require CoBlocks custom utilities.
+			require_once COBLOCKS_PLUGIN_DIR . 'src/utils/utils.php';
+
 			if ( is_admin() ) {
 				require_once COBLOCKS_PLUGIN_DIR . 'src/extensions/layout-selector/index.php';
 			}

--- a/src/blocks/posts/block.json
+++ b/src/blocks/posts/block.json
@@ -70,5 +70,10 @@
 				"type": "object"
 			}
 		}
+	},
+	"supports": {
+		"gutter": {
+			"default": "medium"
+		}
 	}
 }

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -532,7 +532,10 @@ export default compose( [
 						if ( ! url ) {
 							url = get( image, 'source_url', null );
 						}
-						return { ...post, featuredImageSourceUrl: url };
+						return {
+							...post,
+							featured_media_object: post.featured_media && select( 'core' ).getMedia( post.featured_media ),
+						};
 					}
 					return post;
 				} );

--- a/src/blocks/posts/index.php
+++ b/src/blocks/posts/index.php
@@ -322,6 +322,7 @@ function coblocks_register_posts_block() {
 		'coblocks/posts',
 		array(
 			'attributes'      => $metadata['attributes'],
+			'supports'        => $metadata['supports'],
 			'render_callback' => 'coblocks_render_posts_block',
 		)
 	);

--- a/src/blocks/posts/styles/style.scss
+++ b/src/blocks/posts/styles/style.scss
@@ -111,6 +111,7 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
+	margin-top: auto;
 
 	&.self-center {
 		align-self: center;

--- a/src/blocks/posts/styles/style.scss
+++ b/src/blocks/posts/styles/style.scss
@@ -110,8 +110,8 @@
 .wp-block-coblocks-posts__content {
 	display: flex;
 	flex-direction: column;
-	width: 100%;
 	margin-top: auto;
+	width: 100%;
 
 	&.self-center {
 		align-self: center;

--- a/src/components/gutter-control/gutter-wrapper.php
+++ b/src/components/gutter-control/gutter-wrapper.php
@@ -33,7 +33,7 @@ add_filter( 'coblocks_render_wrapper_styles', 'coblocks_add_gutter_styles', 10, 
  * @return array
  */
 function coblocks_add_gutter_class( $classes, $attributes ) {
-	if ( isset( $attributes['columns'] ) && 1 < intval ( $attributes['columns'] ) && isset( $attributes['gutter'] ) ) {
+	if ( isset( $attributes['columns'] ) && 1 < intval( $attributes['columns'] ) && isset( $attributes['gutter'] ) ) {
 		array_push( $classes, 'has-' . $attributes['gutter'] . '-gutter' );
 	}
 
@@ -44,10 +44,7 @@ add_filter( 'coblocks_render_wrapper_class', 'coblocks_add_gutter_class', 10, 2 
 /**
  * Add gutter attribute in php
  *
- * @param array $classes array of classes.
- * @param array $attributes block attributes.
- *
- * @return array
+ * @param WP_Block_Type $block_type Block Type.
  */
 function coblocks_register_gutter_support( $block_type ) {
 	$has_gutter_support = false;
@@ -60,22 +57,25 @@ function coblocks_register_gutter_support( $block_type ) {
 		if ( ! $block_type->attributes ) {
 
 			$block_type->attributes = array();
+
 		}
 	
-	
 		if ( ! array_key_exists( 'gutter', $block_type->attributes ) ) {
+
 			$block_type->attributes['gutter'] = array(
-				'type' => 'string',
-				'default' => 'medium'
+				'type'    => 'string',
+				'default' => 'medium',
 			);
-			
+
 		}
 	
 		if ( ! array_key_exists( 'gutterCustom', $block_type->attributes ) ) {
+
 			$block_type->attributes['gutterCustom'] = array(
-				'type' => 'string',
-				'default' => ''
+				'type'    => 'string',
+				'default' => '',
 			);
+
 		}
 	}
 }

--- a/src/components/gutter-control/gutter-wrapper.php
+++ b/src/components/gutter-control/gutter-wrapper.php
@@ -33,7 +33,7 @@ add_filter( 'coblocks_render_wrapper_styles', 'coblocks_add_gutter_styles', 10, 
  * @return array
  */
 function coblocks_add_gutter_class( $classes, $attributes ) {
-	if ( isset( $attributes['columns'] ) && isset( $attributes['gutter'] ) ) {
+	if ( isset( $attributes['columns'] ) && 1 < intval ( $attributes['columns'] ) && isset( $attributes['gutter'] ) ) {
 		array_push( $classes, 'has-' . $attributes['gutter'] . '-gutter' );
 	}
 
@@ -50,7 +50,13 @@ add_filter( 'coblocks_render_wrapper_class', 'coblocks_add_gutter_class', 10, 2 
  * @return array
  */
 function coblocks_register_gutter_support( $block_type ) {
-	if ( $block_type->name === 'coblocks/posts') {
+	$has_gutter_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$has_gutter_support = coblocks_experimental_get( $block_type->supports, array( 'gutter' ), false );
+	}
+
+
+	if ( $has_gutter_support ) {
 		if ( ! $block_type->attributes ) {
 
 			$block_type->attributes = array();

--- a/src/components/gutter-control/gutter-wrapper.php
+++ b/src/components/gutter-control/gutter-wrapper.php
@@ -48,10 +48,12 @@ add_filter( 'coblocks_render_wrapper_class', 'coblocks_add_gutter_class', 10, 2 
  */
 function coblocks_register_gutter_support( $block_type ) {
 	$has_gutter_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_gutter_support = coblocks_experimental_get( $block_type->supports, array( 'gutter' ), false );
-	}
 
+	if ( property_exists( $block_type, 'supports' ) ) {
+
+		$has_gutter_support = coblocks_experimental_get( $block_type->supports, array( 'gutter' ), false );
+
+	}
 
 	if ( $has_gutter_support ) {
 		if ( ! $block_type->attributes ) {
@@ -59,7 +61,7 @@ function coblocks_register_gutter_support( $block_type ) {
 			$block_type->attributes = array();
 
 		}
-	
+
 		if ( ! array_key_exists( 'gutter', $block_type->attributes ) ) {
 
 			$block_type->attributes['gutter'] = array(
@@ -68,7 +70,7 @@ function coblocks_register_gutter_support( $block_type ) {
 			);
 
 		}
-	
+
 		if ( ! array_key_exists( 'gutterCustom', $block_type->attributes ) ) {
 
 			$block_type->attributes['gutterCustom'] = array(

--- a/src/components/gutter-control/gutter-wrapper.php
+++ b/src/components/gutter-control/gutter-wrapper.php
@@ -40,3 +40,45 @@ function coblocks_add_gutter_class( $classes, $attributes ) {
 	return $classes;
 }
 add_filter( 'coblocks_render_wrapper_class', 'coblocks_add_gutter_class', 10, 2 );
+
+/**
+ * Add gutter attribute in php
+ *
+ * @param array $classes array of classes.
+ * @param array $attributes block attributes.
+ *
+ * @return array
+ */
+function coblocks_register_gutter_support( $block_type ) {
+	if ( $block_type->name === 'coblocks/posts') {
+		if ( ! $block_type->attributes ) {
+
+			$block_type->attributes = array();
+		}
+	
+	
+		if ( ! array_key_exists( 'gutter', $block_type->attributes ) ) {
+			$block_type->attributes['gutter'] = array(
+				'type' => 'string',
+				'default' => 'medium'
+			);
+			
+		}
+	
+		if ( ! array_key_exists( 'gutterCustom', $block_type->attributes ) ) {
+			$block_type->attributes['gutterCustom'] = array(
+				'type' => 'string',
+				'default' => ''
+			);
+		}
+	}
+}
+
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'gutter',
+	array(
+		'register_attribute' => 'coblocks_register_gutter_support',
+	)
+);

--- a/src/components/gutter-control/gutter-wrapper.php
+++ b/src/components/gutter-control/gutter-wrapper.php
@@ -55,30 +55,34 @@ function coblocks_register_gutter_support( $block_type ) {
 
 	}
 
-	if ( $has_gutter_support ) {
-		if ( ! $block_type->attributes ) {
+	if ( ! $has_gutter_support ) {
 
-			$block_type->attributes = array();
+		return;
 
-		}
+	}
 
-		if ( ! array_key_exists( 'gutter', $block_type->attributes ) ) {
+	if ( ! $block_type->attributes ) {
 
-			$block_type->attributes['gutter'] = array(
-				'type'    => 'string',
-				'default' => 'medium',
-			);
+		$block_type->attributes = array();
 
-		}
+	}
 
-		if ( ! array_key_exists( 'gutterCustom', $block_type->attributes ) ) {
+	if ( ! array_key_exists( 'gutter', $block_type->attributes ) ) {
 
-			$block_type->attributes['gutterCustom'] = array(
-				'type'    => 'string',
-				'default' => '',
-			);
+		$block_type->attributes['gutter'] = array(
+			'type'    => 'string',
+			'default' => 'medium',
+		);
 
-		}
+	}
+
+	if ( ! array_key_exists( 'gutterCustom', $block_type->attributes ) ) {
+
+		$block_type->attributes['gutterCustom'] = array(
+			'type'    => 'string',
+			'default' => '',
+		);
+
 	}
 }
 

--- a/src/utils/utils.php
+++ b/src/utils/utils.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * General utilities.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * This function allows to easily access a part from a php array.
+ * It is equivalent to want lodash get provides for JavaScript and is useful to have something similar
+ * in php so functions that do the same thing on the client and sever can have identical code.
+ * 
+ * Utility is cloned from source: 
+ * https://github.com/WordPress/gutenberg/blob/5f614054e92f5147018f07db601ac1c5eae9d14e/lib/utils.php#L8-L33
+ *
+ * @param array $array    An array from where we want to retrieve some information from.
+ * @param array $path     An array containing the path we want to retrieve.
+ * @param array $default  The return value if $array or $path is not expected input type.
+ *
+ * @return array An array matching the path specified.
+ */
+function coblocks_experimental_get( $array, $path, $default = array() ) {
+	// Confirm input values are expected type to avoid notice warnings.
+	if ( ! is_array( $array ) || ! is_array( $path ) ) {
+		return $default;
+	}
+
+	$path_length = count( $path );
+	for ( $i = 0; $i < $path_length; ++$i ) {
+		if ( ! isset( $array[ $path[ $i ] ] ) ) {
+			return $default;
+		}
+		$array = $array[ $path[ $i ] ];
+	}
+	return $array;
+}

--- a/src/utils/utils.php
+++ b/src/utils/utils.php
@@ -2,7 +2,7 @@
 /**
  * General utilities.
  *
- * @package gutenberg
+ * @package CoBlocks
  */
 
 /**


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1728 
API changes introduced in https://github.com/godaddy-wordpress/coblocks/pull/1576 caused an unintentional change in property syntax. Minor change within the `edit.js` file to allow images to properly render and controls along with them.

In addition to the syntax error when accessing properties, the `coblocks/posts` block also has a failure to properly apply gutter attributes and styles from the `Gutter Controls` component. 

Changes here properly apply attributes, styles, and classes to the `coblocks/posts` SSR block.


![postsBlockImagesLayout](https://user-images.githubusercontent.com/30462574/107683067-5f81cd80-6c5e-11eb-8b43-19ff68b25cda.gif)


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
