### PR TITLE
Issue 1862

### DIFF
--- a/src/extensions/padding-controls/padding-wrapper.js
+++ b/src/extensions/padding-controls/padding-wrapper.js
@@ -20,7 +20,6 @@ function PaddingWrapper( { children, padding, paddingCustom, className } ) {
 	const attributes = {
 		className: classnames(
 			className,
-			children.props.className,
 			{ [ `has-${ padding }-padding` ]: padding }
 		),
 	};

--- a/src/extensions/padding-controls/test/padding-wrapper.spec.js
+++ b/src/extensions/padding-controls/test/padding-wrapper.spec.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+ import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies.
+ */
+ import PaddingWrapper from '../padding-wrapper';
+
+ describe( 'padding-wrapper', () => {
+     it( 'returns style attributes for block', () => {
+         const baseProps = {
+            className: 'test test test mock test',
+         };         
+
+         const wrapper = shallow(
+            <PaddingWrapper {...baseProps} >
+                <div  />
+            </PaddingWrapper>
+         );
+
+         expect(wrapper.hasClass(baseProps.className)).toEqual(true);
+     } );
+ } );


### PR DESCRIPTION
### Description
Remove addition of child className to parent in PaddingWrapper
fixes #1862 

### Screenshots

### Types of changes
Bug fix

### How has this been tested?
wrote unit test

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
