### PR TITLE
WPEX-1459 - do not throw error on custom entered category for post carousel and posts block

### DIFF
--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -356,12 +356,7 @@ export default compose( [
 
 		const updatedQuery = () => {
 			const catIds = categories && categories.length > 0
-				? categories.map( ( cat ) => {
-					if ( ! cat ) {
-						return null;
-					}
-					return cat.id;
-				} )
+				? categories.map( ( cat ) => cat?.id )
 				: [];
 
 			const latestPostsQuery = pickBy( {

--- a/src/blocks/post-carousel/edit.js
+++ b/src/blocks/post-carousel/edit.js
@@ -356,7 +356,12 @@ export default compose( [
 
 		const updatedQuery = () => {
 			const catIds = categories && categories.length > 0
-				? categories.map( ( cat ) => cat.id )
+				? categories.map( ( cat ) => {
+					if ( ! cat ) {
+						return null;
+					}
+					return cat.id;
+				} )
 				: [];
 
 			const latestPostsQuery = pickBy( {

--- a/src/blocks/post-carousel/inspector.js
+++ b/src/blocks/post-carousel/inspector.js
@@ -130,9 +130,20 @@ const Inspector = ( props ) => {
 			onCategoryChange={ ( tokens ) => {
 				// Categories that are already will be objects, while new additions will be strings (the name).
 				// allCategories nomalizes the array so that they are all objects.
-				const allCategories = tokens.map( ( token ) =>
-					typeof token === 'string' ? suggestions[ token ] : token
-				);
+				const allCategories = tokens.reduce( ( acc, curr ) => {
+					if ( typeof curr === 'string' ) {
+						const suggestedToken = suggestions[ curr ];
+
+						if ( suggestedToken ) {
+							acc.push( suggestedToken );
+						}
+					} else {
+						acc.push( curr );
+					}
+
+					return acc;
+				}, [] );
+
 				setAttributes( { categories: allCategories } );
 				if ( tokens.length < 2 ) {
 					setAttributes( { categoryRelation: 'or' } );

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -489,7 +489,7 @@ export default compose( [
 
 		const updatedQuery = () => {
 			const catIds = categories && categories.length > 0
-				? categories.map( ( cat ) => cat.id )
+				? categories.map( ( cat ) => cat?.id )
 				: [];
 
 			const latestPostsQuery = pickBy( {

--- a/src/blocks/posts/inspector.js
+++ b/src/blocks/posts/inspector.js
@@ -243,9 +243,19 @@ const Inspector = ( props ) => {
 			onCategoryChange={ ( tokens ) => {
 				// Categories that are already will be objects, while new additions will be strings (the name).
 				// allCategories nomalizes the array so that they are all objects.
-				const allCategories = tokens.map( ( token ) =>
-					typeof token === 'string' ? suggestions[ token ] : token
-				);
+				const allCategories = tokens.reduce( ( acc, curr ) => {
+					if ( typeof curr === 'string' ) {
+						const suggestedToken = suggestions[ curr ];
+
+						if ( suggestedToken ) {
+							acc.push( suggestedToken );
+						}
+					} else {
+						acc.push( curr );
+					}
+
+					return acc;
+				}, [] );
 				setAttributes( { categories: allCategories } );
 				if ( tokens.length < 2 ) {
 					setAttributes( { categoryRelation: 'or' } );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR handles the use case of a custom category entered into the feed settings for both the Posts and Post Carousel block. If an unrecognized, custom category is entered then no action is taken and no block error will be thrown.

Fixes #1974 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
