### PR TITLE
Fix gallery block toolbar overlap

### DIFF
--- a/src/components/block-gallery/styles/editor.scss
+++ b/src/components/block-gallery/styles/editor.scss
@@ -13,6 +13,10 @@
 	}
 }
 
+.block-editor-block-contextual-toolbar {
+	display: inline-flex;
+}
+
 // Fix overflowing appender outline
 [data-type*="coblocks/gallery"] .is-appender {
 	outline-offset: -1px;


### PR DESCRIPTION
### Description
Gallery block toolbars were overlapping under the site header due to a missing class, this provides a workaround by always applying that css rule to each header. 

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/9936886/119903052-2112d480-bf16-11eb-8b99-2725a39c909b.png)
After:
![Screen Shot 2021-05-27 at 6 03 59 PM](https://user-images.githubusercontent.com/9936886/119902970-f6c11700-bf15-11eb-9736-a867d32bdca5.png)

### Types of changes
CSS rule update

### How has this been tested?
Locally, in-editor

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
