### PR TITLE
Show a snackbar notice when a layout is added to a page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ commands:
             if [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "develop" ] || [ "$CIRCLE_BRANCH" == *"run-all-tests"* ]; then
               ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >>
             else
-              ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >> --spec "$(cat /tmp/specstring)"
+              ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >> --spec "$(cat /tmp/specstring | xargs | sed -e 's/ /,/g')"
             fi
 
   start_wpcli_server:

--- a/src/extensions/layout-selector/index.js
+++ b/src/extensions/layout-selector/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component, isValidElement } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
@@ -210,11 +210,12 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 					updateSelectedCategory,
 				} = dispatch( 'coblocks/template-selector' );
 				const { editPost } = dispatch( 'core/editor' );
-				const { createWarningNotice } = dispatch( 'core/notices' );
+				const { createWarningNotice, createSuccessNotice } = dispatch( 'core/notices' );
 
 				return {
 					closeTemplateSelector,
 					createWarningNotice,
+					createSuccessNotice,
 					editPost,
 					updateSelectedCategory,
 
@@ -226,6 +227,14 @@ if ( typeof coblocksLayoutSelector !== 'undefined' && coblocksLayoutSelector.pos
 						} );
 						closeTemplateSelector();
 						incrementLayoutUsage( layout );
+						createSuccessNotice(
+							sprintf(
+								// translators: %s is the post title.
+								__( '"%s" layout has been added to the page.', 'nextgen' ),
+								layout.label
+							),
+							{ type: 'snackbar' }
+						);
 					},
 
 					useEmptyTemplateLayout: () => {


### PR DESCRIPTION
### Description
Display a snackbar notice when a layout is selected from the layout picker.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/116308787-f0ece000-a775-11eb-913f-c8d5e912e7b2.png)

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
