### PR TITLE
Remove the shadow from collage gallery placeholders

### DIFF
--- a/src/blocks/gallery-collage/edit.js
+++ b/src/blocks/gallery-collage/edit.js
@@ -213,7 +213,7 @@ class GalleryCollageEdit extends Component {
 		const hasImage = !! image;
 
 		const classNames = classnames( 'wp-block-coblocks-gallery-collage__figure', {
-			[ `shadow-${ this.props.attributes.shadow }` ]: this.props.attributes.shadow,
+			[ `shadow-${ this.props.attributes.shadow }` ]: hasImage && this.props.attributes.shadow,
 		} );
 
 		return (


### PR DESCRIPTION
### Description
Remove the shadow class from the collage image placeholders.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
