### PR TITLE
Bug fix for text color in Hero block

### DIFF
--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -173,6 +173,77 @@ const deprecated = [
 			);
 		},
 	},
+	{
+		attributes,
+		save: ( deprecatedProps ) => {
+			const {
+				coblocks,
+				layout,
+				fullscreen,
+				maxWidth,
+				backgroundImg,
+				backgroundType,
+				paddingSize,
+				backgroundColor,
+				customBackgroundColor,
+				customTextColor,
+				textColor,
+				contentAlign,
+				focalPoint,
+				hasParallax,
+				height,
+			} = deprecatedProps.attributes;
+
+			const textClass = getColorClassName( 'color', textColor );
+			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+
+			let classes = classnames( {
+				'has-text-color': textColor || customTextColor,
+				[ textClass ]: textClass,
+			} );
+
+			if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+				classes = classnames( classnames, `coblocks-hero-${ coblocks.id }` );
+			}
+
+			const styles = {
+				color: textClass ? undefined : customTextColor,
+			};
+
+			const innerClasses = classnames(
+				'wp-block-coblocks-hero__inner',
+				...BackgroundClasses( deprecatedProps.attributes ), {
+					[ `hero-${ layout }-align` ]: layout,
+					'has-text-color': textColor && textColor.color,
+					'has-padding': paddingSize && paddingSize !== 'no',
+					[ `has-${ paddingSize }-padding` ]: paddingSize && paddingSize !== 'advanced',
+					[ backgroundClass ]: backgroundClass,
+					[ `has-${ contentAlign }-content` ]: contentAlign,
+					'is-fullscreen': fullscreen,
+				} );
+
+			const innerStyles = {
+				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+				backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
+				color: textColor ? textColor.color : undefined,
+				backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
+				minHeight: fullscreen ? undefined : height,
+			};
+
+			return (
+				<div className={ classes } style={ styles } >
+					<div className={ innerClasses } style={ innerStyles }>
+						{ BackgroundVideo( deprecatedProps.attributes ) }
+						<div className="wp-block-coblocks-hero__content-wrapper">
+							<div className="wp-block-coblocks-hero__content" style={ { maxWidth: maxWidth ? maxWidth + 'px' : undefined } }>
+								<InnerBlocks.Content />
+							</div>
+						</div>
+					</div>
+				</div>
+			);
+		},
+	},
 ];
 
 export default deprecated;

--- a/src/blocks/hero/save.js
+++ b/src/blocks/hero/save.js
@@ -42,7 +42,7 @@ const save = ( { attributes } ) => {
 	} );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classnames, `coblocks-hero-${ coblocks.id }` );
+		classes = classnames( classes, `coblocks-hero-${ coblocks.id }` );
 	}
 
 	const styles = {

--- a/src/blocks/hero/test/hero.cypress.js
+++ b/src/blocks/hero/test/hero.cypress.js
@@ -36,10 +36,7 @@ describe( 'Test CoBlocks Hero Block', function() {
 	 * Test that we can add a hero block to the content, adjust colors
 	 * and are able to successfully save the block without errors.
 	 */
-	// Skip reason: "A bug exists with the Hero block and setting text color."
-	// Skip issue: https://github.com/godaddy-wordpress/coblocks/issues/1762
-	// eslint-disable-next-line jest/no-disabled-tests
-	it.skip( 'Test hero block saves with color values set.', function() {
+	it( 'Test hero block saves with color values set.', function() {
 		const { textColor, backgroundColor, textColorRGB, backgroundColorRGB } = heroData;
 		helpers.addBlockToPost( 'coblocks/hero', true );
 


### PR DESCRIPTION
### Description
~This test had been skipped because of issue #1762 . However, now it seems to pass and I am not able to reproduce the problem in Go and TwentyTwenty.~

This is a suggested fix for #1762. I have now found the problem. See later in the thread.

### Types of changes
~Add a test~
Bug fix

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
