### PR TITLE
filter posts by removing the current post from the list

### DIFF
--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -339,7 +339,10 @@ export default compose( [
 	withSelect( ( select, props ) => {
 		const { postsToShow, order, orderBy, categories } = props.attributes;
 		const { getEntityRecords, getMedia } = select( 'core' );
-		const { isRTL } = select( 'core/editor' ).getEditorSettings();
+		const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
+
+		const { isRTL } = getEditorSettings();
+		const currentPost = getCurrentPost();
 
 		const useUpdatedQueryControls = QueryControls.toString().includes( 'selectedCategories' );
 
@@ -349,6 +352,7 @@ export default compose( [
 				order,
 				orderby: orderBy,
 				per_page: postsToShow,
+				exclude: currentPost.id,
 			}, ( value ) => ! isUndefined( value ) );
 
 			let latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );
@@ -373,6 +377,7 @@ export default compose( [
 				order,
 				orderby: orderBy,
 				per_page: postsToShow,
+				exclude: currentPost.id,
 			}, ( value ) => ! isUndefined( value ) );
 
 			const latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -478,6 +478,7 @@ export default compose( [
 	withSelect( ( select, props ) => {
 		const { postsToShow, order, orderBy, categories } = props.attributes;
 		const { getEntityRecords, getMedia } = select( 'core' );
+		const { getCurrentPost } = select( 'core/editor' );
 
 		const useUpdatedQueryControls = QueryControls.toString().includes( 'selectedCategories' );
 
@@ -541,8 +542,12 @@ export default compose( [
 				} );
 		};
 
+		const currentPost = getCurrentPost();
+		const queryResults = useUpdatedQueryControls ? updatedQuery() : deprecatedQuery();
+		const filteredResults = ( queryResults || [] ).filter( ( { id } ) => id !== currentPost.id );
+
 		return {
-			latestPosts: useUpdatedQueryControls ? updatedQuery() : deprecatedQuery(),
+			latestPosts: filteredResults,
 			useUpdatedQueryControls,
 		};
 	} ),

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -481,6 +481,7 @@ export default compose( [
 		const { getCurrentPost } = select( 'core/editor' );
 
 		const useUpdatedQueryControls = QueryControls.toString().includes( 'selectedCategories' );
+		const currentPost = getCurrentPost();
 
 		const deprecatedQuery = () => {
 			const latestPostsQuery = pickBy( {
@@ -488,6 +489,7 @@ export default compose( [
 				order,
 				orderby: orderBy,
 				per_page: postsToShow,
+				exclude: currentPost.id,
 			}, ( value ) => ! isUndefined( value ) );
 
 			let latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );
@@ -512,6 +514,7 @@ export default compose( [
 				order,
 				orderby: orderBy,
 				per_page: postsToShow,
+				exclude: currentPost.id,
 			}, ( value ) => ! isUndefined( value ) );
 
 			const latestPosts = getEntityRecords( 'postType', 'post', latestPostsQuery );
@@ -542,12 +545,8 @@ export default compose( [
 				} );
 		};
 
-		const currentPost = getCurrentPost();
-		const queryResults = useUpdatedQueryControls ? updatedQuery() : deprecatedQuery();
-		const filteredResults = ( queryResults || [] ).filter( ( { id } ) => id !== currentPost.id );
-
 		return {
-			latestPosts: filteredResults,
+			latestPosts: useUpdatedQueryControls ? updatedQuery() : deprecatedQuery(),
 			useUpdatedQueryControls,
 		};
 	} ),


### PR DESCRIPTION
### Description
This PR will filter the current post from the posts that are passed into the Posts block  . 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug Fix

### How has this been tested?
visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
