### PR TITLE
Fix custom colors on Alert block

### DIFF
--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -44,8 +44,8 @@ const Edit = ( props ) => {
 	useEffect( () => {
 		// Convert is-{type}-alert to is-style-{type}.
 		// See: https://github.com/godaddy-wordpress/coblocks/pull/781
-		if ( /is-\w+-alert/.test( attributes.className ) ) {
-			let newClassName = attributes.className;
+		if ( /is-\w+-alert/.test( className ) ) {
+			let newClassName = className;
 
 			newClassName = newClassName.replace( 'is-default-alert', 'is-style-info' );
 			newClassName = newClassName.replace( /is-(\w+)-alert/, 'is-style-$1' );
@@ -56,10 +56,10 @@ const Edit = ( props ) => {
 	useEffect( () => {
 		// Reset color selections when a new style has been selected.
 		// If the legacy alert class is detected, we want to retain the custom color selections.
-		if ( ! /is-\w+-alert/.test( prevClassName ) && prevClassName !== attributes.className ) {
-			setAttributes( { backgroundColor: '', customBackgroundColor: '', textColor: '', customTextColor: '' } );
+		if ( !! prevClassName && ! /is-\w+-alert/.test( prevClassName ) && prevClassName !== className ) {
+			setAttributes( { backgroundColor: undefined, customBackgroundColor: undefined, textColor: undefined, customTextColor: undefined } );
 		}
-	}, [ prevClassName, attributes ] );
+	}, [ prevClassName, className ] );
 
 	return (
 		<>


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR fixes the `useEffect` logic so that the user may properly apply custom colors to the Alert block.

[There is an ancillary issue that should be closed in concert](https://github.com/godaddy-wordpress/go/pull/696) in order to properly resolve this issue.

The linked issue on the Go repo prevents colors from properly applying on the front-end.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/135536092-c5189e05-a939-4245-991a-a15dc5909285.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
