### PR TITLE
Close FontSizes bug that exists with WP 5.6.1 but fixed with 5.6.2

### DIFF
--- a/src/blocks/highlight/test/highlight.cypress.js
+++ b/src/blocks/highlight/test/highlight.cypress.js
@@ -39,9 +39,7 @@ describe( 'Block: Highlight', function() {
 	/**
 	 * Test the accordion block content font settings
 	 */
-	// Disable reason: https://github.com/godaddy-wordpress/coblocks/issues/1832.
-	// eslint-disable-next-line jest/no-disabled-tests
-	it.skip( 'Test highlight block font size setting.', function() {
+	it( 'Test highlight block font size setting.', function() {
 		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
 			.type( 'highlighted text' );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1832 
This PR Re-enables a skipped test around the use of FontSizes control.


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
E2E

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
