### PR TITLE
Fix posts block margin in Safari and IE

### DIFF
--- a/src/blocks/posts/styles/style.scss
+++ b/src/blocks/posts/styles/style.scss
@@ -20,7 +20,6 @@
 
 .wp-block-coblocks-posts__item {
 	align-items: stretch;
-	display: flex;
 	flex: 1 1 auto;
 	margin-bottom: var(--coblocks-spacing--3, map-get($spacing, 3));
 	margin-left: 0;

--- a/src/blocks/posts/styles/style.scss
+++ b/src/blocks/posts/styles/style.scss
@@ -36,6 +36,10 @@
 	}
 }
 
+.wp-block-coblocks-posts.is-style-horizontal .wp-block-coblocks-posts__item {
+	display: flex;
+}
+
 .wp-block-coblocks-posts__image {
 	display: table;
 	flex: 0 0 auto;

--- a/src/extensions/animation/styles/editor.scss
+++ b/src/extensions/animation/styles/editor.scss
@@ -96,6 +96,10 @@
 		max-width: none !important;
 	}
 
+	.components-resizable-box__container {
+		width: 100% !important;
+	}
+
 	.components-tip {
 		margin-top: 12px;
 	}

--- a/src/extensions/animation/styles/editor.scss
+++ b/src/extensions/animation/styles/editor.scss
@@ -96,10 +96,6 @@
 		max-width: none !important;
 	}
 
-	.components-resizable-box__container {
-		width: 100% !important;
-	}
-
 	.components-tip {
 		margin-top: 12px;
 	}


### PR DESCRIPTION
### Description
In Safari and IE, the posts block content height was incorrect. This PR fixes that issue.

### Screenshots

#### Chrome
![image](https://user-images.githubusercontent.com/5321364/113347206-d48a8e80-9302-11eb-86bb-f3116dd42020.png)

#### Safari
![image](https://user-images.githubusercontent.com/5321364/113347243-de13f680-9302-11eb-9760-554524295695.png)

#### Safari Editor
![image](https://user-images.githubusercontent.com/5321364/113347399-1e737480-9303-11eb-8b33-823a21f78122.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested this in Safari. Confirmed no regressions were introduced in other browsers.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
