### PR TITLE
Remove the isLarge button attribute from post and post carousel

### DIFF
--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -224,7 +224,7 @@ class PostCarousel extends Component {
 								onChange={ ( value ) => setAttributes( { externalRssUrl: value } ) }
 								className={ 'components-placeholder__input' }
 							/>
-							<Button isLarge type="submit" disabled={ ! externalRssUrl }>
+							<Button type="submit" disabled={ ! externalRssUrl }>
 								{ __( 'Use URL', 'coblocks' ) }
 							</Button>
 						</form>

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -331,7 +331,7 @@ class PostsEdit extends Component {
 								onChange={ ( value ) => setAttributes( { externalRssUrl: value } ) }
 								className={ 'components-placeholder__input' }
 							/>
-							<Button isLarge type="submit" disabled={ ! externalRssUrl }>
+							<Button type="submit" disabled={ ! externalRssUrl }>
 								{ __( 'Use URL', 'coblocks' ) }
 							</Button>
 						</form>


### PR DESCRIPTION
### Description
Remove the `isLarge` attribute from the post and post carousel blocks. Apparently [this was removed](https://github.com/WordPress/gutenberg/issues/16541#issuecomment-645336060) from core and was throwing a console warning in the editor.

### Screenshots
![image](https://user-images.githubusercontent.com/85256006/124648797-ad91aa80-de65-11eb-9b7c-1bee9adb5bf6.png)

### Types of changes
Non-Breaking change.

### How has this been tested?
Added a post and post carousel block to the page to make sure there were no regressions.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
