### PR TITLE
Improve Food & Drink block test reliability

### DIFF
--- a/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
+++ b/src/blocks/food-and-drinks/test/food-and-drinks.cypress.js
@@ -62,7 +62,7 @@ describe( 'Block: Food and Drinks', function() {
 			cy.get( '[data-type="coblocks/food-item"]' ).first().find( '.block-editor-media-placeholder' ).should( 'not.exist' );
 		} );
 
-		cy.get( '[data-type="coblocks/food-and-drinks"]' ).first().click();
+		helpers.selectBlock( 'food & drink' );
 
 		helpers.openSettingsPanel( /food & drinks settings/i );
 		cy.get( '.components-toggle-control' ).find( '.components-base-control__field' ).contains( /images/i ).click();
@@ -81,7 +81,7 @@ describe( 'Block: Food and Drinks', function() {
 			cy.get( '[data-type="coblocks/food-item"]' ).first().find( '.wp-block-coblocks-food-item__price' ).should( 'exist' );
 		} );
 
-		cy.get( '[data-type="coblocks/food-and-drinks"]' ).first().click();
+		helpers.selectBlock( 'food & drink' );
 
 		helpers.openSettingsPanel( /food & drinks settings/i );
 		cy.get( '.components-toggle-control' ).find( '.components-base-control__field' ).contains( /prices/i ).click();
@@ -100,7 +100,7 @@ describe( 'Block: Food and Drinks', function() {
 	it( 'Test the food-and-drinks block custom classes.', function() {
 		helpers.addBlockToPost( 'coblocks/food-and-drinks', true );
 
-		cy.get( '[data-type="coblocks/food-and-drinks"]' ).first().click();
+		helpers.selectBlock( 'food & drink' );
 
 		helpers.openSettingsPanel( /food & drinks settings/i );
 		cy.get( '.components-toggle-control' ).find( '.components-base-control__field' ).contains( /prices/i ).click();
@@ -121,7 +121,7 @@ describe( 'Block: Food and Drinks', function() {
 		helpers.addCustomBlockClass( 'my-custom-class', 'food-and-drinks' );
 
 		// Click "Add Menu Section" and verify two blocks exist on the page.
-		cy.get( '[data-type="coblocks/food-and-drinks"]' ).click();
+		helpers.selectBlock( 'food & drink' );
 		cy.get( '[data-type="coblocks/food-and-drinks"]' ).find( '.block-editor-button-block-appender' ).click();
 		cy.get( '.wp-block-coblocks-food-and-drinks' ).should( 'have.length', 2 );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Fix Food & Drink block test reliability by using helpers to select the block.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor test changes. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
E2E 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
