### PR TITLE
Fix invisble block states enabled by animation class

### DIFF
--- a/src/extensions/animation/index.js
+++ b/src/extensions/animation/index.js
@@ -136,14 +136,24 @@ const withAnimationSettings = createHigherOrderComponent( ( BlockListBlock ) => 
 	return enhance( ( { select, ...props } ) => {
 		let wrapperProps = props.wrapperProps;
 
-		const block = select( 'core/block-editor' ).getBlock( props.rootClientId || props.clientId );
 		const blockName	= select( 'core/block-editor' ).getBlockName( props.rootClientId || props.clientId );
 
-		if ( ! allowedBlocks.some( ( allowedBlock ) => allowedBlock.blockType === blockName && ! allowedBlock.animateChildren ) || ! block?.attributes?.animation ) {
+		// Block not supported return unmodified.
+		if ( ! allowedBlocks.some( ( allowedBlock ) => allowedBlock.blockType === blockName && ! allowedBlock.animateChildren ) ) {
 			return <BlockListBlock { ...props } />;
 		}
 
-		const { animation } = block.attributes;
+		if ( ! props.attributes?.animation ) {
+			// If animation is unset ensure that `coblocks-animate` class is unset.
+			if ( props.attributes?.className?.includes( 'coblocks-animate' ) ) {
+				const classList = props.attributes?.className.split( ' ' );
+				props.attributes.className = classList.filter( ( c ) => c !== 'coblocks-animate' ).join( ' ' );
+			}
+
+			return <BlockListBlock { ...props } />;
+		}
+
+		const { animation } = props.attributes;
 
 		// Apply animation classes to block wrapper only if the animation attribute has changed.
 		const prevAnimation = useRef();
@@ -185,22 +195,4 @@ addFilter(
 	'editor.BlockListBlock',
 	'coblocks/withAnimationSettings',
 	withAnimationSettings
-);
-
-const withAnimationSafeCheck = ( settings, block ) => {
-	if ( allowedBlocks.some( ( allowedBlock ) => allowedBlock.blockType === block.name ) ) {
-		if ( settings.animation === undefined && settings.className?.includes( 'coblocks-animate' ) ) {
-			const settingsClass = settings.className.split( ' ' );
-
-			settings.className = settingsClass.filter( ( c ) => c !== 'coblocks-animate' ).join( ' ' );
-		}
-	}
-
-	return settings;
-};
-
-addFilter(
-	'blocks.getBlockAttributes',
-	'coblocks/withAnimationSafeCheck',
-	withAnimationSafeCheck
 );

--- a/src/extensions/animation/index.js
+++ b/src/extensions/animation/index.js
@@ -187,17 +187,8 @@ addFilter(
 	withAnimationSettings
 );
 
-const ALLOWED_ANIMATION_BLOCKS = [
-	'core/media-text',
-	'core/image',
-	'core/group',
-	'core/gallery',
-	'core/cover',
-	'core/columns',
-];
-
 const withAnimationSafeCheck = ( settings, block ) => {
-	if ( ALLOWED_ANIMATION_BLOCKS.includes( block.name ) ) {
+	if ( allowedBlocks.some( ( allowedBlock ) => allowedBlock.blockType === block.name ) ) {
 		if ( settings.animation === undefined && settings.className?.includes( 'coblocks-animate' ) ) {
 			const settingsClass = settings.className.split( ' ' );
 

--- a/src/extensions/animation/index.js
+++ b/src/extensions/animation/index.js
@@ -186,3 +186,23 @@ addFilter(
 	'coblocks/withAnimationSettings',
 	withAnimationSettings
 );
+
+const ALLOWED_ANIMATION_BLOCKS = [ 'core/media-text' ];
+
+const withAnimationSafeCheck = ( settings, block ) => {
+	if ( ALLOWED_ANIMATION_BLOCKS.includes( block.name ) ) {
+		if ( settings.animation === undefined && settings.className?.includes( 'coblocks-animate' ) ) {
+			const settingsClass = settings.className.split( ' ' );
+
+			settings.className = settingsClass.filter( ( c ) => c !== 'coblocks-animate' ).join( ' ' );
+		}
+	}
+
+	return settings;
+};
+
+addFilter(
+	'blocks.getBlockAttributes',
+	'coblocks/withAnimationSafeCheck',
+	withAnimationSafeCheck
+);

--- a/src/extensions/animation/index.js
+++ b/src/extensions/animation/index.js
@@ -187,7 +187,14 @@ addFilter(
 	withAnimationSettings
 );
 
-const ALLOWED_ANIMATION_BLOCKS = [ 'core/media-text' ];
+const ALLOWED_ANIMATION_BLOCKS = [
+	'core/media-text',
+	'core/image',
+	'core/group',
+	'core/gallery',
+	'core/cover',
+	'core/columns',
+];
 
 const withAnimationSafeCheck = ( settings, block ) => {
 	if ( ALLOWED_ANIMATION_BLOCKS.includes( block.name ) ) {


### PR DESCRIPTION
Fixes #1941 

### Description
<!-- Please describe what you have changed or added -->
If an animation (coblocks extension) is added to a block, and the coblocks plugin is deactivated, block validation will fail and block recovery will remove the animation attribute, however the classname `coblocks-animate` will be kept. If coblocks is re-activated , as the animation is undefined and the className is set, an opacity of 0 is set to the block. This PR attempts to add a block filter to remove this class name in the event of an undefined animation attribute.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
