### PR TITLE
Remove stacked gallery margin when gutter is set to 0

### DIFF
--- a/src/blocks/gallery-stacked/styles/editor.scss
+++ b/src/blocks/gallery-stacked/styles/editor.scss
@@ -16,8 +16,7 @@
 	// Fix issue where selected images are not wider than the viewport.
 	.coblocks-gallery--item:not(.is-appender) .coblocks-gallery--figure {
 		display: inline-block;
-		margin-left: 0;
-		margin-right: 0;
+		margin: 0;
 	}
 
 	.has-fullwidth-images .coblocks-gallery--figure {

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -18,6 +18,9 @@ class ResponsiveTabsControl extends Component {
 	}
 
 	setGutterTo( value ) {
+		if ( 0 === value ) {
+			this.props.setAttributes( { radius: value } );
+		}
 		this.props.setAttributes( { gutter: value } );
 	}
 


### PR DESCRIPTION
### Description
Setting the gutter to "0" should remove any spacing between images. This is not reflected when editing the page but is rendered properly to site visitors.

Additionally, when a gutter is applied (greater than zero), a setting to set the rounded corner size is available. The rounded corner settings should be reset or removed if the gutter is set to zero.

- [x] No spacing between images when gutter is set to zero.
- [x] No rounded corners on images when gutter is set to zero.
- [x] Verify display within the main block list, the preview from the inserter, and on the front-end

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/135685850-e0568ec8-37dd-4d27-9cdc-55d9ef1c8b50.png)

![image](https://user-images.githubusercontent.com/5321364/135685897-5c62d9dd-6d85-4269-8828-9d95d65217b2.png)

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
