### PR TITLE
Fix `run-all-tests` feature to also run php and css linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ commands:
       - run:
           name: "Pre-Check files"
           command: |
-            if [ -z $FILES ] && [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "develop" ] && [ "$CIRCLE_BRANCH" != *"run-all-tests"* ]; then
+            if [ -z $FILES ] && [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "develop" ] && [[ "$CIRCLE_BRANCH" != *"run-all-tests"* ]]; then
               echo "Changes do not require testing."
               circleci-agent step halt
             fi

--- a/cypress.json
+++ b/cypress.json
@@ -6,7 +6,6 @@
   "supportFile": ".dev/tests/cypress/support/commands.js",
   "screenshotsFolder": ".dev/tests/cypress/screenshots",
   "projectId": "sovnn2",
-  "firefoxGcInterval": null,
   "integrationFolder": "./",
   "testFiles": "**/*.cypress.js",
   "viewportWidth": 1920,


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
A valid but unexpected bash syntax was causing the reversed output within an if statement. This was preventing lint tests from running.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Fix bash syntax located in the config.yml file.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested within the CI pipeline.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
