### PR TITLE
Fix excess padding on Accordion block

### DIFF
--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -10,7 +10,8 @@
 		margin-bottom: 0;
 	}
 
-	&__title {
+	&__title,
+	&__title.has-background {
 		background: hsla(240, 5%, 57%, 0.1);
 		border-radius: 4px;
 		padding: 10px 15px;


### PR DESCRIPTION
### Description
Styles for the accordion block were being overridden when background colors were set, fixed in style.scss. In reference to this issue: https://github.com/godaddy-wordpress/coblocks/issues/1902


### Types of changes
Minor - scss update to increase scope

### How has this been tested?
Locally, in editor

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
