### PR TITLE
WPEX-1022 Remove animations from Layouts Selector

### DIFF
--- a/.dev/tests/jest/helpers.js
+++ b/.dev/tests/jest/helpers.js
@@ -202,7 +202,7 @@ export const testDeprecatedBlockVariations = ( blockName, blockSettings, blockVa
  *
  * @return {Object} The filtered block object.
  */
-const filterBlockObjectResult = ( blockObject ) => {
+export const filterBlockObjectResult = ( blockObject ) => {
 	const { name, attributes, isValid } = blockObject;
 	const validationIssues = blockObject.validationIssues.map( ( issue ) => issue.args );
 	return { name, attributes, isValid, validationIssues };

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -79,7 +79,7 @@ export const LayoutPreview = ( { layout, onClick } ) => {
  * @return {Array} Sanitized version of the blocks
  */
 const sanitizeBlocks = ( blocks ) => {
-	const sanitized = blocks.map( ( block ) => {
+	return blocks.map( ( block ) => {
 		// Remove animation
 		if ( block?.attributes?.animation ) {
 			block.attributes.animation = '';
@@ -92,8 +92,6 @@ const sanitizeBlocks = ( blocks ) => {
 
 		return block;
 	} );
-
-	return sanitized;
 };
 
 /**

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -78,7 +78,7 @@ export const LayoutPreview = ( { layout, onClick } ) => {
  * @param {Array} blocks Array of blocks
  * @return {Array} Sanitized version of the blocks
  */
-const sanitizeBlocks = ( blocks ) => {
+export const sanitizeBlocks = ( blocks ) => {
 	return blocks.map( ( block ) => {
 		// Remove animation
 		if ( block?.attributes?.animation ) {

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -57,6 +57,8 @@ export const LayoutSelectorResults = ( { layouts, category, onInsert } ) => {
  * Renders the layout's block preview.
  */
 export const LayoutPreview = ( { layout, onClick } ) => {
+	const sanitizedBlocks = sanitizeBlocks( layout.blocks );
+
 	return (
 		<Button
 			className={ classnames( 'coblocks-layout-selector__layout' ) }
@@ -64,9 +66,34 @@ export const LayoutPreview = ( { layout, onClick } ) => {
 
 			<Spinner />
 
-			<BlockPreview blocks={ layout.blocks } viewportWidth={ 700 } />
+			<BlockPreview blocks={ sanitizedBlocks } viewportWidth={ 700 } />
 		</Button>
 	);
+};
+
+/**
+ * Remove unwanted stuff from blocks displayed in preview
+ * - Remove animations
+ *
+ * @param {Array} blocks Array of blocks
+ * @return {Array} Sanitized version of the blocks
+ */
+const sanitizeBlocks = ( blocks ) => {
+	const sanitized = blocks.map( ( block ) => {
+		// Remove animation
+		if ( block?.attributes?.animation ) {
+			block.attributes.animation = '';
+		}
+
+		// Process innerBlocks, if any
+		if ( block?.innerBlocks?.length > 0 ) {
+			block.innerBlocks = sanitizeBlocks( block.innerBlocks );
+		}
+
+		return block;
+	} );
+
+	return sanitized;
 };
 
 /**

--- a/src/extensions/layout-selector/test/layout-preview.spec.js
+++ b/src/extensions/layout-selector/test/layout-preview.spec.js
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import '@testing-library/jest-dom/extend-expect';
 
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock, serialize, parse } from '@wordpress/blocks';
 registerCoreBlocks();
 
 /**
@@ -15,7 +16,9 @@ import {
 	LayoutPreviewList,
 	LayoutPreviewPlaceholder,
 	LayoutSelectorResults,
+	sanitizeBlocks,
 } from '../layout-selector-results';
+import * as helpers from '../../../../.dev/tests/jest/helpers';
 
 describe( 'layout-selector-results', () => {
 
@@ -158,7 +161,6 @@ describe( 'layout-selector-results', () => {
 			onInsert: jest.fn(),
 		};
 
-
 		const setup = ( props = {} ) => {
 			const setupProps = { ...defaultProps, ...props };
 			return shallow( <LayoutSelectorResults { ...setupProps } /> );
@@ -182,6 +184,64 @@ describe( 'layout-selector-results', () => {
 			expect( wrapper.text() ).toContain( 'No layouts are available for this category.' );
 		} );
 
+	} );
+
+	describe( 'sanitizeBlocks()', () => {
+		beforeAll( () => {
+			helpers.registerGalleryBlocks();
+		} );
+
+		it( 'sanitize blocks without breaking them', () => {
+			const blocks = [
+				createBlock( 'coblocks/gallery-stacked' ),
+				createBlock( 'coblocks/gallery-masonry' ),
+				{
+					"clientId": "ff9f9721-eb6d-4817-ab60-cfceee6c28a8",
+					"name": "core/gallery",
+					"isValid": true,
+					"attributes": {
+					  "images": [
+						{
+						  "url": "https://wpnux.godaddy.com/v2/api/image?aspect=3%3A4&index=2&lang=en_US&seed=wpnux_layout_home-1&size=large&category=fashion",
+						  "link": "https://wpnux.godaddy.com/v2/api/image?aspect=3%3A4&index=2&lang=en_US&seed=wpnux_layout_home-1&size=large&category=fashion",
+						  "alt": "Image Description",
+						  "id": "2",
+						  "caption": ""
+						},
+						{
+						  "url": "https://wpnux.godaddy.com/v2/api/image?aspect=3%3A4&index=3&lang=en_US&seed=wpnux_layout_home-1&size=large&category=fashion",
+						  "link": "https://wpnux.godaddy.com/v2/api/image?aspect=3%3A4&index=3&lang=en_US&seed=wpnux_layout_home-1&size=large&category=fashion",
+						  "alt": "Image Description",
+						  "id": "3",
+						  "caption": ""
+						}
+					  ],
+					  "ids": [
+						{},
+						{}
+					  ],
+					  "caption": "",
+					  "imageCrop": true,
+					  "linkTo": "none",
+					  "sizeSlug": "large",
+					  "align": "wide",
+					  "animation": "slideInBottom",
+					  "noBottomMargin": false,
+					  "noTopMargin": false,
+					  "lightbox": false,
+					  "filter": "none"
+					},
+					"innerBlocks": []
+				  }
+			];
+			const sanitized = sanitizeBlocks( blocks );
+			const selializedBlocks = serialize( sanitized );
+			const parsedBlocks = parse( selializedBlocks );
+
+			expect(
+				parsedBlocks.filter( ( block ) => ! block.isValid ).map( helpers.filterBlockObjectResult )
+			).toEqual( [] );
+		} );
 	} );
 
 } );


### PR DESCRIPTION
### Description
Remove animations from Layouts Selector

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
