### PR TITLE
Black and white logo block - Issue 2023

### DIFF
--- a/src/blocks/logos/styles/style.scss
+++ b/src/blocks/logos/styles/style.scss
@@ -2,7 +2,7 @@
 
 	&.has-filter-grayscale img,
 	&.is-style-black-and-white img {
-		filter: grayscale(1) brightness(0);
+		filter: grayscale(1) brightness(0.9);
 	}
 
 	&.is-style-grayscale img {


### PR DESCRIPTION
### Description
Fixes #2023 

<!-- Please describe what you have changed or added -->
This PR increases the brightness for the black & white filter for the Logos block

### Screenshots
<!-- if applicable -->

Before:
<img width="1438" alt="Screen Shot 2021-09-21 at 11 29 27 AM" src="https://user-images.githubusercontent.com/18115694/134200606-1110d0fb-581c-4b14-8bd8-54560d4d10ac.png">

After:
<img width="1438" alt="Screen Shot 2021-09-21 at 11 30 29 AM" src="https://user-images.githubusercontent.com/18115694/134200792-fd51afb9-decd-4cbc-9416-c37c5f6f618b.png">


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bugfix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
