### PR TITLE
Force typing form inputs in E2E environment

### DIFF
--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -344,13 +344,13 @@ describe( 'Test CoBlocks Form Block', function() {
 			.should( 'exist' );
 
 		cy.get( 'input[name="field-name[value]"]' )
-			.type( 'Name' );
+			.type( 'Name', { force: true } );
 
 		cy.get( 'input[name="field-email[value]"]' )
-			.type( 'email@example.com' );
+			.type( 'email@example.com', { force: true } );
 
 		cy.get( 'textarea[name="field-message[value]"]' )
-			.type( 'My message for you.' );
+			.type( 'My message for you.', { force: true } );
 
 		cy.get( '.coblocks-form__submit button' )
 			.click();
@@ -425,13 +425,13 @@ describe( 'Test CoBlocks Form Block', function() {
 			.should( 'exist' );
 
 		cy.get( 'input[name="field-name[value]"]' )
-			.type( 'Name' );
+			.type( 'Name', { force: true } );
 
 		cy.get( 'input[name="field-email[value]"]' )
-			.type( 'email@example.com' );
+			.type( 'email@example.com', { force: true } );
 
 		cy.get( 'textarea[name="field-message[value]"]' )
-			.type( 'My message for you.' );
+			.type( 'My message for you.', { force: true } );
 
 		cy.get( '.coblocks-form__submit button' )
 			.click();
@@ -475,7 +475,7 @@ describe( 'Test CoBlocks Form Block', function() {
 				cy.get( $inputElem ).invoke( 'val' ).then( ( ) => {
 					cy.get( $inputElem )
 						.clear()
-						.type( 'Thank you for submitting this form!' );
+						.type( 'Thank you for submitting this form!', { force: true } );
 				} );
 			} );
 
@@ -486,13 +486,13 @@ describe( 'Test CoBlocks Form Block', function() {
 			.should( 'exist' );
 
 		cy.get( 'input[name="field-name[value]"]' )
-			.type( 'Name' );
+			.type( 'Name', { force: true } );
 
 		cy.get( 'input[name="field-email[value]"]' )
-			.type( 'email@example.com' );
+			.type( 'email@example.com', { force: true } );
 
 		cy.get( 'textarea[name="field-message[value]"]' )
-			.type( 'My message for you.' );
+			.type( 'My message for you.', { force: true } );
 
 		cy.get( '.coblocks-form__submit button' )
 			.click();
@@ -527,15 +527,15 @@ describe( 'Test CoBlocks Form Block', function() {
 		helpers.addFormChild( 'text' );
 
 		helpers.addFormChild( 'radio' );
-		cy.get( '.coblocks-option__input' ).type( 'text' );
+		cy.get( '.coblocks-option__input' ).type( 'text', { force: true } );
 
 		helpers.addFormChild( 'phone' );
 
 		helpers.addFormChild( 'checkbox' );
-		cy.get( '.coblocks-option__input' ).type( 'text' );
+		cy.get( '.coblocks-option__input' ).type( 'text', { force: true } );
 
 		helpers.addFormChild( 'select' );
-		cy.get( '.coblocks-option__input' ).type( 'text' );
+		cy.get( '.coblocks-option__input' ).type( 'text', { force: true } );
 
 		helpers.addFormChild( 'website' );
 


### PR DESCRIPTION
### Description
Sometimes in the E2E environment, the screen viewport does not center on the inputs thus we can receive errors. This PR forces the type event even if the input is out of view.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Test changes. Forced Inputs.

### How has this been tested?
Tested in the E2E pipeline.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
