### PR TITLE
Fix Gallery Duplicate Upload

### DIFF
--- a/src/components/block-gallery/gallery-placeholder.js
+++ b/src/components/block-gallery/gallery-placeholder.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { every, forEach, map, find } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,103 +12,79 @@ import * as helper from './../../utils/helper';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
 import { MediaPlaceholder } from '@wordpress/block-editor';
 import { Icon } from '@wordpress/components';
-import { mediaUpload } from '@wordpress/editor';
-import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 
-class GalleryPlaceholder extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onSelectImages = this.onSelectImages.bind( this );
-		this.onUploadError = this.onUploadError.bind( this );
-	}
-
-	selectCaption( newImage, images ) {
+const GalleryPlaceholder = ( props ) => {
+	const selectCaption = ( newImage, images ) => {
 		const currentImage = find( images, ( obj ) => parseInt( obj?.id ) === newImage?.id );
 		return Array.isArray( currentImage?.caption ) ? currentImage?.caption?.[ 0 ] : currentImage?.caption || newImage?.caption || '';
-	}
+	};
 
-	selectImgLink( newImage, images ) {
+	const selectImgLink = ( newImage, images ) => {
 		const currentImage = find( images, ( obj ) => parseInt( obj?.id ) === newImage?.id );
 		return currentImage?.imgLink || newImage?.imgLink || '';
-	}
+	};
 
-	onSelectImages( newImages ) {
-		const { images } = this.props.attributes;
-		this.props.setAttributes( {
+	const onSelectImages = ( newImages ) => {
+		const { images } = props.attributes;
+
+		props.setAttributes( {
 			images: newImages.map( ( image ) => ( {
 				...helper.pickRelevantMediaFiles( image ),
-				caption: this.selectCaption( image, images ),
-				imgLink: this.selectImgLink( image, images ),
+				caption: selectCaption( image, images ),
+				imgLink: selectImgLink( image, images ),
 			} ) ),
 		} );
-	}
+	};
 
-	onUploadError( message ) {
-		const { noticeOperations } = this.props;
+	const onUploadError = ( message ) => {
+		const { noticeOperations } = props;
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
-	}
+	};
 
-	componentDidMount() {
-		const { attributes } = this.props;
-		const { images } = attributes;
-		if ( every( images, ( { url } ) => isBlobURL( url ) ) ) {
-			const filesList = map( images, ( { url } ) => getBlobByURL( url ) );
-			forEach( images, ( { url } ) => revokeBlobURL( url ) );
-			mediaUpload( {
-				filesList,
-				onFileChange: this.onSelectImages,
-				allowedTypes: [ 'image' ],
-			} );
-		}
-	}
+	const {
+		attributes,
+		gutter,
+		isSelected,
+	} = props;
 
-	render() {
-		const {
-			attributes,
-			gutter,
-			isSelected,
-		} = this.props;
+	const {
+		images,
+	} = attributes;
 
-		const {
-			images,
-		} = attributes;
+	const hasImages = !! images.length;
 
-		const hasImages = !! images.length;
+	const styles = {
+		marginTop: gutter + 'px',
+	};
 
-		const styles = {
-			marginTop: gutter + 'px',
-		};
-
-		return (
-			<div style={ styles }>
-				<MediaPlaceholder
-					addToGallery={ hasImages }
-					isAppender={ hasImages }
-					className="coblocks-gallery--figure"
-					disableMediaButtons={ hasImages && ! isSelected }
-					icon={ ! hasImages && <Icon icon={ this.props.icon } /> }
-					labels={ {
-						title: ! hasImages && sprintf(
-							/* translators: %s: Type of gallery */
-							__( '%s Gallery', 'coblocks' ),
-							this.props.label
-						),
-						instructions: ! hasImages && __( 'Drag images, upload new ones or select files from your library.', 'coblocks' ),
-					} }
-					onSelect={ this.onSelectImages }
-					accept="image/*"
-					allowedTypes={ helper.ALLOWED_GALLERY_MEDIA_TYPES }
-					multiple
-					value={ hasImages ? images : undefined }
-					onError={ this.onUploadError }
-				/>
-			</div>
-		);
-	}
-}
+	return (
+		<div style={ styles }>
+			<MediaPlaceholder
+				addToGallery={ hasImages }
+				isAppender={ hasImages }
+				className="coblocks-gallery--figure"
+				disableMediaButtons={ hasImages && ! isSelected }
+				icon={ ! hasImages && <Icon icon={ props.icon } /> }
+				labels={ {
+					title: ! hasImages && sprintf(
+						/* translators: %s: Type of gallery */
+						__( '%s Gallery', 'coblocks' ),
+						props.label
+					),
+					instructions: ! hasImages && __( 'Drag images, upload new ones or select files from your library.', 'coblocks' ),
+				} }
+				onSelect={ onSelectImages }
+				accept="image/*"
+				allowedTypes={ helper.ALLOWED_GALLERY_MEDIA_TYPES }
+				multiple
+				value={ hasImages ? images : undefined }
+				onError={ onUploadError }
+			/>
+		</div>
+	);
+};
 
 export default GalleryPlaceholder;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1585 
It turns out this bug affects Stacked, Offset, Masonry, and Carousel Blocks. Fix here removes a superfluous upload action which leads to duplicate images. 

### Screenshots
<!-- if applicable -->
![masonryDuplicateUploads](https://user-images.githubusercontent.com/30462574/113060683-d79c4800-9165-11eb-97c3-8fb8bdf90ca5.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Refactor to stateless component and removal of a superfluous effect.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested using all upload paths.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
