### PR TITLE
Fix issue with transforming to refactored core gallery

### DIFF
--- a/src/components/block-gallery/shared/transforms.js
+++ b/src/components/block-gallery/shared/transforms.js
@@ -25,9 +25,9 @@ function GalleryTransforms( props ) {
 		gridSize: props.gridSize,
 		gutterMobile: props.gutterMobile,
 		height: props.height,
-		images: props.images?.map((image, index) => {
-			return { ...helper.pickRelevantMediaFiles(image), index };
-		}),
+		images: props.images?.map( ( image, index ) => {
+			return { ...helper.pickRelevantMediaFiles( image ), index };
+		} ),
 		linkTo: props.linkTo,
 		pageDots: props.pageDots,
 		prevNextButtons: props.prevNextButtons,

--- a/src/components/block-gallery/shared/transforms.js
+++ b/src/components/block-gallery/shared/transforms.js
@@ -25,9 +25,9 @@ function GalleryTransforms( props ) {
 		gridSize: props.gridSize,
 		gutterMobile: props.gutterMobile,
 		height: props.height,
-		images: props.images.map( ( image, index ) => {
-			return { ...helper.pickRelevantMediaFiles( image ), index };
-		} ),
+		images: props.images?.map((image, index) => {
+			return { ...helper.pickRelevantMediaFiles(image), index };
+		}),
 		linkTo: props.linkTo,
 		pageDots: props.pageDots,
 		prevNextButtons: props.prevNextButtons,


### PR DESCRIPTION
### Description
Adds optional chaining operator to image array in gallery transform to prevent editor crash when transforming from [new core gallery block refactor](https://github.com/WordPress/gutenberg/pull/25940) which does not have an image attribute by default.

### Screenshots
Before:
![before-coblocks](https://user-images.githubusercontent.com/3629020/129310048-aa2cab0e-5370-4f22-8839-13c378dd989c.gif)

After:
![after-coblocks](https://user-images.githubusercontent.com/3629020/129310060-0745c212-98b3-4336-92b8-5b68d66fd41d.gif)

### Types of changes
Addition of optional chaining operator to for the core gallery image attribute array.



### How has this been tested?
Tested on local dev install with build of Gutenberg Gallery refactor branch also installed.