### PR TITLE
Add a from: header to the form emails.

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -971,7 +971,7 @@ class CoBlocks_Form {
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
 		$reply_to  = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
-		$from_name = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : $reply_to;
+		$from_name = ( isset( $_POST[ $name_field_id ]['value'] ) && ! empty( $_POST[ $name_field_id ]['value'] ) ) ? esc_html( $_POST[ $name_field_id ]['value'] ) . " <{$reply_to}>" : /* translators: 1. Reply to email address; eg: email@example.com */ sprintf( __( 'Form Submission <%s>', 'coblocks' ), $reply_to );
 
 		/**
 		 * Filter the form email headers.

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -971,7 +971,7 @@ class CoBlocks_Form {
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
 		$reply_to  = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
-		$from_name = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : esc_html( $reply_to );
+		$from_name = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : $reply_to;
 
 		/**
 		 * Filter the form email headers.

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -970,8 +970,8 @@ class CoBlocks_Form {
 		 */
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
-		$from_name = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : esc_html( get_bloginfo( 'name' ) );
 		$reply_to  = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
+		$from_name = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : esc_html( $reply_to );
 
 		/**
 		 * Filter the form email headers.

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -970,7 +970,8 @@ class CoBlocks_Form {
 		 */
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
-		$reply_to = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
+		$from_name = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : esc_html( get_bloginfo( 'name' ) );
+		$reply_to  = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
 
 		/**
 		 * Filter the form email headers.
@@ -982,6 +983,7 @@ class CoBlocks_Form {
 		$email_headers = (array) apply_filters(
 			'coblocks_form_email_headers',
 			array(
+				"From: {$from_name}",
 				"Reply-To: {$reply_to}",
 			),
 			$_POST,


### PR DESCRIPTION
### Description
Add a `From:` header to the form emails. This value is set to the name field, and if one is not set then it falls back to the site title.

### Types of changes
New feature (non-breaking change which adds functionality).

### How has this been tested?
Manually tested locally running MailHog. I was having some issues locally, so I will need to double check this is working as intended on a live site.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
