### PR TITLE
Fix image link controls for Services block

### DIFF
--- a/src/blocks/services/service/edit.js
+++ b/src/blocks/services/service/edit.js
@@ -166,7 +166,7 @@ const Edit = ( props ) => {
 		);
 	};
 
-	const onSetHref = ( ) => setAttributes( props );
+	const onSetHref = ( { href } ) => setAttributes( { href } );
 
 	const { className } = props;
 	const {


### PR DESCRIPTION
### Description
Adds the href attribute to the image within the services block
Fixes #1901 

### How has this been tested?
Visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
