### PR TITLE
Fix button size controls on Share and Social Profiles blocks

### DIFF
--- a/src/blocks/share/edit.js
+++ b/src/blocks/share/edit.js
@@ -71,7 +71,7 @@ class edit extends Component {
 		const isCircularStyle = includes( className, 'is-style-circular' );
 
 		const classes = classnames( className, {
-			[ `has-button-size-${ size }` ]: size !== 'med',
+			[ `has-button-size-${ size }` ]: size,
 			'has-colors': hasColors,
 			'has-background': blockBackgroundColor.color || customBlockBackgroundColor,
 			[ `has-text-align-${ textAlign }` ]: textAlign,

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -219,7 +219,7 @@ function coblocks_render_share_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] ) {
+	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -219,7 +219,7 @@ function coblocks_render_share_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) ) {
+	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -219,7 +219,7 @@ function coblocks_render_share_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
+	if ( isset( $attributes['size'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/share/styles/style.scss
+++ b/src/blocks/share/styles/style.scss
@@ -204,6 +204,23 @@ $icons: (twitter, #55acee), (facebook, #3b5999), (pinterest, #e60023), (linkedin
 		}
 	}
 
+	&.has-button-size-med {
+		// Icon only style.
+		&:not(.is-style-text):not(.is-style-icon-and-text):not(.is-style-circular) .wp-block-coblocks-social__button {
+			padding: 12px 20px;
+		}
+
+		.wp-block-coblocks-social__icon {
+			height: 18px;
+			width: 18px;
+		}
+
+		.wp-block-coblocks-social__button {
+			font-size: 15px;
+			padding: 12px 14px;
+		}
+	}
+
 	&.has-button-size-lrg {
 		// Icon only style.
 		&:not(.is-style-text):not(.is-style-icon-and-text):not(.is-style-circular) .wp-block-coblocks-social__button {
@@ -216,8 +233,8 @@ $icons: (twitter, #55acee), (facebook, #3b5999), (pinterest, #e60023), (linkedin
 		}
 
 		.wp-block-coblocks-social__button {
-			font-size: 16px;
-			padding: 12px 16px;
+			font-size: 17px;
+			padding: 14px 18px;
 		}
 	}
 

--- a/src/blocks/share/test/share.cypress.js
+++ b/src/blocks/share/test/share.cypress.js
@@ -103,6 +103,11 @@ describe( 'Test CoBlocks Share Block', function() {
 			.select( 'sml' );
 
 		cy.get( '.has-button-size-sml' ).should( 'exist' );
+
+		cy.get( '.components-coblocks-inspector__social-button-size select' )
+			.select( 'med' );
+
+		cy.get( '.has-button-size-med' ).should( 'exist' );
 	} );
 
 	/**

--- a/src/blocks/share/test/share.cypress.js
+++ b/src/blocks/share/test/share.cypress.js
@@ -24,6 +24,7 @@ describe( 'Test CoBlocks Share Block', function() {
 
 	/**
 	 * Test the coblocks share block colors.
+	 * Go traditional style default color: rgb(200, 106, 25)
 	 */
 	it( 'Test the share block colors.', function() {
 		helpers.addBlockToPost( 'coblocks/social', true );
@@ -31,7 +32,7 @@ describe( 'Test CoBlocks Share Block', function() {
 		helpers.toggleSettingCheckbox( 'Social colors' );
 
 		cy.get( '.block-editor-writing-flow .wp-block-coblocks-social li:first-child .wp-block-coblocks-social__button' )
-			.should( 'have.css', 'background-color', 'rgb(40, 48, 61)' );
+			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
 
 		helpers.savePage();
 
@@ -40,7 +41,7 @@ describe( 'Test CoBlocks Share Block', function() {
 		helpers.viewPage();
 
 		cy.get( '.wp-block-coblocks-social li:first-child .wp-block-coblocks-social__button' )
-			.should( 'have.css', 'background-color', 'rgb(49, 55, 60)' );
+			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
 
 		helpers.editPage();
 	} );

--- a/src/blocks/share/test/share.cypress.js
+++ b/src/blocks/share/test/share.cypress.js
@@ -24,7 +24,6 @@ describe( 'Test CoBlocks Share Block', function() {
 
 	/**
 	 * Test the coblocks share block colors.
-	 * Go traditional style default color: rgb(200, 106, 25)
 	 */
 	it( 'Test the share block colors.', function() {
 		helpers.addBlockToPost( 'coblocks/social', true );
@@ -32,7 +31,7 @@ describe( 'Test CoBlocks Share Block', function() {
 		helpers.toggleSettingCheckbox( 'Social colors' );
 
 		cy.get( '.block-editor-writing-flow .wp-block-coblocks-social li:first-child .wp-block-coblocks-social__button' )
-			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
+			.should( 'have.css', 'background-color', 'rgb(40, 48, 61)' );
 
 		helpers.savePage();
 
@@ -41,7 +40,7 @@ describe( 'Test CoBlocks Share Block', function() {
 		helpers.viewPage();
 
 		cy.get( '.wp-block-coblocks-social li:first-child .wp-block-coblocks-social__button' )
-			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
+			.should( 'have.css', 'background-color', 'rgb(49, 55, 60)' );
 
 		helpers.editPage();
 	} );
@@ -89,10 +88,7 @@ describe( 'Test CoBlocks Share Block', function() {
 	/**
 	 * Test the coblocks share block button size.
 	 */
-	// Disable Reason: Social block size controls have not worked since the introduction of these tests.
-	// https://github.com/godaddy-wordpress/coblocks/issues/1926
-	// eslint-disable-next-line jest/no-disabled-tests
-	it.skip( 'Test the share block button size.', function() {
+	it( 'Test the share block button size.', function() {
 		helpers.addBlockToPost( 'coblocks/social', true );
 
 		helpers.toggleSettingCheckbox( 'Social colors' );
@@ -100,19 +96,12 @@ describe( 'Test CoBlocks Share Block', function() {
 		cy.get( '.components-coblocks-inspector__social-button-size select' )
 			.select( 'lrg' );
 
-		cy.get( '.wp-block-coblocks-social li:first-child .wp-block-coblocks-social__button' )
-			.should( 'have.css', 'width', '84px' );
+		cy.get( '.has-button-size-lrg' ).should( 'exist' );
 
-		helpers.savePage();
+		cy.get( '.components-coblocks-inspector__social-button-size select' )
+			.select( 'sml' );
 
-		helpers.checkForBlockErrors( 'coblocks/social' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-social li:first-child .wp-block-coblocks-social__button' )
-			.should( 'have.css', 'width', '66px' );
-
-		helpers.editPage();
+		cy.get( '.has-button-size-sml' ).should( 'exist' );
 	} );
 
 	/**

--- a/src/blocks/social-profiles/edit.js
+++ b/src/blocks/social-profiles/edit.js
@@ -89,7 +89,7 @@ class edit extends Component {
 
 		const classes = classnames( className,
 			'wp-block-coblocks-social', {
-				[ `has-button-size-${ size }` ]: size !== 'med',
+				[ `has-button-size-${ size }` ]: size,
 				'has-colors': hasColors,
 				'has-background': blockBackgroundColor.color || customBlockBackgroundColor,
 			} );

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -160,7 +160,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && ( isset( $attributes['className'] ) ) ) {
+	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -160,7 +160,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
+	if ( isset( $attributes['size'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -160,7 +160,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) ) {
+	if ( isset( $attributes['size'] ) && 'med' !== $attributes['size'] && ( isset( $attributes['className'] ) ) ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/social-profiles/styles/editor.scss
+++ b/src/blocks/social-profiles/styles/editor.scss
@@ -21,6 +21,23 @@
 			outline-offset: -2px;
 		}
 	}
+
+	&.has-button-size-med {
+		// Icon only style.
+		&:not(.is-style-text):not(.is-style-icon-and-text):not(.is-style-circular) .wp-block-coblocks-social__button {
+			padding: 12px 20px;
+		}
+
+		.wp-block-coblocks-social__icon {
+			height: 18px;
+			width: 18px;
+		}
+
+		.wp-block-coblocks-social__button {
+			font-size: 15px;
+			padding: 12px 14px;
+		}
+	}
 }
 
 .block-library-button__inline-link--coblocks {

--- a/src/blocks/social-profiles/test/social-profiles.cypress.js
+++ b/src/blocks/social-profiles/test/social-profiles.cypress.js
@@ -230,7 +230,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 
 	/**
 	 * Test the coblocks social profiles colors.
-	 * Go traditional style default color: rgb(200, 106, 25)
+	 * Go traditional style default color: rgb(49, 55, 60)
 	 */
 	it( 'Test the social profiles colors.', function() {
 		helpers.addBlockToPost( 'coblocks/social-profiles', true );
@@ -249,7 +249,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		helpers.toggleSettingCheckbox( 'Social colors' );
 
 		cy.get( '.block-editor-writing-flow button[aria-label="Add Facebook profile"]' )
-			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
+			.should( 'have.css', 'background-color', 'rgb(40, 48, 61)' );
 
 		helpers.savePage();
 
@@ -258,7 +258,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		helpers.viewPage();
 
 		cy.get( '.wp-block-coblocks-social-profiles ul li:first-child a' )
-			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
+			.should( 'have.css', 'background-color', 'rgb(49, 55, 60)' );
 
 		helpers.editPage();
 	} );
@@ -317,10 +317,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 	/**
 	 * Test the coblocks social profiles button size.
 	 */
-	// Disable Reason: Social block size controls have not worked since the introduction of these tests.
-	// https://github.com/godaddy-wordpress/coblocks/issues/1926
-	// eslint-disable-next-line jest/no-disabled-tests
-	it.skip( 'Test the social profiles button size.', function() {
+	it( 'Test the social profiles button size.', function() {
 		helpers.addBlockToPost( 'coblocks/social-profiles', true );
 
 		cy.get( '.wp-block-coblocks-social-profiles button[aria-label="Add Facebook profile"]' ).first().click();
@@ -338,19 +335,12 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		cy.get( '.components-coblocks-inspector__social-button-size select' )
 			.select( 'lrg' );
 
-		cy.get( 'button[aria-label="Add Facebook profile"]' )
-			.should( 'have.css', 'width', '84px' );
+		cy.get( '.has-button-size-lrg' ).should( 'exist' );
 
-		helpers.savePage();
+		cy.get( '.components-coblocks-inspector__social-button-size select' )
+			.select( 'sml' );
 
-		helpers.checkForBlockErrors( 'coblocks/social-profiles' );
-
-		helpers.viewPage();
-
-		cy.get( '.wp-block-coblocks-social-profiles ul li:first-child a' )
-			.should( 'have.css', 'width', '66px' );
-
-		helpers.editPage();
+		cy.get( '.has-button-size-sml' ).should( 'exist' );
 	} );
 
 	/**

--- a/src/blocks/social-profiles/test/social-profiles.cypress.js
+++ b/src/blocks/social-profiles/test/social-profiles.cypress.js
@@ -230,7 +230,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 
 	/**
 	 * Test the coblocks social profiles colors.
-	 * Go traditional style default color: rgb(49, 55, 60)
+	 * Go traditional style default color: rgb(200, 106, 25)
 	 */
 	it( 'Test the social profiles colors.', function() {
 		helpers.addBlockToPost( 'coblocks/social-profiles', true );
@@ -249,7 +249,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		helpers.toggleSettingCheckbox( 'Social colors' );
 
 		cy.get( '.block-editor-writing-flow button[aria-label="Add Facebook profile"]' )
-			.should( 'have.css', 'background-color', 'rgb(40, 48, 61)' );
+			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
 
 		helpers.savePage();
 
@@ -258,7 +258,7 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 		helpers.viewPage();
 
 		cy.get( '.wp-block-coblocks-social-profiles ul li:first-child a' )
-			.should( 'have.css', 'background-color', 'rgb(49, 55, 60)' );
+			.should( 'have.css', 'background-color', 'rgb(200, 106, 25)' );
 
 		helpers.editPage();
 	} );

--- a/src/blocks/social-profiles/test/social-profiles.cypress.js
+++ b/src/blocks/social-profiles/test/social-profiles.cypress.js
@@ -341,6 +341,11 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 			.select( 'sml' );
 
 		cy.get( '.has-button-size-sml' ).should( 'exist' );
+
+		cy.get( '.components-coblocks-inspector__social-button-size select' )
+			.select( 'med' );
+
+		cy.get( '.has-button-size-med' ).should( 'exist' );
 	} );
 
 	/**


### PR DESCRIPTION
### Description
This PR applies the block size classnames that are set within the editor on the resulting front end class names.
Fixes #1926 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug Fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
