### PR TITLE
Update all compatibility versions for WP 5.8

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -7,7 +7,7 @@
  * Version: 2.13.0
  * Text Domain: coblocks
  * Domain Path: /languages
- * Tested up to: 5.7
+ * Tested up to: 5.8
  *
  * CoBlocks is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "CoBlocks",
 	"description": "CoBlocks is a suite of professional page building blocks for the WordPress Gutenberg block editor.",
 	"version": "2.13.0",
-	"tested_up_to": "5.7",
+	"tested_up_to": "5.8",
 	"author": "GoDaddy",
 	"license": "GPL-2.0",
 	"repository": "godaddy-wordpress/coblocks",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Author URI: https://www.godaddy.com
 Contributors: godaddy, richtabor, eherman24, jonathanbardo, jrtashjian, paranoia1906, fjarrett
 Tags: page builder, Gutenberg blocks, WordPress blocks, gutenberg, blocks
 Requires at least: 5.0
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 2.13.0
 License: GPL-2.0


### PR DESCRIPTION
### Description
Update `"tested_up_to"` in package.json from 5.7 to 5.8, then run grunt version.

### Types of changes
Version compatibility fields in class-coblocks.php, readme.txt and package.json

### How has this been tested?
Locally

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
