### PR TITLE
Fix the resizable block handles for the Logos and Badges block

### DIFF
--- a/src/blocks/logos/logos.js
+++ b/src/blocks/logos/logos.js
@@ -5,14 +5,14 @@ import classnames from 'classnames';
 import { chunk, flatten } from 'lodash';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
-import { usePrevious } from '@wordpress/compose';
+import { useState, useEffect, forwardRef } from '@wordpress/element';
+import { usePrevious, useViewportMatch } from '@wordpress/compose';
 import { ResizableBox } from '@wordpress/components';
 import { BACKSPACE } from '@wordpress/keycodes';
 
-const Logos = ( props ) => {
+const Logos = ( props, ref ) => {
 	const {
 		isSelected,
 		attributes,
@@ -54,7 +54,9 @@ const Logos = ( props ) => {
 					<div className="wp-block-coblocks-logos__row" key={ 'wrapper-' + keyOuter }>
 						{ images.map( ( img, index ) => {
 							return (
-								<ResizableBox
+								<ResizableBoxContainer
+									axis="x"
+									ref={ ref }
 									key={ img.id + '-' + keyOuter + '-' + index }
 									minWidth="10%"
 									maxWidth={ ( 100 / images.length ) + '%' }
@@ -120,8 +122,7 @@ const Logos = ( props ) => {
 										data-width={ img.width || ( 100 / images.length ) + '%' }
 										tabIndex="0"
 									/>
-
-								</ResizableBox>
+								</ResizableBoxContainer>
 							);
 						} ) }
 					</div>
@@ -131,4 +132,19 @@ const Logos = ( props ) => {
 	);
 };
 
-export default Logos;
+const ResizableBoxContainer = forwardRef(
+	( { isSelected, isStackedOnMobile, ...props }, ref ) => {
+		const isMobile = useViewportMatch( 'small', '<' );
+		return (
+			<ResizableBox
+				ref={ ref }
+				showHandle={
+					isSelected && ( ! isMobile || ! isStackedOnMobile )
+				}
+				{ ...props }
+			/>
+		);
+	}
+);
+
+export default forwardRef( Logos );

--- a/src/blocks/logos/styles/editor.scss
+++ b/src/blocks/logos/styles/editor.scss
@@ -24,7 +24,7 @@
 		padding: 0 1.75vw;
 
 		&::before {
-			right: calc( 41% + .25vw );
+			right: calc(41% + 0.25vw);
 		}
 	}
 
@@ -32,7 +32,7 @@
 		padding: 0 1.75vw;
 
 		&::before {
-			right: calc( 39% + .25vw );
+			right: calc(39% + 0.25vw);
 		}
 	}
 }

--- a/src/blocks/logos/styles/editor.scss
+++ b/src/blocks/logos/styles/editor.scss
@@ -21,10 +21,18 @@
 	}
 
 	.components-resizable-box__handle-left {
-		left: 13px;
+		padding: 0 1.75vw;
+
+		&::before {
+			right: calc( 41% + .25vw );
+		}
 	}
 
 	.components-resizable-box__handle-right {
-		right: 14px;
+		padding: 0 1.75vw;
+
+		&::before {
+			right: calc( 39% + .25vw );
+		}
 	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Logos block resizable handles can overlap the image when the screen is zoomed in. We do a padding calculation on the resize container in order to allow proper spacing between logos block images and we attempt to compensate for that padding by setting explicit `right` CSS. 

Unfortunately, that solution was not complete due to the edge case of browser zoom. In order to compensate for a slight variation on spacing with various zoom settings, this PR alters the resize handles to be slightly apart from the image edge. This allows for a more consistent UX.

I also modify the way that we utilize the ResizableBox to match core standards with `forwardRef`.


### Screenshots
<!-- if applicable -->
**Old**
![image](https://user-images.githubusercontent.com/30462574/135149784-e2a66f08-e358-4501-bc7a-ff5c512729f6.png)

**New**
![image](https://user-images.githubusercontent.com/30462574/135150048-3bc4fbd2-c86f-45a5-be0a-41c45c6b4807.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JS. CSS.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually at various zoom settings. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
