### PR TITLE
Update styles, remove missing

### DIFF
--- a/src/blocks/dynamic-separator/styles/editor.scss
+++ b/src/blocks/dynamic-separator/styles/editor.scss
@@ -5,10 +5,6 @@
 		&::before {
 			transition: width 300ms cubic-bezier(0.645, 0.045, 0.355, 1), max-width 300ms cubic-bezier(0.645, 0.045, 0.355, 1);
 		}
-
-		&.is-selected {
-			background: $gray-200;
-		}
 	}
 }
 

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -1,5 +1,5 @@
 .wp-block-coblocks-dynamic-separator {
-	background: none !important;
+	background: none;
 	border: 0;
 	max-width: 100% !important;
 	opacity: 1;

--- a/src/blocks/gallery-collage/styles/editor.scss
+++ b/src/blocks/gallery-collage/styles/editor.scss
@@ -81,7 +81,7 @@
 	}
 
 	.block-editor-media-placeholder {
-		background: $dark-opacity-light-200;
+		background: $white;
 		min-height: inherit;
 		outline-offset: -1px;
 
@@ -114,10 +114,6 @@
 	}
 
 	.is-style-layered {
-
-		.block-editor-media-placeholder {
-			background: $gray-200;
-		}
 
 		.components-form-file-upload {
 			display: none;

--- a/src/blocks/row/styles/editor.scss
+++ b/src/blocks/row/styles/editor.scss
@@ -8,10 +8,6 @@
 .wp-block-coblocks-row {
 	display: block;
 
-	.components-placeholder {
-		color: $gray-900;
-	}
-
 	.wp-block-coblocks-row__inner.has-no-gutter {
 
 		> .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit {

--- a/src/components/block-gallery/styles/editor/_gallery-item-link.scss
+++ b/src/components/block-gallery/styles/editor/_gallery-item-link.scss
@@ -27,28 +27,6 @@
 		width: 16px;
 	}
 
-	.components-icon-button {
-		margin-left: 1px;
-		margin-right: 3px;
-		padding: 6px;
-
-		&:not(:disabled):not([aria-disabled="true"]):hover {
-			background: var(--wp-admin-theme-color, #007cba) !important;
-			box-shadow: none;
-			color: $white !important;
-			opacity: 0.75;
-		}
-
-		&:focus,
-		&:active {
-			box-shadow: none !important;
-
-			.dashicon {
-				color: $gray-900 !important;
-			}
-		}
-	}
-
 	.block-editor-url-input {
 		flex: 1 2;
 		padding: 2px;


### PR DESCRIPTION
Resolves https://github.com/godaddy-wordpress/coblocks/issues/1652

### Description
Remove any styles that have been deprecated, and tweak the existing styles for the dynamic separator to remove the `!important` override.

### Screenshots
Some screenshots in the issue mentioned above.

### Types of changes
Style tweaks - non-breaking change

### How has this been tested?
Manually inspected each element to ensure no regressions occurred after style tweaks.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
