### PR TITLE
Fix stacked gallery preview margin

### DIFF
--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -3,6 +3,7 @@
 @import "editor/columns-gutter";
 @import "editor/columns-responsive";
 @import "editor/is-transient";
+@import "editor/preview";
 @import "../components/**/editor.scss";
 @import "../extensions/**/editor.scss";
 @import "../blocks/**/editor.scss";

--- a/src/styles/editor/preview.scss
+++ b/src/styles/editor/preview.scss
@@ -1,0 +1,10 @@
+.block-editor-inserter__preview-container {
+
+	div[data-type="coblocks/gallery-stacked"] {
+		margin-bottom: 0;
+
+		.wp-block {
+			margin-bottom: inherit !important;
+		}
+	}
+}


### PR DESCRIPTION
### Description
The stacked gallery bottom margin was incorrect in the block preview window. This PR resolves the excessive bottom margin.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/114783880-5e494b80-9d48-11eb-95b6-a8f57174eda2.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
