### PR TITLE
Bump trim-newlines down to 3.0.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 	},
 	"resolutions": {
 		"css-what": "^5.0.1",
-		"trim-newlines": "^4.0.1",
+		"trim-newlines": "^3.0.1",
 		"glob-parent": "^5.1.2",
 		"ws": "^7.4.6",
 		"trim": "^0.0.3",

--- a/src/blocks/accordion/styles/editor.scss
+++ b/src/blocks/accordion/styles/editor.scss
@@ -11,4 +11,8 @@
 	&[data-align="full"] .wp-block-coblocks-accordion {
 		padding: 0 12px;
 	}
+
+	.test-class { 
+		color: transparent;
+	}
 }

--- a/src/blocks/accordion/styles/editor.scss
+++ b/src/blocks/accordion/styles/editor.scss
@@ -11,8 +11,4 @@
 	&[data-align="full"] .wp-block-coblocks-accordion {
 		padding: 0 12px;
 	}
-
-	.test-class { 
-		color: transparent;
-	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,7 +7110,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
+glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -13902,10 +13902,10 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trim-newlines@^1.0.0, trim-newlines@^2.0.0, trim-newlines@^3.0.0, trim-newlines@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.0.2.tgz#d6aaaf6a0df1b4b536d183879a6b939489808c7c"
-  integrity sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==
+trim-newlines@^1.0.0, trim-newlines@^2.0.0, trim-newlines@^3.0.0, trim-newlines@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-trailing-lines@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
### Description
Changing the version of `trim-newlines` to 3.0.1 to fix the css job on CircleCI. Should be merged (if possible) before the next coblocks release.

### Types of changes
Version change, yarn && yarn build.

### How has this been tested?
Locally, circleci

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
