### PR TITLE
Fix gutter value in the editor always set to 0 on page load

### DIFF
--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -47,7 +47,6 @@ const GalleryCarouselEdit = ( props ) => {
 	const [ captionFocused, setCaptionFocused ] = useState( false );
 
 	const prevSelected = usePrevious( props.isSelected );
-	const prevAlign = usePrevious( props.attributes.align );
 
 	useEffect( () => {
 		if ( ! props.isSelected && prevSelected ) {
@@ -65,16 +64,6 @@ const GalleryCarouselEdit = ( props ) => {
 			props.setAttributes( { radius: 0 } );
 		}
 	}, [ props.attributes.gutter ] );
-
-	useEffect( () => {
-		if (
-			props.attributes.gridSize === 'xlrg' &&
-			prevAlign === undefined &&
-			( gutter !== 0 || gutterMobile !== 0 )
-		) {
-			props.setAttributes( { gutter: 0, gutterMobile: 0 } );
-		}
-	}, [ props.attributes.gridSize, prevAlign ] );
 
 	useEffect( () => {
 		if ( parsedNavForClass !== props.attributes.navForClass ) {


### PR DESCRIPTION
### Description
The gutter controls for the Carousel gallery was not showing properly in the editor. The value was saving to the DB and the front of site looked correct, but the editor always had a `gutter` and `gutterMobile` values of 0. The following code is responsible for setting the gutter value back to 0 on page load. This block of code only seemed to be causing a problem and not necessary for the block to function properly.

```js
useEffect( () => {
	if (
		props.attributes.gridSize === 'xlrg' &&
		prevAlign === undefined &&
		( gutter !== 0 || gutterMobile !== 0 )
	) {
		props.setAttributes( { gutter: 0, gutterMobile: 0 } );
	}
}, [ props.attributes.gridSize, prevAlign ] );
```

### Types of changes
 Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Manually tested each block with the older gutter controls.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
