### PR TITLE
Fix E2E tests for Media Filter component

### DIFF
--- a/.dev/bin/setup-test-specs.sh
+++ b/.dev/bin/setup-test-specs.sh
@@ -42,6 +42,26 @@ do
 			SPECS=( "${SPECS[@]}" "${testSpec}" )
 		fi
   fi
+
+    # Changed file matches /src/components/*
+  if [[ $FILE == *"src/components/"* ]]; then
+    testSpec=$(echo $FILE | cut -d'/' -f3)
+		foundwords=$(echo ${SPECS[@]} | grep -o "${testSpec}" | wc -w)
+		# Catch cases where no cypress spec file exists. 
+		if [[ $(ls -l src/components/${testSpec}/**/*.cypress.js | wc -l) -eq 0 ]]; then
+			continue
+		fi
+		# The test spec does not yet exist in the SPECS array
+		if [[ "${foundwords}" -eq 0 ]]; then
+			# Spec file string is empty, do not start string with a comma
+			if [[ ${#SPECSTRING} -eq 0 ]]; then
+				SPECSTRING="src/components/${testSpec}/**/*.cypress.js"
+			else
+				SPECSTRING="${SPECSTRING},src/components/${testSpec}/**/*.cypress.js"
+			fi
+			SPECS=( "${SPECS[@]}" "${testSpec}" )
+		fi
+  fi
 done
 
 # No spec files to run

--- a/src/components/media-filter-control/test/media-filter-control.cypress.js
+++ b/src/components/media-filter-control/test/media-filter-control.cypress.js
@@ -86,6 +86,8 @@ describe( 'Test CoBlocks Media Filter Control component', function() {
 
 			childIteration++;
 		}
+
+		cy.reload();
 	} );
 
 	/**
@@ -161,5 +163,7 @@ describe( 'Test CoBlocks Media Filter Control component', function() {
 
 			childIteration++;
 		}
+
+		cy.reload();
 	} );
 } );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
JavaScript loops within these component tests are causing unexpected conditions in the CI environment.
Change here will properly reset between tests so that this test can pass.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in E2E pipeline. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
