### PR TITLE
Try using getBlocks selectors directly to check performance gain

### DIFF
--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -23,6 +23,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import { ResizableBox, Spinner } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { isBlobURL } from '@wordpress/blob';
+import { getBlockAttributes } from '@wordpress/blocks';
 
 /**
  * Allowed blocks and template constant is passed to InnerBlocks precisely as specified here.
@@ -87,7 +88,6 @@ const Edit = ( props ) => {
 		clientId,
 		attributes,
 		getEditedPostAttribute,
-		getBlock,
 		editPost,
 		name,
 		isSelected,
@@ -141,15 +141,15 @@ const Edit = ( props ) => {
 
 	const saveMeta = ( type ) => {
 		const meta = getEditedPostAttribute( 'meta' );
-		const block = getBlock( clientId );
+		const block = getBlockAttributes( clientId );
 		let dimensions = {};
 
 		if ( typeof attributes.coblocks !== 'undefined' && typeof attributes.coblocks.id !== 'undefined' ) {
 			const id = name.split( '/' ).join( '-' ) + '-' + attributes.coblocks.id;
 			const newHeight = {
-				height: block.attributes[ type ],
-				heightTablet: block.attributes[ type + 'Tablet' ],
-				heightMobile: block.attributes[ type + 'Mobile' ],
+				height: block[ type ],
+				heightTablet: block[ type + 'Tablet' ],
+				heightMobile: block[ type + 'Mobile' ],
 			};
 
 			if ( typeof meta._coblocks_responsive_height === 'undefined' || ( typeof meta._coblocks_responsive_height !== 'undefined' && meta._coblocks_responsive_height === '' ) ) {
@@ -414,12 +414,10 @@ export default compose( [
 	} ),
 
 	withSelect( ( select ) => {
-		const { getBlock } = select( 'core/block-editor' );
 		const { getEditedPostAttribute } = select( 'core/editor' );
 
 		return {
 			getEditedPostAttribute,
-			getBlock,
 		};
 	} ),
 ] )( Edit );

--- a/src/blocks/shape-divider/edit.js
+++ b/src/blocks/shape-divider/edit.js
@@ -20,6 +20,7 @@ import InlineColorPicker from '../../components/inline-color-picker';
 import { useState, useEffect } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { ResizableBox } from '@wordpress/components';
+import { getBlockAttributes } from '@wordpress/blocks';
 
 /**
  * Block edit function
@@ -70,15 +71,15 @@ const Edit = ( props ) => {
 
 	const saveMeta = ( type ) => {
 		const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
-		const block = wp.data.select( 'core/block-editor' ).getBlock( clientId );
+		const block = getBlockAttributes( clientId );
 		let dimensions = {};
 
 		if ( typeof attributes.coblocks !== 'undefined' && typeof attributes.coblocks.id !== 'undefined' ) {
 			const id = name.split( '/' ).join( '-' ) + '-' + attributes.coblocks.id;
 			const height = {
-				height: block.attributes[ type ],
-				heightTablet: block.attributes[ type + 'Tablet' ],
-				heightMobile: block.attributes[ type + 'Mobile' ],
+				height: block[ type ],
+				heightTablet: block[ type + 'Tablet' ],
+				heightMobile: block[ type + 'Mobile' ],
 			};
 
 			if ( typeof meta._coblocks_responsive_height === 'undefined' || ( typeof meta._coblocks_responsive_height !== 'undefined' && meta._coblocks_responsive_height === '' ) ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
A performance issue is that the `getBlock` and `getBlocks` selectors are slow. [This is identified in this PR on the Gutenberg repo](https://github.com/WordPress/gutenberg/pull/33974). The language used makes me think that ideally, we should try to find a way to avoid using these selectors all together. Because we reference the props pulled from `getBlock(s)` selectors in a few blocks it makes removal of this logic complicated.

Another change identified in this PR is simply a different way of accessing the `getBlock(s)` APIs essentially directly as opposed to within a callback.

Both the Hero block and the Shape-Divider blocks have been refactored to remove the use of `getBlock(s)` selectors. All other uses of `getBlock(s)` are needed to reference the `innerBlocks` prop. 

I wonder if this could be different if we were using the V2 blocks API and useBlockProps. 🤔 



### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Testing performance change in CI.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
CI E2E, Jest and Performance.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
