### PR TITLE
Fix invalid value passed to layered collage

### DIFF
--- a/src/blocks/gallery-collage/edit.js
+++ b/src/blocks/gallery-collage/edit.js
@@ -38,7 +38,7 @@ class GalleryCollageEdit extends Component {
 		if ( this.props.className !== prevProps.className ) {
 			if ( this.props.className.includes( 'is-style-layered' ) ) {
 				this.setState( { lastGutterValue: this.props.attributes.gutter } );
-				this.props.setAttributes( { gutter: 0 } );
+				this.props.setAttributes( { gutter: '0' } );
 			} else {
 				this.props.setAttributes( {
 					shadow: 'none',


### PR DESCRIPTION
### Description
Fix invalid value being set for gutter prop in the layered collage.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested, converting existing collage to layered collage.

### Checklist:
- [x] My code is tested
- [ ] I've added proper labels to this pull request <!-- if applicable -->
