### PR TITLE
Set opacity to 1 on .coblocks-animate when in AMP

### DIFF
--- a/includes/class-coblocks-body-classes.php
+++ b/includes/class-coblocks-body-classes.php
@@ -83,6 +83,10 @@ class CoBlocks_Body_Classes {
 			$classes[] = 'is-' . $this->theme_slug();
 		}
 
+		if ( apply_filters( 'coblocks_is_amp', ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() && ! in_array( 'amp', $classes, true ) ) ) ) {
+			$classes[] = 'amp';
+		}
+
 		return $classes;
 	}
 

--- a/src/extensions/animation/styles/style.scss
+++ b/src/extensions/animation/styles/style.scss
@@ -156,3 +156,8 @@
 		}
 	}
 }
+
+// AMP support
+body.amp .coblocks-animate {
+	opacity: 1;
+}


### PR DESCRIPTION
### Description
Originally reported on WordPress.org, [here](https://wordpress.org/support/topic/coblocks-animations-not-working-with-amp/). This PR adds a `amp` class when the front of site is loaded via AMP, and then sets `opacity: 1;` on all `.coblocks-animate` elements. This was the simplest solution with the least amount of code.

It is worth noting that some of the galleries are not laid out properly due to AMP not loading any JS. Here is a masonry gallery, as an example.

![image](https://user-images.githubusercontent.com/5321364/110045888-6362b600-7d19-11eb-8c25-945fa34fb0ef.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually, locally, with the official AMP plugin. After installing, you can add `?amp` to the URL and it will force load via amp.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
