### PR TITLE
Issue 1580

### DIFF
--- a/src/blocks/hero/controls.js
+++ b/src/blocks/hero/controls.js
@@ -40,7 +40,7 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-					{ BackgroundControls( this.props ) }
+					<BackgroundControls { ...this.props } />
 				</BlockControls>
 			</Fragment>
 		);

--- a/src/blocks/hero/test/hero.cypress.js
+++ b/src/blocks/hero/test/hero.cypress.js
@@ -92,4 +92,34 @@ describe( 'Test CoBlocks Hero Block', function() {
 
 		helpers.editPage();
 	} );
+
+	it( 'should close media upload flow on media selection', function() {
+		helpers.addBlockToPost( 'coblocks/hero', true );
+
+		cy.get( '.wp-block-coblocks-hero__inner' ).click();
+
+		cy.get( '.block-editor-block-toolbar .components-toolbar__control[aria-label="Add background image"]' ).click();
+
+		const fileName = helpers.upload.spec.fileName;
+
+		// Disable reason: cy.fixture should not return a value.
+		// eslint-disable-next-line jest/valid-expect-in-promise
+		cy.fixture( helpers.upload.spec.pathToFixtures + fileName, 'base64' ).then( ( fileContent ) => {
+			cy.get( '.media-frame input[type="file"]' )
+				.upload(
+					{ fileContent, fileName, mimeType: 'image/png' },
+					{ force: true },
+				);
+		} );
+
+		cy.get( '.media-toolbar-primary > .button' ).click();
+
+		cy.get( '.media-replace-flow button' ).click();
+
+		cy.get( '.components-popover__content' ).should( 'be.visible' );
+
+		cy.get( '.block-editor-media-replace-flow__media-upload-menu .components-menu-item__button' ).contains( 'Open Media Library' ).click();
+
+		cy.get( '.components-popover__content' ).should( 'not.be.visible' );
+	} );
 } );

--- a/src/components/background/controls.js
+++ b/src/components/background/controls.js
@@ -9,9 +9,8 @@ import { ALLOWED_BG_MEDIA_TYPES } from './';
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { Toolbar, ToolbarButton, Popover, MenuItem } from '@wordpress/components';
-import { edit, trash } from '@wordpress/icons';
+import { MediaUpload, MediaUploadCheck, MediaReplaceFlow, BlockControls } from '@wordpress/block-editor';
+import { Toolbar, ToolbarButton } from '@wordpress/components';
 
 /**
  * Background image block toolbar controls.
@@ -27,63 +26,30 @@ function BackgroundControls( props ) {
 
 	const {
 		backgroundImg,
-		openPopover,
 	} = attributes;
 
 	return (
 		<Fragment>
 			<MediaUploadCheck>
 				<Toolbar className={ backgroundImg ? 'components-dropdown-menu' : '' }>
-					{ openPopover && (
-						<Popover
-							position="bottom center"
-							className="components-coblocks__background-popover"
-						>
-							<MediaUpload
-								onSelect={ ( media ) => {
-									setAttributes( { backgroundImg: media.url, backgroundType: media.type, openPopover: ! openPopover } );
-								} }
-								allowedTypes={ ALLOWED_BG_MEDIA_TYPES }
-								value={ backgroundImg }
-								render={ ( { open } ) => (
-									<MenuItem
-										className="components-dropdown-menu__menu-item"
-										icon={ edit }
-										role="menuitem"
-										onClick={ open } >
-										{ __( 'Edit background', 'coblocks' ) }
-									</MenuItem>
-								) }
-							/>
-							<MenuItem
-								className="components-dropdown-menu__menu-item"
-								icon={ trash }
-								role="menuitem"
-								onClick={ () => {
-									setAttributes( {
-										backgroundImg: '',
-										backgroundOverlay: 0,
-										backgroundRepeat: 'no-repeat',
-										backgroundPosition: '',
-										backgroundSize: 'cover',
-										hasParallax: false,
-										openPopover: ! openPopover,
-									} );
-								} } >
-								{ __( 'Remove background', 'coblocks' ) }
-							</MenuItem>
-						</Popover>
-					) }
 					{ backgroundImg
 						? (
-							<ToolbarButton
-								className="components-dropdown-menu__toggle"
-								icon={ icons.background }
-								aria-haspopup="true"
-								label={ __( 'Edit background image', 'coblocks' ) }
-								tooltip={ __( 'Edit background image', 'coblocks' ) }
-								onClick={ () => setAttributes( { openPopover: ! openPopover } ) }
-							/>
+							<BlockControls group="other">
+								<MediaReplaceFlow
+									name={ icons.background }
+									mediaURL={ backgroundImg }
+									allowedTypes={ ALLOWED_BG_MEDIA_TYPES }
+									accept="image/*"
+									onSelect={ ( media ) => {
+										if ( media ) {
+											setAttributes( { backgroundImg: media.url, backgroundType: ( media.media_type || media.type ) } );
+										}
+									} }
+									onError={ () => {
+										setAttributes( { backgroundImg: undefined, backgroundType: undefined } );
+									} }
+								/>
+							</BlockControls>
 						) : (
 							<MediaUpload
 								onSelect={ ( media ) => {
@@ -100,7 +66,6 @@ function BackgroundControls( props ) {
 									/>
 								) }
 							/>
-
 						) }
 				</Toolbar>
 			</MediaUploadCheck>


### PR DESCRIPTION
### Description
Hide the media flow popup menu when upload modal is visible
fixes - https://github.com/godaddy-wordpress/coblocks/issues/1580

### Screenshots
<!-- if applicable -->

### Types of changes
Bug fix

### How has this been tested?
wrote cypress test

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
