### PR TITLE
Fix width of images in image filter previews

### DIFF
--- a/src/extensions/animation/styles/editor.scss
+++ b/src/extensions/animation/styles/editor.scss
@@ -96,6 +96,10 @@
 		max-width: none !important;
 	}
 
+	.components-resizable-box__container {
+		width: 100% !important;
+	}
+
 	.components-tip {
 		margin-top: 12px;
 	}


### PR DESCRIPTION
### Description
Fix the width of images in the image filter preview window. The preview is still about 3px taller than the image, so there is a small "tail" of background color beneath the image. The height of the parent container, holding the image, is auto generated, so I'm not sure the best way to set that.

### Screenshots

##### Master
<img src="https://user-images.githubusercontent.com/5321364/113734797-a1ad1580-96c9-11eb-891f-c7781ad7652c.png" width="450" />

##### Fix
<img src="https://user-images.githubusercontent.com/5321364/113357147-7f09ae00-9311-11eb-9f5f-0bd7d043e153.png" width="450" />

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
