### PR TITLE
Click to tweet

### DIFF
--- a/src/blocks/click-to-tweet/styles/style.scss
+++ b/src/blocks/click-to-tweet/styles/style.scss
@@ -2,14 +2,14 @@
 	border: 1px solid transparent;
 	border-radius: 4px;
 	margin-bottom: 1.9em;
-	position: relative;
-	padding-top: var(--coblocks-spacing--3);
 	padding-bottom: var(--coblocks-spacing--4);
+	padding-top: var(--coblocks-spacing--3);
+	position: relative;
 
 	.wp-block-coblocks-click-to-tweet__text {
 		margin-bottom: 0;
-		padding-top: 0;
 		padding-left: 40px;
+		padding-top: 0;
 		position: relative;
 
 		&::before {

--- a/src/blocks/click-to-tweet/styles/style.scss
+++ b/src/blocks/click-to-tweet/styles/style.scss
@@ -3,9 +3,12 @@
 	border-radius: 4px;
 	margin-bottom: 1.9em;
 	position: relative;
+	padding-top: var(--coblocks-spacing--3);
+	padding-bottom: var(--coblocks-spacing--4);
 
-	&__text {
+	.wp-block-coblocks-click-to-tweet__text {
 		margin-bottom: 0;
+		padding-top: 0;
 		padding-left: 40px;
 		position: relative;
 
@@ -15,12 +18,16 @@
 			content: "";
 			display: inline-block;
 			height: 24px;
-			left: 0;
+			left: 29px;
 			mask-image: url(images/social/twitter.svg);
 			opacity: 0.3;
 			position: absolute;
 			top: 5px;
 			width: 24px;
+		}
+
+		&::after {
+			content: none;
 		}
 
 		a {


### PR DESCRIPTION
### Description
Augment CSS specificity to make sure we override Go styles that are attributed to Quotes and do not apply in this context.

### Screenshots
Before:
<img width="1820" alt="Before" src="https://user-images.githubusercontent.com/1933681/135905051-a0575a48-b7a4-4142-bc40-3df2a3bf3dc6.png">
After: 
<img width="1876" alt="After" src="https://user-images.githubusercontent.com/1933681/135905066-6c1c14fc-fd41-42b5-9232-8b4a5cc818d5.png">
