### PR TITLE
Bring the farthest back image to the front when it's selected in the layered gallery block

### DIFF
--- a/src/blocks/gallery-collage/edit.js
+++ b/src/blocks/gallery-collage/edit.js
@@ -269,6 +269,7 @@ const GalleryCollageEdit = ( props ) => {
 					`item-${ imageIndex + 1 }`,
 					{
 						[ `coblocks-animate ${ animation }` ]: animation,
+						'is-selected': imageIndex === parseInt( selectedImage ),
 					}
 				) }
 			>

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -142,6 +142,10 @@
 			width: calc(198 / 890 * 100%);
 			z-index: 2;
 
+			&.is-selected {
+				z-index: 4;
+			}
+
 			figure,
 			.block-editor-media-placeholder {
 				padding-top: 100%;

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -169,6 +169,10 @@
 			width: calc(492 / 890 * 100%);
 			z-index: 1;
 
+			&.is-selected {
+				z-index: 4;
+			}
+
 			figure,
 			.block-editor-media-placeholder {
 				padding-top: calc(378 / 492 * 100%);


### PR DESCRIPTION
### Description
When `image-2` is selected in the layered gallery, the image now pops to the front so the upload/replace/x buttons are all visible to the user.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/119884987-40523780-beff-11eb-8056-d4ba30a8d5e0.png)

![image](https://user-images.githubusercontent.com/5321364/119885021-4811dc00-beff-11eb-8cd6-261cf80dab01.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
