### PR TITLE
Fix background color of Accordion Items taking precedence over user selection

### DIFF
--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -10,8 +10,9 @@
 		margin-bottom: 0;
 	}
 
-	&__title,
-	&__title.has-background {
+
+
+	&__title {
 		background: hsla(240, 5%, 57%, 0.1);
 		border-radius: 4px;
 		padding: 10px 15px;

--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -10,8 +10,7 @@
 		margin-bottom: 0;
 	}
 
-	&__title,
-	&__title.has-background {
+	&__title {
 		background: hsla(240, 5%, 57%, 0.1);
 		border-radius: 4px;
 		padding: 10px 15px;

--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -10,9 +10,8 @@
 		margin-bottom: 0;
 	}
 
-
-
-	&__title {
+	&__title,
+	&__title.has-background {
 		background: hsla(240, 5%, 57%, 0.1);
 		border-radius: 4px;
 		padding: 10px 15px;

--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -10,8 +10,8 @@
 		margin-bottom: 0;
 	}
 
-	&__title {
-		background: hsla(240, 5%, 57%, 0.1);
+	&__title,
+	&__title.has-background {
 		border-radius: 4px;
 		padding: 10px 15px;
 		position: relative;
@@ -25,6 +25,10 @@
 			right: 0;
 			top: 0;
 			transition: background 100ms cubic-bezier(0.694, 0, 0.335, 1);
+		}
+
+		&:not(.has-background) {
+			background: hsla(240, 5%, 57%, 0.1);
 		}
 
 		&:hover::after {


### PR DESCRIPTION
### Description
Changes the css selector for accordion-item title to no longer include `.has-background`.

Resolves #1918.

### Types of changes
CSS style change of scope. Reverts to the version in CoBlocks 2.11.1

### How has this been tested?
Locally in editor

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
