### PR TITLE
Add an events block preview

### DIFF
--- a/src/blocks/events/example.js
+++ b/src/blocks/events/example.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const example = {
+	attributes: {},
+	innerBlocks: [
+		{
+			name: 'coblocks/events',
+			attributes: {},
+			innerBlocks: [
+				{
+					name: 'coblocks/event-item',
+					attributes: {
+						title: __( 'Soccer Practice', 'coblocks' ),
+						description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed placerat convallis porta.',
+						eventDay: '21',
+						eventMonth: __( 'April', 'coblocks' ),
+						eventYear: '2021',
+						eventTime: __( '10:30 AM', 'coblocks' ),
+						eventLocation: __( 'Middle School', 'coblocks' ),
+					},
+				},
+				{
+					name: 'coblocks/event-item',
+					attributes: {
+						title: __( 'Soccer Practice', 'coblocks' ),
+						description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed placerat convallis porta.',
+						eventDay: '21',
+						eventMonth: __( 'April', 'coblocks' ),
+						eventYear: '2021',
+						eventTime: __( '10:30 AM', 'coblocks' ),
+						eventLocation: __( 'Middle School', 'coblocks' ),
+					},
+				},
+			],
+		},
+	],
+};
+
+export default example;

--- a/src/blocks/events/index.js
+++ b/src/blocks/events/index.js
@@ -7,6 +7,7 @@ import { EventsIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies.
  */
 import edit from './edit';
+import example from './example';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -36,6 +37,7 @@ const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 	},
+	example,
 	transforms,
 	edit,
 	save,


### PR DESCRIPTION
### Description
Introduce an events block preview.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/135692335-ae0d0746-57b1-4290-b259-8a0e4d7c63fa.png)

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
