### PR TITLE
Fix Social block undefined index

### DIFF
--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -219,7 +219,7 @@ function coblocks_render_share_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
+	if ( isset( $attributes['size'] ) && ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -160,7 +160,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 		$class .= ' has-colors';
 	}
 
-	if ( isset( $attributes['size'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) {
+	if ( isset( $attributes['size'] ) && ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) === false ) ) {
 		$class .= ' has-button-size-' . $attributes['size'];
 	}
 


### PR DESCRIPTION
### Description
Assertions made on the `className` attribute result in undefined index errors. We can prevent this by first checking `isset` on the object property.