### PR TITLE
Fix Font Size controls in WordPress 5.8

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -208,6 +208,7 @@ class CoBlocks_Block_Assets {
 				'customIconConfigExists'         => file_exists( get_stylesheet_directory() . '/coblocks/icons/config.json' ),
 				'typographyControlsEnabled'      => $typography_controls_enabled,
 				'animationControlsEnabled'       => $animation_controls_enabled,
+				'isWP58'                         => version_compare( floatval( get_bloginfo( 'version' ) ), '5.8', '>=' ),
 			)
 		);
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -208,7 +208,6 @@ class CoBlocks_Block_Assets {
 				'customIconConfigExists'         => file_exists( get_stylesheet_directory() . '/coblocks/icons/config.json' ),
 				'typographyControlsEnabled'      => $typography_controls_enabled,
 				'animationControlsEnabled'       => $animation_controls_enabled,
-				'isWP58'                         => version_compare( floatval( get_bloginfo( 'version' ) ), '5.8', '>=' ),
 			)
 		);
 

--- a/src/blocks/author/inspector.js
+++ b/src/blocks/author/inspector.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { showFeature } from '../../utils/helper';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -38,14 +43,16 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Author settings', 'coblocks' ) } className="blocks-font-size">
-						<FontSizePicker
-							label={ 'test' }
-							fallbackFontSize={ fallbackFontSize }
-							value={ fontSize.size }
-							onChange={ setFontSize }
-						/>
-					</PanelBody>
+					{ showFeature() && (
+						<PanelBody title={ __( 'Author settings', 'coblocks' ) } className="blocks-font-size">
+							<FontSizePicker
+								label={ 'test' }
+								fallbackFontSize={ fallbackFontSize }
+								value={ fontSize.size }
+								onChange={ setFontSize }
+							/>
+						</PanelBody>
+					) }
 					<PanelColorSettings
 						title={ __( 'Color settings', 'coblocks' ) }
 						initialOpen={ false }

--- a/src/blocks/author/inspector.js
+++ b/src/blocks/author/inspector.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { showFeature } from '../../utils/helper';
+import CoBlocksFontSizePicker from '../../components/fontsize-picker';
 
 /**
  * WordPress dependencies
@@ -9,7 +9,7 @@ import { showFeature } from '../../utils/helper';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { InspectorControls, ContrastChecker, PanelColorSettings, withColors, FontSizePicker, withFontSizes } from '@wordpress/block-editor';
+import { InspectorControls, ContrastChecker, PanelColorSettings, withColors, withFontSizes } from '@wordpress/block-editor';
 import { PanelBody, withFallbackStyles } from '@wordpress/components';
 
 const { getComputedStyle } = window;
@@ -33,8 +33,6 @@ class Inspector extends Component {
 			setBackgroundColor,
 			setTextColor,
 			textColor,
-			setFontSize,
-			fallbackFontSize,
 			fallbackTextColor,
 			fallbackBackgroundColor,
 			fontSize,
@@ -43,16 +41,9 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					{ showFeature() && (
-						<PanelBody title={ __( 'Author settings', 'coblocks' ) } className="blocks-font-size">
-							<FontSizePicker
-								label={ 'test' }
-								fallbackFontSize={ fallbackFontSize }
-								value={ fontSize.size }
-								onChange={ setFontSize }
-							/>
-						</PanelBody>
-					) }
+					<PanelBody title={ __( 'Author settings', 'coblocks' ) } className="blocks-font-size">
+						<CoBlocksFontSizePicker { ...this.props } />
+					</PanelBody>
 					<PanelColorSettings
 						title={ __( 'Color settings', 'coblocks' ) }
 						initialOpen={ false }

--- a/src/blocks/click-to-tweet/inspector.js
+++ b/src/blocks/click-to-tweet/inspector.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import applyWithColors from './colors';
-import { showFeature } from '../../utils/helper';
+import CoBlocksFontSizePicker from '../../components/fontsize-picker';
 
 /**
  * WordPress dependencies
@@ -10,7 +10,7 @@ import { showFeature } from '../../utils/helper';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { InspectorControls, ContrastChecker, PanelColorSettings, FontSizePicker, withFontSizes } from '@wordpress/block-editor';
+import { InspectorControls, ContrastChecker, PanelColorSettings, withFontSizes } from '@wordpress/block-editor';
 import { PanelBody, withFallbackStyles } from '@wordpress/components';
 
 /**
@@ -38,11 +38,8 @@ class Inspector extends Component {
 		const {
 			buttonColor,
 			fallbackButtonColor,
-			fallbackFontSize,
 			fallbackTextColor,
-			fontSize,
 			setButtonColor,
-			setFontSize,
 			setTextColor,
 			textColor,
 		} = this.props;
@@ -50,15 +47,9 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					{ showFeature() && (
-						<PanelBody title={ __( 'Text settings', 'coblocks' ) } className="blocks-font-size">
-							<FontSizePicker
-								fallbackFontSize={ fallbackFontSize }
-								value={ fontSize.size }
-								onChange={ setFontSize }
-							/>
-						</PanelBody>
-					) }
+					<PanelBody title={ __( 'Text settings', 'coblocks' ) } className="blocks-font-size">
+						<CoBlocksFontSizePicker { ...this.props } />
+					</PanelBody>
 					<PanelColorSettings
 						title={ __( 'Color settings', 'coblocks' ) }
 						initialOpen={ false }

--- a/src/blocks/click-to-tweet/inspector.js
+++ b/src/blocks/click-to-tweet/inspector.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import applyWithColors from './colors';
+import { showFeature } from '../../utils/helper';
 
 /**
  * WordPress dependencies
@@ -49,13 +50,15 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Text settings', 'coblocks' ) } className="blocks-font-size">
-						<FontSizePicker
-							fallbackFontSize={ fallbackFontSize }
-							value={ fontSize.size }
-							onChange={ setFontSize }
-						/>
-					</PanelBody>
+					{ showFeature() && (
+						<PanelBody title={ __( 'Text settings', 'coblocks' ) } className="blocks-font-size">
+							<FontSizePicker
+								fallbackFontSize={ fallbackFontSize }
+								value={ fontSize.size }
+								onChange={ setFontSize }
+							/>
+						</PanelBody>
+					) }
 					<PanelColorSettings
 						title={ __( 'Color settings', 'coblocks' ) }
 						initialOpen={ false }

--- a/src/blocks/gallery-stacked/inspector.js
+++ b/src/blocks/gallery-stacked/inspector.js
@@ -4,6 +4,7 @@
 import ResponsiveTabsControl from '../../components/responsive-tabs-control';
 import SizeControl from '../../components/size-control';
 import GalleryLinkSettings from '../../components/block-gallery/gallery-link-settings';
+import { showFeature } from '../../utils/helper';
 
 /**
  * WordPress dependencies
@@ -124,7 +125,7 @@ class Inspector extends Component {
 						help={ this.getCaptionsHelp }
 					/>
 
-					{ captions &&
+					{ showFeature() && captions &&
 						<FontSizePicker
 							value={ fontSize.size }
 							onChange={ setFontSize }

--- a/src/blocks/gallery-stacked/inspector.js
+++ b/src/blocks/gallery-stacked/inspector.js
@@ -4,7 +4,7 @@
 import ResponsiveTabsControl from '../../components/responsive-tabs-control';
 import SizeControl from '../../components/size-control';
 import GalleryLinkSettings from '../../components/block-gallery/gallery-link-settings';
-import { showFeature } from '../../utils/helper';
+import CoBlocksFontSizePicker from '../../components/fontsize-picker';
 
 /**
  * WordPress dependencies
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { InspectorControls, FontSizePicker, withFontSizes } from '@wordpress/block-editor';
+import { InspectorControls, withFontSizes } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 
 /**
@@ -67,8 +67,6 @@ class Inspector extends Component {
 		const {
 			attributes,
 			setAttributes,
-			setFontSize,
-			fontSize,
 			wideControlsEnabled = false,
 		} = this.props;
 
@@ -125,11 +123,8 @@ class Inspector extends Component {
 						help={ this.getCaptionsHelp }
 					/>
 
-					{ showFeature() && captions &&
-						<FontSizePicker
-							value={ fontSize.size }
-							onChange={ setFontSize }
-						/>
+					{ captions &&
+						<CoBlocksFontSizePicker { ...this.props } />
 					}
 
 					{ ! fullwidth &&

--- a/src/blocks/highlight/controls.js
+++ b/src/blocks/highlight/controls.js
@@ -1,31 +1,28 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
 import { BlockControls, AlignmentToolbar } from '@wordpress/block-editor';
 
-class Controls extends Component {
-	render() {
-		const {
-			attributes,
-			setAttributes,
-		} = this.props;
+const Controls = ( props ) => {
+	const {
+		attributes,
+		setAttributes,
+	} = props;
 
-		const {
-			align,
-		} = attributes;
+	const {
+		align,
+	} = attributes;
 
-		return (
-			<Fragment>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
-					/>
-				</BlockControls>
-			</Fragment>
-		);
-	}
-}
+	return (
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
+				/>
+			</BlockControls>
+		</>
+	);
+};
 
 export default Controls;

--- a/src/blocks/highlight/edit.js
+++ b/src/blocks/highlight/edit.js
@@ -15,20 +15,11 @@ import { computeFontSize } from '../../utils/helper';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { RichText, withFontSizes } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 
-/**
- * Block edit function
- */
-export class Edit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.splitBlock = this.splitBlock.bind( this );
-	}
-
+const Edit = ( props ) => {
 	/**
 	 * Split handler for RichText value, namely when content is pasted or the
 	 * user presses the Enter key.
@@ -42,13 +33,13 @@ export class Edit extends Component {
 	 * @param {...WPBlock} blocks Optional blocks inserted between the before
 	 *                            and after value blocks.
 	 */
-	splitBlock( before, after, ...blocks ) {
+	const splitBlock = ( before, after, ...blocks ) => {
 		const {
 			attributes,
 			insertBlocksAfter,
 			setAttributes,
 			onReplace,
-		} = this.props;
+		} = props;
 
 		if ( after ) {
 			// Append "After" content as a new paragraph block to the end of
@@ -71,65 +62,63 @@ export class Edit extends Component {
 			// of before will be strictly equal to the current content.
 			setAttributes( { content: before } );
 		}
-	}
+	};
 
-	render() {
-		const {
-			attributes,
-			backgroundColor,
-			className,
-			mergeBlocks,
-			onReplace,
-			setAttributes,
-			textColor,
-			fontSize,
-		} = this.props;
+	const {
+		attributes,
+		backgroundColor,
+		className,
+		mergeBlocks,
+		onReplace,
+		setAttributes,
+		textColor,
+		fontSize,
+	} = props;
 
-		const {
-			content,
-			align,
-		} = attributes;
+	const {
+		content,
+		align,
+	} = attributes;
 
-		const classes = classnames( 'wp-block-coblocks-highlight__content',
-			backgroundColor && {
-				'has-background': backgroundColor.color,
-				[ backgroundColor.class ]: backgroundColor.class,
-			},
-			textColor && {
-				'has-text-color': textColor.color,
-				[ textColor.class ]: textColor.class,
-			},
+	const classes = classnames( 'wp-block-coblocks-highlight__content',
+		backgroundColor && {
+			'has-background': backgroundColor.color,
+			[ backgroundColor.class ]: backgroundColor.class,
+		},
+		textColor && {
+			'has-text-color': textColor.color,
+			[ textColor.class ]: textColor.class,
+		},
 			fontSize?.class && {
-				[ fontSize?.class ]: fontSize?.class,
-			}
-		);
+			[ fontSize?.class ]: fontSize?.class,
+		}
+	);
 
-		return (
-			<Fragment>
-				<Controls { ...this.props } />
-				<Inspector { ...this.props } />
-				<p className={ className } style={ { textAlign: align } }>
-					<RichText
-						tagName="mark"
-						placeholder={ __( 'Add highlighted text…', 'coblocks' ) }
-						value={ content }
-						onChange={ ( value ) => setAttributes( { content: value } ) }
-						onMerge={ mergeBlocks }
-						onSplit={ this.splitBlock }
-						onRemove={ () => onReplace( [] ) }
-						className={ classes }
-						style={ {
-							backgroundColor: backgroundColor?.color,
-							color: textColor?.color,
-							fontSize: computeFontSize( fontSize ) ?? undefined,
-						} }
-						keepPlaceholderOnFocus
-					/>
-				</p>
-			</Fragment>
-		);
-	}
-}
+	return (
+		<>
+			<Controls { ...props } />
+			<Inspector { ...props } />
+			<p className={ className } style={ { textAlign: align } }>
+				<RichText
+					tagName="mark"
+					placeholder={ __( 'Add highlighted text…', 'coblocks' ) }
+					value={ content }
+					onChange={ ( value ) => setAttributes( { content: value } ) }
+					onMerge={ mergeBlocks }
+					onSplit={ splitBlock }
+					onRemove={ () => onReplace( [] ) }
+					className={ classes }
+					style={ {
+						backgroundColor: backgroundColor?.color,
+						color: textColor?.color,
+						fontSize: computeFontSize( fontSize ) ?? undefined,
+					} }
+					keepPlaceholderOnFocus
+				/>
+			</p>
+		</>
+	);
+};
 
 export default compose( [
 	applyWithColors,

--- a/src/blocks/highlight/inspector.js
+++ b/src/blocks/highlight/inspector.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import applyWithColors from './colors';
+import { showFeature } from '../../utils/helper';
 
 /**
  * WordPress dependencies
@@ -32,13 +33,15 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Highlight settings', 'coblocks' ) } className="blocks-font-size">
-						<FontSizePicker
-							fallbackFontSize={ fallbackFontSize }
-							value={ fontSize.size }
-							onChange={ setFontSize }
-						/>
-					</PanelBody>
+					{ showFeature() && (
+						<PanelBody title={ __( 'Highlight settings', 'coblocks' ) } className="blocks-font-size">
+							<FontSizePicker
+								fallbackFontSize={ fallbackFontSize }
+								value={ fontSize.size }
+								onChange={ setFontSize }
+							/>
+						</PanelBody>
+					) }
 					<PanelColorSettings
 						title={ __( 'Color settings', 'coblocks' ) }
 						initialOpen={ false }

--- a/src/blocks/highlight/inspector.js
+++ b/src/blocks/highlight/inspector.js
@@ -2,76 +2,61 @@
  * Internal dependencies
  */
 import applyWithColors from './colors';
-import { showFeature } from '../../utils/helper';
+import CoBlocksFontSizePicker from '../../components/fontsize-picker';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { InspectorControls, ContrastChecker, PanelColorSettings, FontSizePicker, withFontSizes } from '@wordpress/block-editor';
+import { InspectorControls, ContrastChecker, PanelColorSettings, withFontSizes } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 
-/**
- * Inspector controls
- */
-class Inspector extends Component {
-	render() {
-		const {
-			backgroundColor,
-			textColor,
-			setBackgroundColor,
-			setTextColor,
-			fallbackBackgroundColor,
-			fallbackTextColor,
-			setFontSize,
-			fallbackFontSize,
-			fontSize,
-		} = this.props;
+const Inspector = ( props ) => {
+	const {
+		backgroundColor,
+		textColor,
+		setBackgroundColor,
+		setTextColor,
+		fallbackBackgroundColor,
+		fallbackTextColor,
+	} = props;
 
-		return (
-			<Fragment>
-				<InspectorControls>
-					{ showFeature() && (
-						<PanelBody title={ __( 'Highlight settings', 'coblocks' ) } className="blocks-font-size">
-							<FontSizePicker
-								fallbackFontSize={ fallbackFontSize }
-								value={ fontSize.size }
-								onChange={ setFontSize }
-							/>
-						</PanelBody>
-					) }
-					<PanelColorSettings
-						title={ __( 'Color settings', 'coblocks' ) }
-						initialOpen={ false }
-						colorSettings={ [
-							{
-								value: backgroundColor.color,
-								onChange: setBackgroundColor,
-								label: __( 'Background color', 'coblocks' ),
-							},
-							{
-								value: textColor.color,
-								onChange: setTextColor,
-								label: __( 'Text color', 'coblocks' ),
-							},
-						] }
-					>
-						<ContrastChecker
-							{ ...{
-								textColor: textColor.color,
-								backgroundColor: backgroundColor.color,
-								fallbackBackgroundColor,
-								fallbackTextColor,
-							} }
-						/>
-					</PanelColorSettings>
-				</InspectorControls>
-			</Fragment>
-		);
-	}
-}
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Highlight settings', 'coblocks' ) } className="blocks-font-size">
+					<CoBlocksFontSizePicker	{ ...props } />
+				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color settings', 'coblocks' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: backgroundColor.color,
+							onChange: setBackgroundColor,
+							label: __( 'Background color', 'coblocks' ),
+						},
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text color', 'coblocks' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
+							fallbackBackgroundColor,
+							fallbackTextColor,
+						} }
+					/>
+				</PanelColorSettings>
+			</InspectorControls>
+		</>
+	);
+};
 
 export default compose( [
 	applyWithColors,

--- a/src/blocks/highlight/test/highlight.cypress.js
+++ b/src/blocks/highlight/test/highlight.cypress.js
@@ -39,7 +39,9 @@ describe( 'Block: Highlight', function() {
 	/**
 	 * Test the accordion block content font settings
 	 */
-	it( 'Test highlight block font size setting.', function() {
+	// Disabled because fontSize controls are hidden in 5.8. This should be fixed when we can fix the fontSize controls.
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Test highlight block font size setting.', function() {
 		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
 			.type( 'highlighted text' );
 

--- a/src/blocks/highlight/test/highlight.cypress.js
+++ b/src/blocks/highlight/test/highlight.cypress.js
@@ -39,9 +39,7 @@ describe( 'Block: Highlight', function() {
 	/**
 	 * Test the accordion block content font settings
 	 */
-	// Disabled because fontSize controls are hidden in 5.8. This should be fixed when we can fix the fontSize controls.
-	// eslint-disable-next-line jest/no-disabled-tests
-	it.skip( 'Test highlight block font size setting.', function() {
+	it( 'Test highlight block font size setting.', function() {
 		cy.get( 'p.wp-block-coblocks-highlight' ).find( 'mark' )
 			.type( 'highlighted text' );
 
@@ -60,7 +58,11 @@ describe( 'Block: Highlight', function() {
 
 		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content[style*="font-size: 30px;"]' );
 
+		helpers.savePage();
+
 		helpers.checkForBlockErrors( 'coblocks/highlight' );
+
+		cy.get( 'p.wp-block-coblocks-highlight mark.wp-block-coblocks-highlight__content[style*="font-size: 30px;"]' );
 	} );
 
 	/**

--- a/src/components/fontsize-picker/index.js
+++ b/src/components/fontsize-picker/index.js
@@ -1,0 +1,29 @@
+
+/**
+ * WordPress dependencies
+ */
+import { FontSizePicker } from '@wordpress/block-editor';
+
+/**
+ * CoBlocksFontSizePicker is a functional component to interface `withFontSizes` hoc to FontSizePicker controls.
+ *
+ * @param {Object} props Accepts block props provided by `withFontSizes`.
+ */
+const CoBlocksFontSizePicker = ( props ) => {
+	const { fallbackFontSize, fontSize, setFontSize } = props;
+	return (
+		<FontSizePicker
+			fallbackFontSize={ fallbackFontSize }
+			value={ fontSize.size }
+			onChange={ ( value ) => {
+				const fontSizeValue = value ? parseInt( value, 10 ) : undefined;
+
+				if ( ! Number.isNaN( fontSizeValue ) ) {
+					setFontSize( fontSizeValue );
+				}
+			} }
+		/>
+	);
+};
+
+export default CoBlocksFontSizePicker;

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,3 +1,5 @@
+/*global coblocksBlockData*/
+
 /**
  * External dependencies
  */
@@ -78,3 +80,16 @@ export const computeFontSize = ( fontSize ) => {
 	return RegExp( /([a-z])/ ).test( size ) ? size : size + 'px';
 };
 
+/**
+ * showFeature returns true when WordPress 5.7.2 is active and false with 5.8
+ *
+ * @type {Function} showFeature
+ * @return {boolean} True when running 5.7.2 and false with 5.8
+ */
+export const showFeature = () => {
+	if ( typeof coblocksBlockData === 'undefined' ) {
+		return false;
+	}
+
+	return !! coblocksBlockData?.isWP58 ? false : true;
+};

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,5 +1,3 @@
-/*global coblocksBlockData*/
-
 /**
  * External dependencies
  */
@@ -78,18 +76,4 @@ export const hexToRGB = ( h ) => {
 export const computeFontSize = ( fontSize ) => {
 	const size = fontSize?.size ?? fontSize;
 	return RegExp( /([a-z])/ ).test( size ) ? size : size + 'px';
-};
-
-/**
- * showFeature returns true when WordPress 5.7.2 is active and false with 5.8
- *
- * @type {Function} showFeature
- * @return {boolean} True when running 5.7.2 and false with 5.8
- */
-export const showFeature = () => {
-	if ( typeof coblocksBlockData === 'undefined' ) {
-		return false;
-	}
-
-	return !! coblocksBlockData?.isWP58 ? false : true;
 };


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Closes #1945. [Due to a bug in 5.8 release](https://github.com/WordPress/gutenberg/issues/33653), the `withFontSizes` HOC is conflicting with the `FontSizePicker` component. Changes here fix logic used with the `FontSizePicker` to allow use in 5.7.2 as well as 5.8.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
New CoBlocks shared component where we utilize `FontSizePicker` with improved logic.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
This was tested manually by switching versions 5.7.2 and 5.8.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
