### PR TITLE
refactor services block to use react hooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ commands:
       - run:
           name: Install WordPress
           command: |
-            sudo apt-get update && sudo apt-get install -y subversion default-mysql-client
+            sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y subversion default-mysql-client
             sudo -E docker-php-ext-install mysqli
             mkdir -p /tmp/wordpress
             ./vendor/bin/wp core download --path=/tmp/wordpress

--- a/src/blocks/services/edit.js
+++ b/src/blocks/services/edit.js
@@ -23,7 +23,7 @@ import {
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { Fragment, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { AlignmentToolbar, BlockControls, InnerBlocks } from '@wordpress/block-editor';
 
@@ -141,7 +141,7 @@ const Edit = ( props ) => {
 
 	const activeStyle = getActiveStyle( layoutOptions, className );
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<HeadingToolbar
 					minLevel={ 2 }
@@ -176,7 +176,7 @@ const Edit = ( props ) => {
 					</div>
 				</GutterWrapper>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/src/blocks/services/service/edit.js
+++ b/src/blocks/services/service/edit.js
@@ -13,7 +13,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import {
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	BlockControls,
@@ -130,7 +130,7 @@ const Edit = ( props ) => {
 		);
 
 		return (
-			<Fragment>
+			<>
 				<figure className={ classes }>
 					{ isSelected && (
 						<ButtonGroup className="block-library-gallery-item__inline-menu is-right is-visible">
@@ -147,7 +147,7 @@ const Edit = ( props ) => {
 					{ isBlobURL( attributes.imageUrl ) && <Spinner /> }
 					<img src={ attributes.imageUrl } alt={ attributes.imageAlt } style={ { objectPosition: attributes.focalPoint ? `${ attributes.focalPoint.x * 100 }% ${ attributes.focalPoint.y * 100 }%` : undefined } } />
 				</figure>
-			</Fragment>
+			</>
 		);
 	};
 
@@ -201,7 +201,7 @@ const Edit = ( props ) => {
 	];
 
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				{ imageUrl && (
 					<ImageURLInputUI
@@ -232,7 +232,7 @@ const Edit = ( props ) => {
 					/>
 				</div>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/src/blocks/services/service/inspector.js
+++ b/src/blocks/services/service/inspector.js
@@ -2,7 +2,6 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { PanelBody, ToggleControl, TextareaControl, ExternalLink, FocalPointPicker } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 
@@ -34,12 +33,12 @@ const Inspector = ( props ) => {
 						value={ attributes.imageAlt }
 						onChange={ ( value ) => setAttributes( { imageAlt: value } ) }
 						help={
-							<Fragment>
+							<>
 								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 									{ __( 'Describe the purpose of the image', 'coblocks' ) }
 								</ExternalLink>
 								{ __( 'Leave empty if the image is purely decorative.', 'coblocks' ) }
-							</Fragment>
+							</>
 						}
 					/>
 					<FocalPointPicker


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This block already implements a functional component architecture. This PR is to remove the Fragment components from within the Services block and related components.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
