### PR TITLE
Fix layouts jumping around within the Layout Selector in Safari 

### DIFF
--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -53,6 +53,7 @@
 		height: 96px;
 		margin: 0;
 		padding: 0;
+		z-index: 15;
 
 		@include break-medium() {
 			background-color: $white;
@@ -307,7 +308,6 @@
 	&__layout {
 		background-color: var(--go--color--background, $white);
 		border-radius: $radius-block-ui;
-		display: flex;
 		height: auto;
 		margin-bottom: 2rem;
 		min-height: 150px;
@@ -324,6 +324,12 @@
 		.block-editor-block-preview__container {
 			background-color: var(--go--color--background, $white);
 			margin: 2em;
+			position: relative;
+			z-index: 10;
+
+			&:hover {
+				cursor: pointer;
+			}
 		}
 
 		.components-spinner {
@@ -331,6 +337,17 @@
 			margin: 0;
 			position: absolute;
 			transform: translateX(-50%);
+			z-index: 1;
+		}
+
+		// Safari-only hack. Welcome back to 2005.
+		// Hide spinner because there is a bug with how Safari is rendering column-count
+		@media not all and (min-resolution:.001dpcm) {
+			@supports (-webkit-appearance:none) {
+				.components-spinner {
+					display: none;
+				}
+			}
 		}
 
 		&::after {

--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -342,8 +342,8 @@
 
 		// Safari-only hack. Welcome back to 2005.
 		// Hide spinner because there is a bug with how Safari is rendering column-count
-		@media not all and (min-resolution:.001dpcm) {
-			@supports (-webkit-appearance:none) {
+		@media not all and ( min-resolution: 0.001dpcm ) {
+			@supports ( -webkit-appearance: none ) {
 				.components-spinner {
 					display: none;
 				}


### PR DESCRIPTION
### Description
Fix layouts jumping around within the Layout Selector in Safari. I had to remove the spinner in Safari, there's a known bug with `column-count` that we can't fix.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
