### PR TITLE
WPEX-1512 set default color for social profiles with masked style and no social colors set

### DIFF
--- a/src/blocks/social-profiles/edit.js
+++ b/src/blocks/social-profiles/edit.js
@@ -72,7 +72,11 @@ const SocialProfilesEdit = ( props ) => {
 	}, [ isSelected, prevSelected, prevAlign, align, textAlign, currentIcon ] );
 
 	const getTextColor = ( isMaskStyle ) => {
-		return isMaskStyle ? backgroundColor.color : textColor.color;
+		if ( isMaskStyle ) {
+			return backgroundColor.color ? backgroundColor.color : 'black';
+		} 
+
+		return textColor.color;
 	};
 
 	const isMaskStyle = includes( className, 'is-style-mask' );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
With the masked style and no social colors selected for the Social Profiles block, the icons were no longer visible. This PR sets a default color to black in the event that no color has been set. 

### Screenshots
<!-- if applicable -->
Before:
https://user-images.githubusercontent.com/18115694/135293063-04edba73-35cf-4d3a-ad8b-6d8611819e49.mov

After:
https://user-images.githubusercontent.com/18115694/135293636-1ee915de-cd9c-4375-8f71-910c3025e3a7.mov


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
