### PR TITLE
Server side render Click to Tweet block

### DIFF
--- a/includes/class-coblocks-register-blocks.php
+++ b/includes/class-coblocks-register-blocks.php
@@ -94,14 +94,6 @@ class CoBlocks_Register_Blocks {
 			)
 		);
 		register_block_type(
-			$slug . '/click-to-tweet',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		register_block_type(
 			$slug . '/dynamic-separator',
 			array(
 				'editor_script' => $slug . '-editor',

--- a/src/blocks/click-to-tweet/block.json
+++ b/src/blocks/click-to-tweet/block.json
@@ -4,8 +4,6 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"source": "html",
-			"selector": "p",
 			"default": ""
 		},
 		"url": {

--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -4,7 +4,6 @@
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
-import save from './save';
 import transforms from './transforms';
 import deprecated from './deprecated';
 
@@ -39,7 +38,9 @@ const settings = {
 	attributes,
 	transforms,
 	edit,
-	save,
+	save() {
+		return null;
+	},
 	deprecated,
 };
 

--- a/src/blocks/click-to-tweet/index.php
+++ b/src/blocks/click-to-tweet/index.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Server-side rendering of the `click to tweet` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the block content.
+ */
+function coblocks_render_click_to_tweet_block( $attributes ) {
+
+	ob_start();
+
+	$custom_class   = isset( $attributes['className'] ) ? sprintf( ' %s', $attributes['className'] ) : '';
+	$content        = $attributes['content'];
+	$button_text    = isset( $attributes['buttonText'] ) ? $attributes['buttonText'] : 'Tweet';
+	$url            = sprintf( 'http://twitter.com/share?&text=%1$s&url=%2$s', $content, get_permalink( get_the_id() ) );
+	$content_styles = '';
+	$button_color   = isset( $attributes['customButtonColor'] ) ? sprintf( ' style=background:%s;', $attributes['customButtonColor'] ) : '';
+
+	if ( isset( $attributes['via'] ) ) {
+		$url .= sprintf( '&via=%s', $attributes['via'] );
+	}
+
+	if ( isset( $attributes['customFontSize'] ) ) {
+		$content_styles .= sprintf( 'font-size:%spx;', $attributes['customFontSize'] );
+	}
+
+	if ( isset( $attributes['customTextColor'] ) ) {
+		$content_styles .= sprintf( 'color:%s;', $attributes['customTextColor'] );
+	}
+
+	if ( ! empty( $content_styles ) ) {
+		$content_styles = " style={$content_styles}";
+	}
+
+	?>
+
+	<blockquote class="wp-block-coblocks-click-to-tweet<?php echo esc_attr( $custom_class ); ?>">
+		<p class="wp-block-coblocks-click-to-tweet__text"<?php echo esc_attr( $content_styles ); ?>><?php echo esc_html( $content ); ?></p>
+		<a class="wp-block-coblocks-click-to-tweet__twitter-btn" href="<?php echo esc_attr( esc_url( $url ) ); ?>" target="_blank" rel="noopener noreferrer"<?php echo esc_attr( $button_color ); ?>><?php echo esc_html( $button_text ); ?></a>
+	</blockquote>
+
+	<?php
+
+	return ob_get_clean();
+
+}
+
+/**
+ * Registers the `posts` block on server.
+ */
+function coblocks_register_click_to_tweet_block() {
+	// Return early if this function does not exist.
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+
+	// Load attributes from block.json.
+	ob_start();
+	include COBLOCKS_PLUGIN_DIR . 'src/blocks/posts/block.json';
+	$metadata = json_decode( ob_get_clean(), true );
+
+	$slug = 'coblocks';
+
+	register_block_type(
+		$slug . '/click-to-tweet',
+		array(
+			'editor_script'   => $slug . '-editor',
+			'editor_style'    => $slug . '-editor',
+			'style'           => $slug . '-frontend',
+			'attributes'      => $metadata['attributes'],
+			'render_callback' => function( $attributes ) {
+				return coblocks_render_click_to_tweet_block( $attributes );
+			},
+		)
+	);
+}
+add_action( 'init', 'coblocks_register_click_to_tweet_block' );


### PR DESCRIPTION
Resolves #1663 

### Description
Convert the click to tweet block to a server side rendered block.

### Types of changes
Non-breaking change

### How has this been tested?
Manually tested. The jest tests are currently not passing due to the 'buttonText' attribute getting stripped from the serialized block. This needs to be investigated further.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
