### PR TITLE
Use color for focus state instead of box-shadow and outline

### DIFF
--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -172,8 +172,9 @@
 				&:hover,
 				&:focus,
 				&.is-selected {
-					box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color, #007cba);
-					outline: 1px solid transparent;
+					box-shadow: none;
+					color: var(--wp-admin-theme-color, #007cba);
+					outline: none;
 				}
 			}
 		}


### PR DESCRIPTION
### Description
Layout selector selected state should be using default color for focus/active state instead of box-shadow

### Screenshots
![image](https://user-images.githubusercontent.com/2584073/112355786-60b60980-8ca4-11eb-8f23-347c8c8ccada.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Visually tested

### Checklist:
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
