### PR TITLE
Fix services block image height in TwentyTwentyOne

### DIFF
--- a/.dev/tests/phpunit/includes/test-coblocks-body-classes.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-body-classes.php
@@ -66,6 +66,7 @@ class CoBlocks_Body_Classes_Tests extends WP_UnitTestCase {
 	public function test_themes() {
 
 		$expected = [
+			'twentytwentyone',
 			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',
@@ -87,6 +88,7 @@ class CoBlocks_Body_Classes_Tests extends WP_UnitTestCase {
 	public function test_filtered_themes() {
 
 		$expected = [
+			'twentytwentyone',
 			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',

--- a/includes/class-coblocks-body-classes.php
+++ b/includes/class-coblocks-body-classes.php
@@ -44,6 +44,7 @@ class CoBlocks_Body_Classes {
 	 */
 	public function themes() {
 		$themes = array(
+			'twentytwentyone',
 			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',

--- a/src/blocks/services/styles/editor.scss
+++ b/src/blocks/services/styles/editor.scss
@@ -45,3 +45,8 @@
 .components-toggle-control--services-action-button {
 	margin-top: 30;
 }
+
+// TwentyTwentyOne compatibility
+.is-twentytwentyone .wp-block-coblocks-service img {
+	height: 100%;
+}


### PR DESCRIPTION
Closes #1813 

### Description
When TwentyTwentyOne theme is active the services block image height overflows outside of the container. This PR adds a `is-twentytwentyone` admin body class and then tweaks then sets the height of the services block image back to `100%`.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/110011935-f554c980-7ced-11eb-8706-09e8c8ec8ada.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested with and without TwentyTwentyOne active.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
