### PR TITLE
Issue 1914 - add caret icons to accordion items within editor

### DIFF
--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -91,7 +91,7 @@ class AccordionItemEdit extends Component {
 							}
 						} }
 					/>
-					<Icon icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
+					<Icon style={ { color: textColor.color } } icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
 
 					{ ( isEditing === true || attributes.open ) &&
 						<div className="wp-block-coblocks-accordion-item__content" style={ { borderColor: backgroundColor.color } }>

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -18,6 +18,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { Icon } from '@wordpress/components';
 
 /**
  * Constants
@@ -26,6 +27,7 @@ const TEMPLATE = [
 	[ 'core/paragraph', { placeholder: __( 'Add content…', 'coblocks' ) } ],
 ];
 
+import '../styles/style.scss';
 /**
  * Block edit function
  */
@@ -90,6 +92,9 @@ class AccordionItemEdit extends Component {
 							}
 						} }
 					/>
+					<span className="accordion-icon-container">
+						<Icon icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
+					</span>
 
 					{ ( isEditing === true || attributes.open ) &&
 						<div className="wp-block-coblocks-accordion-item__content" style={ { borderColor: backgroundColor.color } }>

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -91,7 +91,7 @@ class AccordionItemEdit extends Component {
 							}
 						} }
 					/>
-					<Icon style={ { color: textColor.color } } icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
+					<Icon className={ classnames( { 'has-text-color': textColor.color } ) } style={ { color: textColor.color } } icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
 
 					{ ( isEditing === true || attributes.open ) &&
 						<div className="wp-block-coblocks-accordion-item__content" style={ { borderColor: backgroundColor.color } }>

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -27,7 +27,6 @@ const TEMPLATE = [
 	[ 'core/paragraph', { placeholder: __( 'Add content…', 'coblocks' ) } ],
 ];
 
-// import '../styles/style.scss';
 /**
  * Block edit function
  */
@@ -92,9 +91,7 @@ class AccordionItemEdit extends Component {
 							}
 						} }
 					/>
-					<span className="accordion-icon-container">
-						<Icon icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
-					</span>
+					<Icon icon={ isEditing === true || attributes.open ? 'arrow-down' : 'arrow-right' } />
 
 					{ ( isEditing === true || attributes.open ) &&
 						<div className="wp-block-coblocks-accordion-item__content" style={ { borderColor: backgroundColor.color } }>

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -27,7 +27,7 @@ const TEMPLATE = [
 	[ 'core/paragraph', { placeholder: __( 'Add content…', 'coblocks' ) } ],
 ];
 
-import '../styles/style.scss';
+// import '../styles/style.scss';
 /**
  * Block edit function
  */

--- a/src/blocks/accordion/accordion-item/styles/editor.scss
+++ b/src/blocks/accordion/accordion-item/styles/editor.scss
@@ -1,10 +1,9 @@
 .wp-block-coblocks-accordion-item {
-
 	.dashicons {
 		align-items: center;
 		display: flex;
 		flex-direction: column;
-		font-size: 40px;
+		font-size: 30px;
 		justify-content: center;
 		left: 7px;
 		position: absolute;
@@ -17,6 +16,18 @@
 
 	// Remove hover and focus, as the title is a text field.
 	&__title {
+		color: inherit;
+		padding-top: 6px;
+
+		&.has-background {
+			padding: 10px 15px;
+		}
+
+		&::before {
+			content: "";
+			display: inline-block;
+			width: 20px;
+		}
 
 		&::after {
 			display: none;

--- a/src/blocks/accordion/accordion-item/styles/editor.scss
+++ b/src/blocks/accordion/accordion-item/styles/editor.scss
@@ -76,3 +76,14 @@
 [data-type="coblocks/accordion-item"]:not(.is-selected) > .block-editor-block-list__block-edit::before {
 	border: 1px dashed rgba(123, 134, 162, 0.3);
 }
+
+.dashicons {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	font-size: 40px;
+	justify-content: center;
+	left: 5px;
+	position: absolute;
+	top: 20px;
+}

--- a/src/blocks/accordion/accordion-item/styles/editor.scss
+++ b/src/blocks/accordion/accordion-item/styles/editor.scss
@@ -1,5 +1,16 @@
 .wp-block-coblocks-accordion-item {
 
+	.dashicons {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		font-size: 40px;
+		justify-content: center;
+		left: 7px;
+		position: absolute;
+		top: 15px;
+	}
+
 	p {
 		margin-top: 0;
 	}
@@ -75,15 +86,4 @@
 .block-editor-block-list__block[data-type="coblocks/accordion"].has-child-selected
 [data-type="coblocks/accordion-item"]:not(.is-selected) > .block-editor-block-list__block-edit::before {
 	border: 1px dashed rgba(123, 134, 162, 0.3);
-}
-
-.dashicons {
-	align-items: center;
-	display: flex;
-	flex-direction: column;
-	font-size: 40px;
-	justify-content: center;
-	left: 5px;
-	position: absolute;
-	top: 20px;
 }

--- a/src/blocks/accordion/styles/style.scss
+++ b/src/blocks/accordion/styles/style.scss
@@ -14,12 +14,3 @@ _:-webkit-full-screen,
 .wp-block-coblocks-accordion summary {
 	display: block;
 }
-
-.edit-post-visual-editor {
-	.wp-block-coblocks-accordion-item {
-		.wp-block-coblocks-accordion-item__title {
-			padding-left: 37px;
-			padding-top: 6px;
-		}
-	}
-}

--- a/src/blocks/accordion/styles/style.scss
+++ b/src/blocks/accordion/styles/style.scss
@@ -15,19 +15,10 @@ _:-webkit-full-screen,
 	display: block;
 }
 
-.accordion-icon-container {
-	& > .dashicons {
-		align-items: center;
-		display: flex;
-		flex-direction: column;
-		font-size: 40px;
-		justify-content: center;
-		left: 5px;
-		position: absolute;
-		top: 20px;
+.edit-post-visual-editor {
+	.wp-block-coblocks-accordion-item {
+		.wp-block-coblocks-accordion-item__title {
+			padding-left: 35px;
+		}
 	}
-}
-
-.wp-block-coblocks-accordion-item__title {
-	padding-left: 45px;
 }

--- a/src/blocks/accordion/styles/style.scss
+++ b/src/blocks/accordion/styles/style.scss
@@ -18,7 +18,8 @@ _:-webkit-full-screen,
 .edit-post-visual-editor {
 	.wp-block-coblocks-accordion-item {
 		.wp-block-coblocks-accordion-item__title {
-			padding-left: 35px;
+			padding-left: 37px;
+			padding-top: 6px;
 		}
 	}
 }

--- a/src/blocks/accordion/styles/style.scss
+++ b/src/blocks/accordion/styles/style.scss
@@ -14,3 +14,20 @@ _:-webkit-full-screen,
 .wp-block-coblocks-accordion summary {
 	display: block;
 }
+
+.accordion-icon-container {
+	& > .dashicons {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		font-size: 40px;
+		justify-content: center;
+		left: 5px;
+		position: absolute;
+		top: 20px;
+	}
+}
+
+.wp-block-coblocks-accordion-item__title {
+	padding-left: 45px;
+}


### PR DESCRIPTION
### Description
Add caret icons to display open state of accordion items
Fixes #1914 

### Screenshots
https://user-images.githubusercontent.com/18115694/121074131-6ef2cc80-c7a1-11eb-98f8-50bf11aa82ab.mov


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Adds Icon tied to open state within the AccordionItem component

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests 
https://user-images.githubusercontent.com/18115694/121074131-6ef2cc80-c7a1-11eb-98f8-50bf11aa82ab.mov

- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
