### PR TITLE
Update tar dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
 		"trim": "^0.0.3",
 		"node-fetch": "^2.6.1",
 		"normalize-url": "^6.0.1",
-		"yargs-parser": "^20.2.9"
+		"yargs-parser": "^20.2.9",
+	  	"tar": "^6.1.9"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
### Description
Resolve tar dependency version to >= 6.1.0 because there was a security vulnerability in older versions

### How has this been tested?
The automated tests still pass ;)
