### PR TITLE
Add a 'replace' button to the service image

### DIFF
--- a/src/blocks/services/service/edit.js
+++ b/src/blocks/services/service/edit.js
@@ -19,10 +19,11 @@ import {
 	BlockControls,
 	InnerBlocks,
 	MediaPlaceholder,
+	MediaUpload,
+	MediaUploadCheck,
 } from '@wordpress/block-editor';
 import { DropZone, Button, Spinner, ButtonGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { mediaUpload } from '@wordpress/editor';
 import { isBlobURL } from '@wordpress/blob';
 import { closeSmall } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
@@ -107,13 +108,8 @@ const Edit = ( props ) => {
 		setAttributes( { showCta: ! showCta } );
 	};
 
-	const replaceImage = ( files ) => {
-		mediaUpload( {
-			allowedTypes: [ 'image' ],
-			filesList: files,
-			onFileChange: ( [ media ] ) =>
-				setAttributes( { imageUrl: media.url, imageAlt: media.alt, imageId: media.id } ),
-		} );
+	const replaceImage = ( file ) => {
+		setAttributes( { imageUrl: file.url, imageAlt: file.alt, imageId: file.id } );
 	};
 
 	const renderImage = () => {
@@ -134,13 +130,32 @@ const Edit = ( props ) => {
 				<figure className={ classes }>
 					{ isSelected && (
 						<ButtonGroup className="block-library-gallery-item__inline-menu is-right is-visible">
-							<Button
-								icon={ closeSmall }
-								onClick={ () => setAttributes( { imageUrl: '', imageAlt: '', imageId: null } ) }
-								className="coblocks-gallery-item__button"
-								label={ __( 'Remove image', 'coblocks' ) }
-								disabled={ ! isSelected }
-							/>
+							<MediaUploadCheck>
+								<MediaUpload
+									allowedTypes={ [ 'image' ] }
+									onSelect={ ( img ) => replaceImage( img ) }
+									value={ image.url }
+									render={ ( { open } ) => (
+										<>
+											<Button
+												icon={ closeSmall }
+												onClick={ () => setAttributes( { imageUrl: '', imageAlt: '', imageId: null } ) }
+												className="coblocks-gallery-item__button"
+												label={ __( 'Remove image', 'coblocks' ) }
+												disabled={ ! isSelected }
+											/>
+											<Button
+												className="coblocks-gallery-item__button-replace"
+												onClick={ open }
+												label={ __( 'Replace Image', 'coblocks' ) }
+											>
+												{ __( 'Replace', 'coblocks' ) }
+											</Button>
+										</>
+									) }
+								>
+								</MediaUpload>
+							</MediaUploadCheck>
 						</ButtonGroup>
 					) }
 					{ dropZone }


### PR DESCRIPTION
### Description
Add a 'Replace' button to the service image block.

### Screenshots

#### Before
<img src="https://user-images.githubusercontent.com/5321364/131901390-29ea9f73-992c-4a6c-a627-db42a2028257.png" width="350" />

#### After
<img src="https://user-images.githubusercontent.com/5321364/131901009-5ee3dafe-e636-4398-b151-7723bc609abe.png" width="350" />

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
