### PR TITLE
Issue 1921 - remove youtube video from readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,11 +19,6 @@ With additional blocks and true row and column building, CoBlocks gives you a tr
 
 CoBlocks is powerful but lightweight: it adds functionality to the WordPress editor without bloat. This is the plugin you've been waiting for, and it will make you rethink what WordPress is capable of.
 
-
-= See For Yourself =
-https://www.youtube.com/watch?v=SfWoVX_uJ0M
-
-
 ## Make Beautiful Web Pages With Gutenberg & CoBlocks
 CoBlocks is the last page builder you’ll ever need: you get a winning mix of additional WordPress blocks, and page builder functionality. With CoBlocks you have everything you need to make beautiful web pages with the new block editor:
 


### PR DESCRIPTION
### Description
Youtube account which owned the display video on the readme.txt was closed and the video no longer worked. This PR removes the video from the readme.txt file.
Fixes #1921 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug Fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
