### PR TITLE
Improve Gif block previews

### DIFF
--- a/src/blocks/gif/styles/editor.scss
+++ b/src/blocks/gif/styles/editor.scss
@@ -40,34 +40,25 @@
 		}
 
 		&__results {
-			align-content: stretch;
 			display: flex;
 			flex-direction: row;
 			flex-wrap: wrap;
 			justify-content: flex-start;
 			line-height: 1;
 			list-style: none;
-			margin: 0;
-			max-width: 430px;
+			margin: 1em 0 0 -5px;
 			padding: 0;
+			width: calc(100% + 10px);
 
 			li {
 				display: block;
 				flex: 0 0 auto;
-				height: 86px;
+				height: 100px;
 				margin: 0;
 				overflow: hidden;
-				padding: 3px;
+				padding: 5px;
 				position: relative;
-				width: 86px;
-
-				&:nth-child(1),
-				&:nth-child(2),
-				&:nth-child(3),
-				&:nth-child(4),
-				&:nth-child(5) {
-					margin-top: 1.5em;
-				}
+				width: auto;
 
 				img {
 					height: 100%;


### PR DESCRIPTION
### Description
Improve Gif block previews, mainly using 100% container width and keeping aspect ratio

### Screenshots
![image](https://user-images.githubusercontent.com/85305825/135315215-e08d88c5-4b01-4d4a-885b-91edeec6e83e.png)


### Types of changes
Visual changes

### How has this been tested?
Manually tested

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
