### PR TITLE
Load CoBlocks assets when wp_template_part post type contains a CoBlocks block

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -87,7 +87,7 @@ class CoBlocks_Block_Assets {
 			// in the coblocks/* namespace.
 			if ( $wp_post instanceof WP_Post ) {
 
-				$has_coblock = $this->has_coblock( $wp_post );
+				$has_coblock = $this->has_coblocks_block( $wp_post );
 
 			}
 
@@ -111,7 +111,7 @@ class CoBlocks_Block_Assets {
 
 				foreach ( $coblocks_template_part_query as $template_part ) {
 
-					$has_coblock = $this->has_coblock( $template_part );
+					$has_coblock = $this->has_coblocks_block( $template_part );
 
 				}
 			}
@@ -431,7 +431,7 @@ class CoBlocks_Block_Assets {
 	 * Clear transient when wp_template_part is saved/updated
 	 *
 	 * @access public
-	 * @since 2.14.2
+	 * @since  2.14.2
 	 */
 	public function clear_template_transients() {
 
@@ -440,13 +440,15 @@ class CoBlocks_Block_Assets {
 	}
 
 	/**
-	 * Determine if the given post content contains any
+	 * Determine if the given post content contains any CoBlocks blocks
 	 *
+	 * @access public
+	 * @since  2.14.2
 	 * @param  WP_Post $post_object Post object.
 	 *
-	 * @return boolean              True when post content contains a coblock block.
+	 * @return boolean True when post content contains a coblock block.
 	 */
-	public function has_coblock( WP_Post $post_object ) {
+	public function has_coblocks_block( WP_Post $post_object ) {
 
 		return ! empty(
 			array_filter(

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -107,7 +107,7 @@ class CoBlocks_Block_Assets {
 
 			}
 
-			if ( false === $has_coblock && ! empty( $coblocks_template_part_query ) ) {
+			if ( ! $has_coblock && ! empty( $coblocks_template_part_query ) ) {
 
 				foreach ( $coblocks_template_part_query as $template_part ) {
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -86,23 +86,9 @@ class CoBlocks_Block_Assets {
 			// This is similar to has_block() in core, but will match anything
 			// in the coblocks/* namespace.
 			if ( $wp_post instanceof WP_Post ) {
-				$has_coblock = ! empty(
-					array_filter(
-						array(
-							false !== strpos( $wp_post->post_content, '<!-- wp:coblocks/' ),
-							has_block( 'core/block', $wp_post ),
-							has_block( 'core/button', $wp_post ),
-							has_block( 'core/cover', $wp_post ),
-							has_block( 'core/heading', $wp_post ),
-							has_block( 'core/image', $wp_post ),
-							has_block( 'core/gallery', $wp_post ),
-							has_block( 'core/list', $wp_post ),
-							has_block( 'core/paragraph', $wp_post ),
-							has_block( 'core/pullquote', $wp_post ),
-							has_block( 'core/quote', $wp_post ),
-						)
-					)
-				);
+
+				$has_coblock = $this->has_coblock( $wp_post );
+
 			}
 
 			$coblocks_template_part_query = get_transient( 'coblocks_template_parts_query' );
@@ -125,23 +111,8 @@ class CoBlocks_Block_Assets {
 
 				foreach ( $coblocks_template_part_query as $template_part ) {
 
-					$has_coblock = ! empty(
-						array_filter(
-							array(
-								false !== strpos( $template_part->post_content, '<!-- wp:coblocks/' ),
-								has_block( 'core/block', $template_part ),
-								has_block( 'core/button', $template_part ),
-								has_block( 'core/cover', $template_part ),
-								has_block( 'core/heading', $template_part ),
-								has_block( 'core/image', $template_part ),
-								has_block( 'core/gallery', $template_part ),
-								has_block( 'core/list', $template_part ),
-								has_block( 'core/paragraph', $template_part ),
-								has_block( 'core/pullquote', $template_part ),
-								has_block( 'core/quote', $template_part ),
-							)
-						)
-					);
+					$has_coblock = $this->has_coblock( $template_part );
+
 				}
 			}
 		}
@@ -465,6 +436,35 @@ class CoBlocks_Block_Assets {
 	public function clear_template_transients() {
 
 		delete_transient( 'coblocks_template_parts_query' );
+
+	}
+
+	/**
+	 * Determine if the given post content contains any
+	 *
+	 * @param  WP_Post $post_object Post object.
+	 *
+	 * @return boolean              True when post content contains a coblock block.
+	 */
+	public function has_coblock( WP_Post $post_object ) {
+
+		return ! empty(
+			array_filter(
+				array(
+					false !== strpos( $post_object->post_content, '<!-- wp:coblocks/' ),
+					has_block( 'core/block', $post_object ),
+					has_block( 'core/button', $post_object ),
+					has_block( 'core/cover', $post_object ),
+					has_block( 'core/heading', $post_object ),
+					has_block( 'core/image', $post_object ),
+					has_block( 'core/gallery', $post_object ),
+					has_block( 'core/list', $post_object ),
+					has_block( 'core/paragraph', $post_object ),
+					has_block( 'core/pullquote', $post_object ),
+					has_block( 'core/quote', $post_object ),
+				)
+			)
+		);
 
 	}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -446,7 +446,7 @@ class CoBlocks_Block_Assets {
 	 * @since  2.14.2
 	 * @param  WP_Post $post_object Post object.
 	 *
-	 * @return boolean True when post content contains a coblock block.
+	 * @return boolean True when post content contains a CoBlocks block.
 	 */
 	public function has_coblocks_block( WP_Post $post_object ) {
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -107,12 +107,15 @@ class CoBlocks_Block_Assets {
 
 			}
 
-			if ( ! empty( $coblocks_template_part_query ) ) {
+			if ( false === $has_coblock && ! empty( $coblocks_template_part_query ) ) {
 
 				foreach ( $coblocks_template_part_query as $template_part ) {
 
-					$has_coblock = $this->has_coblocks_block( $template_part );
+					if ( $this->has_coblocks_block( $template_part ) ) {
 
+						$has_coblock = true;
+
+					}
 				}
 			}
 		}

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -105,7 +105,12 @@ class CoBlocks_Block_Assets {
 			}
 		}
 
-		if ( ! $has_coblock && ! $this->is_page_gutenberg() ) {
+		/**
+		 * Force load the block assets
+		 */
+		$force_load_block_assets = apply_filters( 'coblocks_force_load_block_assets', false );
+
+		if ( ! $force_load_block_assets && ! $has_coblock && ! $this->is_page_gutenberg() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description
In FSE when a block isn't contained in the post content, the assets do not load. This PR queries the `` psot type and determines if they contain any CoBlocks blocks in their content. If it does, the assets are loaded.

Related issue #1911 

### Types of changes
New functionality (non-breaking change)

### How has this been tested?
Tested against #1911 to ensure the assets load when a CoBlocks block is added to the footer of a page.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
