### PR TITLE
Try using 'small' default gutter value for Offset block example

### DIFF
--- a/src/blocks/gallery-offset/deprecated.js
+++ b/src/blocks/gallery-offset/deprecated.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { GalleryAttributes, GalleryClasses } from '../../components/block-gallery/shared';
 import metadata from './block.json';
+import GutterWrapper from '../../components/gutter-control/gutter-wrapper';
 
 /**
  * WordPress dependencies
@@ -218,6 +219,89 @@ const deprecated = [
 							);
 						} ) }
 					</ul>
+				</div>
+			);
+		},
+	},
+	{
+		attributes: {
+			...GalleryAttributes,
+			...metadata.attributes,
+			gutter: {
+				type: 'string',
+				default: 'medium',
+			},
+		},
+		save: ( { attributes, className } ) => {
+			const {
+				animation,
+				captions,
+				gridSize,
+				images,
+				lightbox,
+				linkTo,
+				rel,
+				target,
+			} = attributes;
+
+			const wrapperClasses = classnames(
+				className, {
+					'has-lightbox': lightbox,
+				}
+			);
+
+			const innerClasses = classnames(
+				...GalleryClasses( attributes ), {
+					[ `has-${ gridSize }-images` ]: gridSize,
+				},
+			);
+
+			const itemClasses = classnames(
+				'coblocks-gallery--item', {
+					[ `coblocks-animate` ]: animation,
+				}
+			);
+
+			return (
+				<div className={ wrapperClasses }>
+					<GutterWrapper { ...attributes }>
+						<ul className={ innerClasses } >
+							{ images.map( ( image ) => {
+								let href;
+
+								switch ( linkTo ) {
+									case 'media':
+										href = image.url;
+										break;
+									case 'attachment':
+										href = image.link;
+										break;
+								}
+
+								// If an image has a custom link, override the linkTo selection.
+								if ( image.imgLink ) {
+									href = image.imgLink;
+								}
+
+								const imgClasses = classnames(
+									image.id ? [ `wp-image-${ image.id }` ] : null, {}
+								);
+
+								const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-imglink={ image.imgLink } data-link={ image.link } className={ imgClasses } />;
+
+								return (
+									<li key={ image.id || image.url } className={ itemClasses } data-coblocks-animation={ animation }>
+										<figure className="wp-block-coblocks-gallery-offset__figure">
+											{ href ? <a href={ href } target={ target } rel={ rel }>{ img }</a> : img }
+											{ captions && image.caption && image.caption.length > 0 && (
+												<RichText.Content tagName="figcaption" className="coblocks-gallery--caption" value={ image.caption } />
+											) }
+										</figure>
+									</li>
+								);
+							} ) }
+						</ul>
+					</GutterWrapper>
 				</div>
 			);
 		},

--- a/src/blocks/gallery-offset/index.js
+++ b/src/blocks/gallery-offset/index.js
@@ -47,12 +47,12 @@ const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		gutter: {
-			default: 'medium',
+			default: 'small',
 		},
 	},
 	example: {
 		attributes: {
-			gutter: 'medium',
+			gutter: 'small',
 			images: [
 				{ index: 0, url: 'https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg' },
 				{ index: 1, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },

--- a/src/components/gutter-control/gutter-control.js
+++ b/src/components/gutter-control/gutter-control.js
@@ -77,7 +77,7 @@ export default class GutterControl extends Component {
 					<RangeControl
 						step={ 0.1 }
 						initialValue={ 0 }
-						value={ parseFloat( gutterCustom ) }
+						value={ parseFloat( gutterCustom ) || 0 }
 						onChange={ ( newGutter ) => setAttributes( { gutterCustom: newGutter.toString() } ) }
 						min={ 0 }
 						max={ this.maxValue }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Try reducing the spacing between the example images on the Offset Gallery block.

This PR also changes the new default gutter for the Offset Gallery block to be 'small' instead of 'medium'. This change requires deprecation.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/117882483-3f62aa00-b25f-11eb-810d-91a1063366b1.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript. Changes require new block deprecation.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
