### PR TITLE
Convert Gist Edit component to React hooks

### DIFF
--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -22,6 +22,13 @@ import { useState, useEffect } from '@wordpress/element';
 
 const Edit = ( props ) => {
 	const [ preview, setPreview ] = useState( props.attributes.preview ? props.attributes.preview : false );
+	const [ gistCallbackId, setGistCallbackId ] = useState( '' );
+
+	useEffect( () => {
+		if ( !! gistCallbackId === false ) {
+			setGistCallbackId( Edit.__nextGist() );
+		}
+	}, [ gistCallbackId ] );
 
 	useEffect( () => {
 		if ( props.attributes.url ) {
@@ -83,7 +90,7 @@ const Edit = ( props ) => {
 			{ preview ? (
 				url && (
 					<div className={ classnames( className, meta ? null : 'no-meta' ) }>
-						<Gist url={ url } file={ file } callbackId={ Edit.__nextGist() } onError={ () => {
+						<Gist url={ url } file={ file } callbackId={ gistCallbackId } onError={ () => {
 							handleErrors();
 						} } />
 						{ ( ! RichText.isEmpty( caption ) || isSelected ) && (


### PR DESCRIPTION
### Description
Refactor the Gist Edit component from React class to React hooks. It was needed because `withState` is now deprecated, so we need to use `useState`

### How has this been tested?
The unit and Cypress tests for that component still pass.

### Checklist:
- [X] My code is tested
- [X] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included any necessary tests <!-- if applicable -->
- [X] I've added proper labels to this pull request <!-- if applicable -->
