### PR TITLE
Keep default experimental features object structure within editor settings

### DIFF
--- a/src/extensions/colors/settings-modal-control.js
+++ b/src/extensions/colors/settings-modal-control.js
@@ -86,6 +86,7 @@ function CoBlocksEditorSettingsControls() {
 
 			// Handle experimental features for WP 5.8
 			__experimentalFeatures: {
+				...settings?.__experimentalFeatures,
 				color: {
 					...settings?.__experimentalFeatures?.color,
 					palette: colorPanelEnabled


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Fixes #1935 

When settings the editor settings, keep the default structure of the __experimentalFeatures object.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bux fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
