### PR TITLE
Fix Logos & Badges block sizing behavior

### DIFF
--- a/src/blocks/logos/save.js
+++ b/src/blocks/logos/save.js
@@ -4,9 +4,9 @@
 import { chunk } from 'lodash';
 
 export default function save( { attributes, className } ) {
-	const { images, align } = attributes;
+	const { align } = attributes;
 
-	const hasImages = !! images.length;
+	const hasImages = !! attributes.images.length;
 
 	if ( ! hasImages ) {
 		return null;
@@ -26,27 +26,31 @@ export default function save( { attributes, className } ) {
 			break;
 	}
 
-	const imageChunks = chunk( images, count );
+	const imageChunks = chunk( attributes.images, count );
 
 	return (
 		<div className={ className }>
-			{ Object.keys( imageChunks ).map( ( keyOuter ) => (
-				<div className="wp-block-coblocks-logos__row" key={ 'wrapper-' + keyOuter }>
-					{ imageChunks[ keyOuter ].map( ( img, index ) => {
-						return (
-							<div style={ { width: img.width || ( 100 / images.length ) + '%' } } key={ 'logo-' + keyOuter }>
-								<img
-									key={ 'img-' + index }
-									src={ img.url }
-									alt={ img.alt }
-									data-id={ img.id }
-									data-width={ img.width || ( 100 / images.length ) + '%' }
-								/>
-							</div>
-						);
-					} ) }
-				</div>
-			) ) }
+			{ Object.keys( imageChunks ).map( ( keyOuter ) => {
+				const images = imageChunks[ keyOuter ];
+
+				return (
+					<div className="wp-block-coblocks-logos__row" key={ 'wrapper-' + keyOuter }>
+						{ images.map( ( img, index ) => {
+							return (
+								<div style={ { width: img.width || ( 100 / images.length ) + '%' } } key={ 'logo-' + keyOuter }>
+									<img
+										key={ 'img-' + index }
+										src={ img.url }
+										alt={ img.alt }
+										data-id={ img.id }
+										data-width={ img.width || ( 100 / images.length ) + '%' }
+									/>
+								</div>
+							);
+						} ) }
+					</div>
+				);
+			} ) }
 		</div>
 	);
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
When the Logos & Badges block is used and the image width is not configured by the user, the existing block logic will automatically determine the widths for the images. When the save function fires, there was an improper logic that did not properly determine the widths of images based on row count. Fixes here allow for proper render of Logos & Badges after saving and editor reload.

This change does **not** require a deprecated save function. The issue was around where attributes had been improperly parsed upon _initial_ save for unconfigured images. This condition cannot be met again after the initial save, thus no block validation errors will occur.

Closes #1811 

### Screenshots
<!-- if applicable -->
![logosBadgesSizingFixed](https://user-images.githubusercontent.com/30462574/111212666-18546880-858d-11eb-89d3-74707076c39d.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor save function change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
