### PR TITLE
Allow inner blocks (e.g. lists) in alert

### DIFF
--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -11,12 +11,32 @@ import Inspector from './inspector';
 import applyWithColors from './colors';
 
 /**
+ * Allowed blocks and template constant is passed to InnerBlocks precisely as specified here.
+ * The contents of the array should never change.
+ * The array should contain the name of each block that is allowed.
+ *
+ * @constant
+ * @type {string[]}
+ */
+ const ALLOWED_BLOCKS = [
+  "core/heading",
+  "core/paragraph",
+  "core/spacer",
+  "core/button",
+  "core/buttons",
+  "core/list",
+  "core/image",
+  "coblocks/social",
+  "coblocks/buttons",
+];
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { RichText } from '@wordpress/block-editor';
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
 
 /**
  * Block edit function
@@ -99,14 +119,22 @@ class Edit extends Component {
 							keepPlaceholderOnFocus
 						/>
 					) }
-					<RichText
-						/* translators: placeholder text for input box */
-						placeholder={ __( 'Write text…', 'coblocks' ) }
-						value={ value }
-						className="wp-block-coblocks-alert__text"
-						onChange={ ( newValue ) => setAttributes( { value: newValue } ) }
-						keepPlaceholderOnFocus
-					/>
+          {!RichText.isEmpty(value) && (
+            <RichText
+              /* translators: placeholder text for input box */
+              placeholder={__("Write text…", "coblocks")}
+              value={value}
+              className="wp-block-coblocks-alert__text"
+              onChange={(newValue) => setAttributes({ value: newValue })}
+              keepPlaceholderOnFocus
+            />
+          )}
+          <InnerBlocks
+            template={TEMPLATE}
+            allowedBlocks={ALLOWED_BLOCKS}
+            templateLock={false}
+            templateInsertUpdatesSelection={false}
+          />
 				</div>
 			</Fragment>
 		);

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -30,6 +30,17 @@ import applyWithColors from './colors';
   "coblocks/buttons",
 ];
 
+const TEMPLATE = [
+  // [
+  //   "core/list",
+  //   {
+  //     /* translators: content placeholder */
+  //     placeholder: __("Add list", "coblocks"),
+  //     level: 2,
+  //   },
+  // ],
+];
+
 /**
  * WordPress dependencies
  */

--- a/src/blocks/alert/save.js
+++ b/src/blocks/alert/save.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText, getColorClassName } from '@wordpress/block-editor';
+import { RichText, getColorClassName, InnerBlocks } from '@wordpress/block-editor';
 
 const save = ( { attributes } ) => {
 	const {
@@ -54,6 +54,7 @@ const save = ( { attributes } ) => {
 				value={ value }
 			/>
 			}
+      <InnerBlocks.Content />
 		</div>
 	);
 };


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR adds the possiblity to add "child-blocks" (inner blocks) to the alert box. The main intent was to add the possibility for lists, but others are possible too. 

See also: https://wordpress.org/support/topic/add-lists-in-alert-block/#post-14476981

### Screenshots
<!-- if applicable -->
![Screenshot 2021-05-24 at 19 13 00](https://user-images.githubusercontent.com/8596965/119383826-1d880f00-bcc4-11eb-9c36-74959ef7713c.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
New feature. 
The only "breaking" change that could be discussed is the reduction of the importance of .wp-block-coblocks-alert__text, as it can be added as a simple paragraph which will not have this class. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Compiled the plugin & installed in my WordPress installation (5.7.2). Visual confirmation that lists and other blocks could be added and successfully persisted.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
