### PR TITLE
Accessibility Accordion block

### DIFF
--- a/src/blocks/accordion/accordion-item/deprecated.js
+++ b/src/blocks/accordion/accordion-item/deprecated.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { getColorClassName, InnerBlocks, RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { attributes as blockAttributes } from './block.json';
+
+const deprecated = [
+	{
+		attributes: {
+			...blockAttributes,
+		},
+
+		save( { attributes } ) {
+			const {
+				backgroundColor,
+				customBackgroundColor,
+				customTextColor,
+				open,
+				textColor,
+				borderColor,
+				title,
+			} = attributes;
+
+			const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
+			const textColorClass = getColorClassName( 'color', textColor );
+
+			const titleClasses = classnames(
+				'wp-block-coblocks-accordion-item__title', {
+					'has-background': backgroundColor || customBackgroundColor,
+					[ backgroundColorClass ]: backgroundColorClass,
+					'has-text-color': textColor || customTextColor,
+					[ textColorClass ]: textColorClass,
+				} );
+
+			const titleStyles = {
+				backgroundColor: backgroundColorClass ? undefined : customBackgroundColor,
+				color: textColorClass ? undefined : customTextColor,
+			};
+
+			const borderStyle = {
+				borderColor: borderColor ? borderColor : customBackgroundColor,
+			};
+
+			return (
+				<div>
+					{ ! RichText.isEmpty( title ) &&
+					<details open={ open }>
+						<RichText.Content
+							tagName="summary"
+							className={ titleClasses }
+							value={ title }
+							style={ titleStyles }
+						/>
+						<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle }>
+							<InnerBlocks.Content />
+						</div>
+					</details>
+					}
+				</div>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/src/blocks/accordion/accordion-item/index.js
+++ b/src/blocks/accordion/accordion-item/index.js
@@ -9,6 +9,7 @@ import { AccordionItemIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -43,6 +44,7 @@ const settings = {
 	attributes,
 	edit,
 	save,
+	deprecated,
 };
 
 export { name, category, metadata, settings };

--- a/src/blocks/accordion/accordion-item/save.js
+++ b/src/blocks/accordion/accordion-item/save.js
@@ -49,7 +49,7 @@ const save = ( { attributes } ) => {
 					value={ title }
 					style={ titleStyles }
 				/>
-				<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle }>
+				<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle } tabIndex="0">
 					<InnerBlocks.Content />
 				</div>
 			</details>


### PR DESCRIPTION
### Description
Fixes #1962 

The inner content of accordion items is not tabbable

### Screenshots
<img width="633" alt="Screen Shot 2021-10-06 at 11 39 44" src="https://user-images.githubusercontent.com/85255688/136237332-971ef9eb-0822-4aa5-b85d-67d0b672a480.png">

### Types of changes
Accessibility improvement

### How has this been tested?
Manually
