### PR TITLE
Fix gallery gutter values not set

### DIFF
--- a/src/blocks/gallery-carousel/inspector.js
+++ b/src/blocks/gallery-carousel/inspector.js
@@ -89,13 +89,11 @@ class Inspector extends Component {
 							/>
 							{ gridSize !== null && ( align === 'wide' || align === 'full' ) &&
 								<ResponsiveTabsControl { ...this.props }
-									label={ __( 'Gutter', 'coblocks' ) }
 									max={ 20 }
 								/>
 							}
 							{ gridSize !== 'xlrg' && ! align &&
 								<ResponsiveTabsControl { ...this.props }
-									label={ __( 'Gutter', 'coblocks' ) }
 									max={ 20 }
 								/>
 							}

--- a/src/blocks/gallery-stacked/inspector.js
+++ b/src/blocks/gallery-stacked/inspector.js
@@ -96,7 +96,6 @@ class Inspector extends Component {
 
 					{ images.length > 1 &&
 						<ResponsiveTabsControl { ...this.props }
-							label={ __( 'Gutter', 'coblocks' ) }
 						/>
 					}
 

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -64,7 +64,7 @@ class ResponsiveTabsControl extends Component {
 											__( 'Mobile %s', 'coblocks' ),
 											label
 										) }
-										value={ attributes.valueMobile }
+										value={ attributes.valueMobile ?? attributes.gutterMobile }
 										onChange={ ( valueMobile ) => onChangeMobile( valueMobile ) }
 										min={ min }
 										max={ max }

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -75,7 +75,7 @@ class ResponsiveTabsControl extends Component {
 							return (
 								<RangeControl
 									label={ label }
-									value={ attributes.gutter }
+									value={ attributes.value ?? attributes.gutter }
 									onChange={ ( value ) => onChange( value ) }
 									min={ min }
 									max={ max }

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -75,7 +75,7 @@ class ResponsiveTabsControl extends Component {
 							return (
 								<RangeControl
 									label={ label }
-									value={ attributes.value }
+									value={ attributes.gutter }
 									onChange={ ( value ) => onChange( value ) }
 									min={ min }
 									max={ max }


### PR DESCRIPTION
### Description
The Masonry, Carousel and Stacked gallery blocks gutter value wasn't set in the `RangeControl` component inside of `ResponsiveTabsControl`, so the value wasn't displaying on initial loads and page reloads.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/114622777-6936aa00-9c7c-11eb-9870-c177213cd8c0.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Manually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
