### PR TITLE
Fix for the fact that sometimes too much accordion items were added

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,3 +46,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @WunderBart       |                        |
 | @sirreal          | @jonsurrell            |
 | @kishanjasani     | @kishanjasani          |
+| @olafleur         |                        |

--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -113,7 +113,7 @@ class AccordionEdit extends Component {
 								<Button
 									label={ __( 'Add accordion item', 'coblocks' ) }
 									className="block-editor-button-block-appender"
-									onMouseUp={ handleEvent }
+									onMouseDown={ handleEvent }
 								>
 									<Icon icon={ plus } />
 								</Button>

--- a/src/blocks/accordion/test/accordion.cypress.js
+++ b/src/blocks/accordion/test/accordion.cypress.js
@@ -48,8 +48,7 @@ describe( 'Block: Accordion', () => {
 	it( 'can add multiple accordion item blocks', () => {
 		cy.get( '[data-type="coblocks/accordion"]' ).click( 'top', { force: true } );
 
-		cy.get( '.coblocks-block-appender button' ).trigger( 'mouseup' );
-		// Using trigger here instead of click to more accurately represent behavior of event bubbling from user interaction within the editor.
+		cy.get( '.coblocks-block-appender button' ).click();
 
 		cy.get( '[data-type="coblocks/accordion"]' ).find( '[data-type="coblocks/accordion-item"]' ).should( 'have.length', 2 );
 


### PR DESCRIPTION
### Description
This is a proposed fix for #1768 

### Types of changes
Bug fix

### How has this been tested?
The automated test was only triggering the onMouseUp event. When you change it to a full click event in the test, it reproduce the error in the issue.
I have changed the onMouseUp event in the component to on MouseDown and it fixes the test and the behavior, from what I see.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
