### PR TITLE
Issue 1989

### DIFF
--- a/src/blocks/accordion/accordion-item/styles/editor.scss
+++ b/src/blocks/accordion/accordion-item/styles/editor.scss
@@ -42,6 +42,10 @@
 		border-radius: 4px 4px 0 0;
 	}
 
+	&__content > .block-editor-inner-blocks > .block-editor-block-list__layout > .has-background {
+		padding: 0 !important;
+	}
+
 	// Set proper margin for the first and last item within the accordion item for < Gutenberg 6.3.
 	.wp-block:first-of-type .block-editor-block-list__block-edit {
 		margin-top: 4px;

--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -54,6 +54,10 @@
 		> div {
 			max-width: 100%;
 		}
+
+		& > .has-background {
+			padding: 0
+		}
 	}
 
 	.alignfull img {

--- a/src/blocks/services/service/styles/editor.scss
+++ b/src/blocks/services/service/styles/editor.scss
@@ -137,6 +137,10 @@
 	[data-type="core/buttons"] {
 		margin-top: 1.7em;
 	}
+
+	&__content > .block-editor-inner-blocks > .block-editor-block-list__layout > .has-background {
+		padding: 0 !important;
+	}
 }
 
 [data-type="coblocks/service"].is-selected.block-editor-block-list__block:focus::after {

--- a/src/blocks/services/service/styles/style.scss
+++ b/src/blocks/services/service/styles/style.scss
@@ -39,6 +39,12 @@
 		}
 	}
 
+	&__content {
+		& > .has-background {
+			padding: 0;
+		}
+	}
+
 }
 
 .wp-block-coblocks-service__figure {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
fixes #1989 

This PR explicitly removes padding from text-based inner blocks of the accordion item and service item blocks when a background color is set. The core functionality for text-based blocks is to add padding to the text when a background is set.

### Screenshots
<!-- if applicable -->

<img width="1438" alt="Screen Shot 2021-09-21 at 11 22 46 AM" src="https://user-images.githubusercontent.com/18115694/134199504-84acf618-6404-4ec6-ba78-b786ef34d6d0.png">

<img width="1438" alt="Screen Shot 2021-09-21 at 11 25 10 AM" src="https://user-images.githubusercontent.com/18115694/134199894-8758a9f1-6c1a-4ed3-8385-9fb8304dfd16.png">


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
