### PR TITLE
Properly save and parse local storage Color Palette values

### DIFF
--- a/src/extensions/colors/settings-modal-control.js
+++ b/src/extensions/colors/settings-modal-control.js
@@ -42,27 +42,44 @@ function CoBlocksEditorSettingsControls() {
 		let settingValue;
 		switch ( key ) {
 			case '__experimentalFeatures.color.palette':
-				settingValue = settings?.__experimentalFeatures?.color?.palette ?? [];
+				settingValue = settings?.__experimentalFeatures?.color?.palette ?? { core: [] };
 				break;
 			case '__experimentalFeatures.color.gradients':
-				settingValue = settings?.__experimentalFeatures?.color?.gradients ?? [];
+				settingValue = settings?.__experimentalFeatures?.color?.gradients ?? { core: [] };
 				break;
 			default:
 				settingValue = settings[ key ];
 				break;
 		}
 
-		// Safely fetch the localStorage value
-		const localStorageValue = !! localStorage.getItem( key ) ? localStorage.getItem( key ) : false;
+		const localStorageValue = localStorage.getItem( key );
+		/**
+		 * Check whether the localStorage value is valid and should be used or discard to use original setting.
+		 *
+		 * @return {boolean} Whether or not the parsed localStorage is valid.
+		 */
+		const localStorageValueIsValid = () => {
+			if ( Array.isArray( localStorageValue ) && ! localStorageValue.length ) {
+				return false;
+			}
 
-		// Backup settings if no key exists.
-		if ( ! isEnabled && ! localStorageValue ) {
+			if ( localStorageValue?.constructor === Object && Object.keys( localStorageValue )?.length === 0 ) {
+				return false;
+			}
+
+			return true;
+		};
+
+		// Backup settings if no key exists or if invalid value saved.
+		if ( ! isEnabled && ! localStorageValueIsValid() ) {
 			localStorage.setItem( key, JSON.stringify( settingValue ) );
 		}
 
 		// Feature is enabled so parse the stored value or return existing setting value.
 		if ( isEnabled ) {
-			return localStorageValue ? JSON.parse( localStorageValue ) : settingValue;
+			// Check if stored value is empty array.
+			return localStorageValue && localStorageValueIsValid()
+				? JSON.parse( localStorageValue ) : settingValue;
 		}
 
 		// Feature is disabled return empty array to disable the setting.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
closes #1978

Due to some oversights in type-checking, there are conditions that allow the saved color palette to be an empty array. Due to improper type-checking, we failed to discard the empty array for the theme-defined values.

Changes here will fix any issues where users have empty palettes by freshly fetching those settings on page load.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
