### PR TITLE
Improve accessibility for Alert block - Issue #1951

### DIFF
--- a/src/blocks/alert/deprecated.js
+++ b/src/blocks/alert/deprecated.js
@@ -169,6 +169,58 @@ const deprecated = [
 			);
 		},
 	},
+	{
+		attributes: blockAttributes,
+		save( { attributes } ) {
+			const {
+				backgroundColor,
+				customBackgroundColor,
+				customTextColor,
+				textAlign,
+				textColor,
+				title,
+				value,
+			} = attributes;
+
+			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+			const textClass = getColorClassName( 'color', textColor );
+
+			const classes = classnames( {
+				'has-text-color': textColor || customTextColor,
+				[ textClass ]: textClass,
+				[ `has-text-align-${ textAlign }` ]: textAlign,
+				'has-background': backgroundColor || customBackgroundColor,
+				[ backgroundClass ]: backgroundClass,
+			} );
+
+			const styles = {
+				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+				color: textClass ? undefined : customTextColor,
+			};
+
+			return (
+				<div
+					className={ classes }
+					style={ styles }
+				>
+					{ ! RichText.isEmpty( title ) &&
+					<RichText.Content
+						tagName="p"
+						className="wp-block-coblocks-alert__title"
+						value={ title }
+					/>
+					}
+					{ ! RichText.isEmpty( value ) &&
+					<RichText.Content
+						tagName="p"
+						className="wp-block-coblocks-alert__text"
+						value={ value }
+					/>
+					}
+				</div>
+			);
+		},
+	},
 ];
 
 export default deprecated;

--- a/src/blocks/alert/save.js
+++ b/src/blocks/alert/save.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText, getColorClassName } from '@wordpress/block-editor';
-import {__} from "@wordpress/i18n";
+import { __ } from '@wordpress/i18n';
 
 const save = ( { attributes } ) => {
 	const {
@@ -40,12 +40,12 @@ const save = ( { attributes } ) => {
 	const getAriaLabel = () => {
 		const type = className?.match( /is-style-(\w+)/ );
 
-		return type && type[ 1 ] ?
+		return type && type[ 1 ]
 			/* translators: text for accessibility defining the type of alert used */
-			`${ __( 'Alert section of type', 'coblocks' ) } ${ type[ 1 ] }` :
+			? `${ __( 'Alert section of type', 'coblocks' ) } ${ type[ 1 ] }`
 			/* translators: text for accessibility defining the block's type */
-			__( 'Alert section', 'coblocks' );
-	}
+			: __( 'Alert section', 'coblocks' );
+	};
 
 	return (
 		<div

--- a/src/blocks/alert/save.js
+++ b/src/blocks/alert/save.js
@@ -7,10 +7,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText, getColorClassName } from '@wordpress/block-editor';
+import {__} from "@wordpress/i18n";
 
 const save = ( { attributes } ) => {
 	const {
 		backgroundColor,
+		className,
 		customBackgroundColor,
 		customTextColor,
 		textAlign,
@@ -35,10 +37,21 @@ const save = ( { attributes } ) => {
 		color: textClass ? undefined : customTextColor,
 	};
 
+	const getAriaLabel = () => {
+		const type = className?.match( /is-style-(\w+)/ );
+
+		return type && type[ 1 ] ?
+			/* translators: text for accessibility defining the type of alert used */
+			`${ __( 'Alert section of type', 'coblocks' ) } ${ type[ 1 ] }` :
+			/* translators: text for accessibility defining the block's type */
+			__( 'Alert section', 'coblocks' );
+	}
+
 	return (
 		<div
 			className={ classes }
 			style={ styles }
+			aria-label={ getAriaLabel() }
 		>
 			{ ! RichText.isEmpty( title ) &&
 			<RichText.Content

--- a/src/blocks/alert/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/alert/test/__snapshots__/save.spec.js.snap
@@ -2,66 +2,66 @@
 
 exports[`coblocks/alert should render with background color 1`] = `
 "<!-- wp:coblocks/alert {\\"backgroundColor\\":\\"#111111\\"} -->
-<div class=\\"wp-block-coblocks-alert has-background has-111111-background-color\\"></div>
+<div class=\\"wp-block-coblocks-alert has-background has-111111-background-color\\" aria-label=\\"Alert section\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with content 1`] = `
 "<!-- wp:coblocks/alert -->
-<div class=\\"wp-block-coblocks-alert\\"><p class=\\"wp-block-coblocks-alert__title\\">Alert title</p><p class=\\"wp-block-coblocks-alert__text\\">Alert description</p></div>
+<div class=\\"wp-block-coblocks-alert\\" aria-label=\\"Alert section\\"><p class=\\"wp-block-coblocks-alert__title\\">Alert title</p><p class=\\"wp-block-coblocks-alert__text\\">Alert description</p></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with custom background color 1`] = `
 "<!-- wp:coblocks/alert {\\"customBackgroundColor\\":\\"#111111\\"} -->
-<div class=\\"wp-block-coblocks-alert has-background\\" style=\\"background-color:#111111\\"></div>
+<div class=\\"wp-block-coblocks-alert has-background\\" style=\\"background-color:#111111\\" aria-label=\\"Alert section\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with custom classes for styles 1`] = `
 "<!-- wp:coblocks/alert {\\"className\\":\\"is-style-info\\"} -->
-<div class=\\"wp-block-coblocks-alert is-style-info\\"></div>
+<div class=\\"wp-block-coblocks-alert is-style-info\\" aria-label=\\"Alert section of type info\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with custom classes for styles 2`] = `
 "<!-- wp:coblocks/alert {\\"className\\":\\"is-style-success\\"} -->
-<div class=\\"wp-block-coblocks-alert is-style-success\\"></div>
+<div class=\\"wp-block-coblocks-alert is-style-success\\" aria-label=\\"Alert section of type success\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with custom classes for styles 3`] = `
 "<!-- wp:coblocks/alert {\\"className\\":\\"is-style-warning\\"} -->
-<div class=\\"wp-block-coblocks-alert is-style-warning\\"></div>
+<div class=\\"wp-block-coblocks-alert is-style-warning\\" aria-label=\\"Alert section of type warning\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with custom classes for styles 4`] = `
 "<!-- wp:coblocks/alert {\\"className\\":\\"is-style-error\\"} -->
-<div class=\\"wp-block-coblocks-alert is-style-error\\"></div>
+<div class=\\"wp-block-coblocks-alert is-style-error\\" aria-label=\\"Alert section of type error\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with text align 1`] = `
 "<!-- wp:coblocks/alert {\\"textAlign\\":\\"left\\"} -->
-<div class=\\"wp-block-coblocks-alert has-text-align-left\\"></div>
+<div class=\\"wp-block-coblocks-alert has-text-align-left\\" aria-label=\\"Alert section\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with text align 2`] = `
 "<!-- wp:coblocks/alert {\\"textAlign\\":\\"center\\"} -->
-<div class=\\"wp-block-coblocks-alert has-text-align-center\\"></div>
+<div class=\\"wp-block-coblocks-alert has-text-align-center\\" aria-label=\\"Alert section\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with text align 3`] = `
 "<!-- wp:coblocks/alert {\\"textAlign\\":\\"right\\"} -->
-<div class=\\"wp-block-coblocks-alert has-text-align-right\\"></div>
+<div class=\\"wp-block-coblocks-alert has-text-align-right\\" aria-label=\\"Alert section\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;
 
 exports[`coblocks/alert should render with text color 1`] = `
 "<!-- wp:coblocks/alert {\\"textColor\\":\\"primary\\"} -->
-<div class=\\"wp-block-coblocks-alert has-text-color has-primary-color\\"></div>
+<div class=\\"wp-block-coblocks-alert has-text-color has-primary-color\\" aria-label=\\"Alert section\\"></div>
 <!-- /wp:coblocks/alert -->"
 `;


### PR DESCRIPTION
### Description
Add `aria-label` for the Alert block, specifying to screen readers what's the block purpose
See #1951 #1927

### Types of changes
<!-- New feature (non-breaking change which adds functionality) -->

### How has this been tested?
Manually tested

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
