### PR TITLE
Fix image replace flow for core gallery block

### DIFF
--- a/src/components/block-gallery/styles/editor/_gallery-item.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item.scss
@@ -50,6 +50,12 @@
 }
 
 // Hide selected state from core/gallery block.
-[data-type="core/gallery"].block-editor-block-list__block::after {
-	box-shadow: none !important;
+[data-type="core/gallery"].block-editor-block-list__block {
+	::after {
+		box-shadow: none !important;
+	}
+
+	figure.is-selected::before {
+		pointer-events: none;
+	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
An existing PR on Gutenberg has been merged: https://github.com/WordPress/gutenberg/pull/29860
This PR mirrors the fix and acts as a temporary fix when running 5.7.0 without the Gutenberg plugin.

### Screenshots
<!-- if applicable -->
![galleryReplace](https://user-images.githubusercontent.com/30462574/113580199-333d5a00-95da-11eb-9fe4-26a383496a64.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor SCSS change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in Go, TwnetyTwenty, and TwentyTwentyOne.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
