### PR TITLE
ISBAT render a Gist with a file that has a capitalized letter in the name

### DIFF
--- a/src/blocks/gist/controls.js
+++ b/src/blocks/gist/controls.js
@@ -2,43 +2,40 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 import { Toolbar } from '@wordpress/components';
 import { edit } from '@wordpress/icons';
 
-class Controls extends Component {
-	render() {
-		const {
-			preview,
-			setState,
-		} = this.props;
+const Controls = ( props ) => {
+	const {
+		preview,
+		setPreview,
+	} = props;
 
-		const editControl = [
-			{
-				icon: edit,
-				title: preview
-					? sprintf(
-						/* translators: %s: "Gist", the name of a code sharing platform */
-						__( 'Return to %s', 'coblocks' ),
-						'Gist'
-					)
-					: sprintf(
-						/* translators: %s: "Gist", the name of a code sharing platform */
-						__( 'Edit %s URL', 'coblocks' ),
-						'Gist'
-					),
-				onClick: () => setState( { preview: ! preview } ),
-				isActive: ! preview,
-			},
-		];
+	const editControl = [
+		{
+			icon: edit,
+			title: preview
+				? sprintf(
+					/* translators: %s: "Gist", the name of a code sharing platform */
+					__( 'Return to %s', 'coblocks' ),
+					'Gist'
+				)
+				: sprintf(
+					/* translators: %s: "Gist", the name of a code sharing platform */
+					__( 'Edit %s URL', 'coblocks' ),
+					'Gist'
+				),
+			onClick: () => setPreview( ! preview ),
+			isActive: ! preview,
+		},
+	];
 
-		return (
-			<BlockControls>
-				<Toolbar controls={ editControl } />
-			</BlockControls>
-		);
-	}
-}
+	return (
+		<BlockControls>
+			<Toolbar controls={ editControl } />
+		</BlockControls>
+	);
+};
 
 export default Controls;

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -38,8 +38,36 @@ const Edit = ( props ) => {
 	}, [] );
 
 	useEffect( () => {
-		props.setAttributes( { file: newFile } );
+		if ( props.attributes.url ) {
+			const gistId = parseGistId( props.attributes.url );
+
+			fetch( 'https://api.github.com/gists/' + gistId )
+				.then( ( data ) => data.json() )
+				// Retrieve the list of files that are the keys of the JSON object
+				.then( ( json ) => Object.keys( json.files ) )
+				.then( ( keys ) => props.setAttributes( {
+					// Transform app.js to App.js, for example
+					file: getFileNameWithCapitalization( newFile, keys ),
+				} ) );
+		}
 	}, [ newFile ] );
+
+	const parseGistId = ( url ) => {
+		const [ gistId ] = url.split( '/' ).slice( -1 );
+
+		return gistId;
+	};
+
+	const getFileNameWithCapitalization = ( fileName, gistFiles ) => {
+		const fileFound = gistFiles.filter( ( file ) => file.toLowerCase() === fileName );
+
+		if ( fileFound.length > 0 ) {
+			return fileFound[ 0 ];
+		}
+
+		// If no file found, we will load all the gist
+		return '';
+	};
 
 	const updateURL = ( newURL ) => {
 		props.setAttributes( { url: newURL, file: '' } );

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -21,9 +21,9 @@ import { withNotices, Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 
 const Edit = ( props ) => {
-	const [ preview, setPreview ] = useState( props.attributes.preview ? props.attributes.preview : false );
+	const [ preview, setPreview ] = useState( false );
+	const [ newFile, setNewFile ] = useState( props.attributes.file ? props.attributes.file : '' );
 	const [ gistCallbackId, setGistCallbackId ] = useState( '' );
-	const [ newFile, setNewFile ] = useState( '' );
 
 	useEffect( () => {
 		if ( !! gistCallbackId === false ) {
@@ -32,7 +32,7 @@ const Edit = ( props ) => {
 	}, [ gistCallbackId ] );
 
 	useEffect( () => {
-		if ( props.attributes.url ) {
+		if ( !! props.attributes.url ) {
 			setPreview( true );
 		}
 	}, [] );
@@ -46,10 +46,9 @@ const Edit = ( props ) => {
 				// Retrieve the list of files that are the keys of the JSON object
 				.then( ( json ) => Object.keys( json.files ) )
 				.then( ( keys ) => {
-					props.setAttributes( {
-						// Transform app.js to App.js, for example
-						file: getFileNameWithCapitalization( newFile, keys ),
-					} );
+					// Transform app.js to App.js, for example
+					const normalizedFilename = getFileNameWithCapitalization( newFile, keys );
+					props.setAttributes( { file: normalizedFilename } );
 
 					setPreview( true );
 				} );
@@ -63,8 +62,10 @@ const Edit = ( props ) => {
 	};
 
 	const getFileNameWithCapitalization = ( fileName, gistFiles ) => {
-		const fileFound = gistFiles.filter( ( file ) => file.toLowerCase() === fileName );
+		const fileFound = gistFiles.filter( ( file ) => file.toLowerCase() === fileName.toLowerCase() );
 
+		// It is possible for a gist to contain two files that differentiate name only by case.
+		// We will return the first file just like Gist api behavior.
 		if ( fileFound.length > 0 ) {
 			return fileFound[ 0 ];
 		}
@@ -73,25 +74,33 @@ const Edit = ( props ) => {
 		return '';
 	};
 
-	const updateURL = ( newURL ) => {
-		props.setAttributes( { url: newURL, file: '' } );
+	const updateURL = ( newURL = '' ) => {
+		// While URL is editing enter preview state
+		setPreview( false );
 
-		if ( 'undefined' === typeof newURL || ! newURL.trim() ) {
-			setPreview( false );
+		// A forward slash suffix will result in not found error from Gist API so remove it here.
+		const normalizeURL = newURL
+			// Remove foward slash suffix at end of string.
+			.replace( /\/$/, '' )
+			// Remove forward slash suffix between `#file-` indicator.
+			.replace( /(.*)(\/)(#file-.*)/, '$1$3' );
+
+		// Handle no specified file.
+		if ( normalizeURL.match( /#file-*/ ) === null ) {
+			setNewFile( '' );
+			props.setAttributes( { url: normalizeURL } );
+
+			clearErrors();
 			return;
 		}
 
 		// Check for #file in the entered URL. If it's there, let's use it properly.
-		const file = newURL.split( '#file-' ).pop();
+		const file = normalizeURL.split( '#file-' ).pop();
 
-		if ( newURL.match( /#file-*/ ) !== null ) {
-			const newURLWithNoFile = newURL.replace( file, '' ).replace( '#file-', '' );
-
-			props.setAttributes( { url: newURLWithNoFile } );
-			setNewFile( file.replace( /-([^-]*)$/, '.' + '$1' ) );
-		} else if ( ! props.attributes.url ) {
-			setPreview( true );
-		}
+		// File specified.
+		const newURLWithNoFile = normalizeURL.replace( file, '' ).replace( '#file-', '' );
+		setNewFile( file.replace( /-([^-]*)$/, '.' + '$1' ) );
+		props.setAttributes( { url: newURLWithNoFile } );
 
 		clearErrors();
 	};
@@ -120,8 +129,21 @@ const Edit = ( props ) => {
 
 	return (
 		<>
-			{ url && url.length > 0 && isSelected && <Controls { ...props } /> }
-			{ url && url.length > 0 && isSelected && <Inspector { ...props } /> }
+			{ url && url.length > 0 && isSelected &&
+				<Controls
+					preview={ preview }
+					setPreview={ setPreview }
+				/>
+			}
+			{ url && url.length > 0 && isSelected &&
+				<Inspector
+					updateURL={ updateURL }
+					setPreview={ setPreview }
+					setNewFile={ setNewFile }
+					newFile={ newFile }
+					{ ...props }
+				/>
+			}
 			{ preview ? (
 				url && (
 					<div className={ classnames( className, meta ? null : 'no-meta' ) }>

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -45,10 +45,14 @@ const Edit = ( props ) => {
 				.then( ( data ) => data.json() )
 				// Retrieve the list of files that are the keys of the JSON object
 				.then( ( json ) => Object.keys( json.files ) )
-				.then( ( keys ) => props.setAttributes( {
-					// Transform app.js to App.js, for example
-					file: getFileNameWithCapitalization( newFile, keys ),
-				} ) );
+				.then( ( keys ) => {
+					props.setAttributes( {
+						// Transform app.js to App.js, for example
+						file: getFileNameWithCapitalization( newFile, keys ),
+					} );
+
+					setPreview( true );
+				} );
 		}
 	}, [ newFile ] );
 
@@ -77,10 +81,6 @@ const Edit = ( props ) => {
 			return;
 		}
 
-		if ( ! props.attributes.url ) {
-			setPreview( true );
-		}
-
 		// Check for #file in the entered URL. If it's there, let's use it properly.
 		const file = newURL.split( '#file-' ).pop();
 
@@ -89,6 +89,8 @@ const Edit = ( props ) => {
 
 			props.setAttributes( { url: newURLWithNoFile } );
 			setNewFile( file.replace( /-([^-]*)$/, '.' + '$1' ) );
+		} else if ( ! props.attributes.url ) {
+			setPreview( true );
 		}
 
 		clearErrors();

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -79,7 +79,7 @@ const Edit = ( props ) => {
 		setPreview( false );
 
 		// A forward slash suffix will result in not found error from Gist API so remove it here.
-		const normalizeURL = newURL
+		const normalizeURL = newURL.trim()
 			// Remove foward slash suffix at end of string.
 			.replace( /\/$/, '' )
 			// Remove forward slash suffix between `#file-` indicator.

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -23,6 +23,7 @@ import { useState, useEffect } from '@wordpress/element';
 const Edit = ( props ) => {
 	const [ preview, setPreview ] = useState( props.attributes.preview ? props.attributes.preview : false );
 	const [ gistCallbackId, setGistCallbackId ] = useState( '' );
+	const [ newFile, setNewFile ] = useState( '' );
 
 	useEffect( () => {
 		if ( !! gistCallbackId === false ) {
@@ -35,6 +36,10 @@ const Edit = ( props ) => {
 			setPreview( true );
 		}
 	}, [] );
+
+	useEffect( () => {
+		props.setAttributes( { file: newFile } );
+	}, [ newFile ] );
 
 	const updateURL = ( newURL ) => {
 		props.setAttributes( { url: newURL, file: '' } );
@@ -55,7 +60,7 @@ const Edit = ( props ) => {
 			const newURLWithNoFile = newURL.replace( file, '' ).replace( '#file-', '' );
 
 			props.setAttributes( { url: newURLWithNoFile } );
-			props.setAttributes( { file: file.replace( /-([^-]*)$/, '.' + '$1' ) } );
+			setNewFile( file.replace( /-([^-]*)$/, '.' + '$1' ) );
 		}
 
 		clearErrors();

--- a/src/blocks/gist/gist.js
+++ b/src/blocks/gist/gist.js
@@ -84,12 +84,12 @@ const Gist = ( props ) => {
 			return `&file=${ fileSplit.replace( 'file-', '' ).replace( '-', '.' ) }`;
 		}
 
-		// Else the user wants to link the whole Gist repository.
+		// Else the user wants to link the whole Gist.
 		return '';
 	};
 
 	const _transformedURL = ( callback ) => {
-		// Construct a gist url that will allow us to redner the Gist into our page.
+		// Construct a gist url that will allow us to render the Gist into our page.
 		const id = _getID();
 		if ( ! id ) {
 			return false;

--- a/src/blocks/gist/inspector.js
+++ b/src/blocks/gist/inspector.js
@@ -7,12 +7,10 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 
 const Inspector = ( props ) => {
-	const updateURL = ( newURL ) => {
-		props.setAttributes( { url: newURL } );
-	};
-
 	const updateFile = ( newFile ) => {
-		props.setAttributes( { file: newFile } );
+		// While editing Gist enter preview state.
+		props.setPreview( false );
+		props.setNewFile( newFile );
 	};
 
 	const getGistMetaHelp = ( checked ) => {
@@ -22,11 +20,12 @@ const Inspector = ( props ) => {
 	const {
 		attributes,
 		setAttributes,
+		updateURL,
+		newFile,
 	} = props;
 
 	const {
 		url,
-		file,
 		meta,
 	} = attributes;
 
@@ -41,7 +40,8 @@ const Inspector = ( props ) => {
 					/>
 					<TextControl
 						label={ __( 'Gist File', 'coblocks' ) }
-						value={ file }
+						// newFile is lowercase to match `props.attributes.file`.
+						value={ newFile.toLowerCase() }
 						onChange={ updateFile }
 					/>
 					<ToggleControl

--- a/src/blocks/gist/inspector.js
+++ b/src/blocks/gist/inspector.js
@@ -2,72 +2,58 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 
-/**
- * Inspector controls
- */
-class Inspector extends Component {
-	constructor() {
-		super( ...arguments );
-		this.updateURL = this.updateURL.bind( this );
-		this.updateFile = this.updateFile.bind( this );
-	}
+const Inspector = ( props ) => {
+	const updateURL = ( newURL ) => {
+		props.setAttributes( { url: newURL } );
+	};
 
-	updateURL( newURL ) {
-		if ( 'undefined' === typeof newURL || ! newURL.trim() ) {
-			this.props.setState( { preview: false } );
-		}
-		this.props.setAttributes( { url: newURL } );
-	}
+	const updateFile = ( newFile ) => {
+		props.setAttributes( { file: newFile } );
+	};
 
-	updateFile( newFile ) {
-		this.props.setAttributes( { file: newFile } );
-	}
-
-	getGistMetaHelp( checked ) {
+	const getGistMetaHelp = ( checked ) => {
 		return checked ? __( 'Showing gist meta data.', 'coblocks' ) : __( 'Toggle to show the gist meta data.', 'coblocks' );
-	}
+	};
 
-	render() {
-		const {
-			attributes,
-			setAttributes,
-		} = this.props;
+	const {
+		attributes,
+		setAttributes,
+	} = props;
 
-		const {
-			url,
-			file,
-			meta,
-		} = attributes;
+	const {
+		url,
+		file,
+		meta,
+	} = attributes;
 
-		return (
-			<Fragment>
-				<InspectorControls>
-					<PanelBody title={ __( 'Gist settings', 'coblocks' ) }>
-						<TextControl
-							label={ __( 'Gist URL', 'coblocks' ) }
-							value={ url }
-							onChange={ this.updateURL }
-						/>
-						<TextControl
-							label={ __( 'Gist File', 'coblocks' ) }
-							value={ file }
-							onChange={ this.updateFile }
-						/>
-						<ToggleControl
-							label={ __( 'Gist Meta', 'coblocks' ) }
-							checked={ !! meta }
-							onChange={ () => setAttributes( { meta: ! meta } ) }
-							help={ this.getGistMetaHelp }
-						/>
-					</PanelBody>
-				</InspectorControls>
-			</Fragment>
-		);
-	}
-}
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={ __( 'Gist settings', 'coblocks' ) }>
+					<TextControl
+						label={ __( 'Gist URL', 'coblocks' ) }
+						value={ url }
+						onChange={ updateURL }
+					/>
+					<TextControl
+						label={ __( 'Gist File', 'coblocks' ) }
+						value={ file }
+						onChange={ updateFile }
+					/>
+					<ToggleControl
+						label={ __( 'Gist Meta', 'coblocks' ) }
+						checked={ !! meta }
+						onChange={ () => setAttributes( { meta: ! meta } ) }
+						help={ getGistMetaHelp }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</Fragment>
+	);
+};
 
 export default Inspector;

--- a/src/blocks/gist/test/gist.cypress.js
+++ b/src/blocks/gist/test/gist.cypress.js
@@ -6,7 +6,6 @@ import * as helpers from '../../../../.dev/tests/cypress/helpers';
 describe( 'Test CoBlocks Gist Block', function() {
 	// setup gist block data.
 	const gistUrl = 'https://gist.github.com/AnthonyLedesma/33ad1a8cd86da3b6bddbdefa432cb51d';
-	const gistUrlWithFile = 'https://gist.github.com/AnthonyLedesma/33ad1a8cd86da3b6bddbdefa432cb51d#file-gistblocktest-text';
 
 	/**
 	 * Test that we can add a gist block to the content, not add any text or
@@ -95,17 +94,5 @@ describe( 'Test CoBlocks Gist Block', function() {
 		helpers.checkForBlockErrors( 'coblocks/gist' );
 
 		cy.get( '.wp-block-coblocks-gist' ).find( '.gist-file' ).should( 'have.length', 2 );
-	} );
-
-	it( 'Test gist with a file that has a capitalized letter in the name renders properly', function() {
-		helpers.addBlockToPost( 'coblocks/gist', true );
-
-		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrlWithFile ).type( '{enter}' );
-
-		helpers.savePage();
-
-		helpers.checkForBlockErrors( 'coblocks/gist' );
-
-		cy.get( '.wp-block-coblocks-gist' ).find( '.gist-file' ).should( 'have.length', 1 );
 	} );
 } );

--- a/src/blocks/gist/test/gist.cypress.js
+++ b/src/blocks/gist/test/gist.cypress.js
@@ -6,6 +6,7 @@ import * as helpers from '../../../../.dev/tests/cypress/helpers';
 describe( 'Test CoBlocks Gist Block', function() {
 	// setup gist block data.
 	const gistUrl = 'https://gist.github.com/AnthonyLedesma/33ad1a8cd86da3b6bddbdefa432cb51d';
+	const gistUrlWithFile = 'https://gist.github.com/AnthonyLedesma/33ad1a8cd86da3b6bddbdefa432cb51d#file-gistblocktest-text';
 
 	/**
 	 * Test that we can add a gist block to the content, not add any text or
@@ -94,5 +95,17 @@ describe( 'Test CoBlocks Gist Block', function() {
 		helpers.checkForBlockErrors( 'coblocks/gist' );
 
 		cy.get( '.wp-block-coblocks-gist' ).find( '.gist-file' ).should( 'have.length', 2 );
+	} );
+
+	it( 'Test gist with a file that has a capitalized letter in the name renders properly', function() {
+		helpers.addBlockToPost( 'coblocks/gist', true );
+
+		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrlWithFile ).type( '{enter}' );
+
+		helpers.savePage();
+
+		helpers.checkForBlockErrors( 'coblocks/gist' );
+
+		cy.get( '.wp-block-coblocks-gist' ).find( '.gist-file' ).should( 'have.length', 1 );
 	} );
 } );

--- a/src/blocks/gist/test/gist.cypress.js
+++ b/src/blocks/gist/test/gist.cypress.js
@@ -2,10 +2,14 @@
  * Include our constants
  */
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
-
+/*
+* The Gist block has a typical user interaction with copy and paste which is not supported by Cypress.
+* Here we dissect the test Gist URL by extracting the final character.
+* Cypress events should be chained as `.invoke( 'val', gistUrlVal ).type( gistUrlType );`
+*/
 describe( 'Test CoBlocks Gist Block', function() {
-	// setup gist block data.
-	const gistUrl = 'https://gist.github.com/AnthonyLedesma/33ad1a8cd86da3b6bddbdefa432cb51d';
+	const gistUrlVal = 'https://gist.github.com/AnthonyLedesma/7d0352e8bc50a8a009c2b930f23d110d#file-gistblocktest-tex';
+	const gistUrlType = 't';
 
 	/**
 	 * Test that we can add a gist block to the content, not add any text or
@@ -34,7 +38,7 @@ describe( 'Test CoBlocks Gist Block', function() {
 	it( 'Test gist block saves with url.', function() {
 		helpers.addBlockToPost( 'coblocks/gist', true );
 
-		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrl ).type( '{enter}' );
+		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrlVal ).type( gistUrlType );
 
 		cy.get( '.wp-block-coblocks-gist .gist' ).should( 'exist' );
 
@@ -57,7 +61,7 @@ describe( 'Test CoBlocks Gist Block', function() {
 	it( 'Test gist block saves with custom classes.', function() {
 		helpers.addBlockToPost( 'coblocks/gist', true );
 
-		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrl ).type( '{enter}' );
+		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrlVal ).type( gistUrlType );
 
 		cy.get( '.wp-block-coblocks-gist .gist' ).should( 'exist' );
 
@@ -83,11 +87,11 @@ describe( 'Test CoBlocks Gist Block', function() {
 	it( 'Test two gists in the edit page should render properly', function() {
 		helpers.addBlockToPost( 'coblocks/gist', true );
 
-		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrl ).type( '{enter}' );
+		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrlVal ).type( gistUrlType );
 
 		helpers.addBlockToPost( 'coblocks/gist' );
 
-		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrl ).type( '{enter}' );
+		cy.get( '.wp-block-coblocks-gist textarea' ).invoke( 'val', gistUrlVal ).type( gistUrlType );
 
 		helpers.savePage();
 


### PR DESCRIPTION
### Description
Fixes #1331 

When there was a Gist URL for a specific file in it 
(ex : https://gist.github.com/olafleur/260e1f1c09284e6b257348b0be706a6a#file-hello_world-html )
which had a capital letter in it, it didn't work.

Additional changes allow users to pass in URI varieties with a forward-slash suffix that previously would fail.

- https://gist.github.com/AnthonyLedesma/7d0352e8bc50a8a009c2b930f23d110d/#file-gistblocktest-text
- https://gist.github.com/AnthonyLedesma/7d0352e8bc50a8a009c2b930f23d110d/

### Types of changes
Bug fix

### How has this been tested?
The Gist tests still pass.

### Checklist:
- [X] My code is tested
- [X] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation <!-- if applicable -->
- [X] I've added proper labels to this pull request <!-- if applicable -->
