### PR TITLE
Accordion inception - Issue 1645

### DIFF
--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -26,6 +26,16 @@ const TEMPLATE = [
 	[ 'core/paragraph', { placeholder: __( 'Add content…', 'coblocks' ) } ],
 ];
 
+const anySelectedBlocks = ( blocks, selectedClientId ) => {
+	return blocks.some( ( block ) => {
+		if ( block.clientId === selectedClientId ) {
+			return true;
+		}
+
+		return anySelectedBlocks( block.innerBlocks, selectedClientId );
+	} );
+};
+
 /**
  * Block edit function
  *
@@ -49,14 +59,14 @@ const AccordionItemEdit = ( props ) => {
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
-			getBlockRootClientId,
 			getBlocks,
 		} = select( 'core/block-editor' );
 
-		const hasSelectedChildren = getBlocks( props.clientId ).filter( ( elem ) => elem.clientId === getSelectedBlockClientId() || elem.clientId === getBlockRootClientId( getSelectedBlockClientId() ) );
+		const selectedBlock = getSelectedBlockClientId();
+		const anySelectedChildrenBlocks = anySelectedBlocks( getBlocks( props.clientId ), selectedBlock );
 
 		return {
-			isEditing: getSelectedBlockClientId() === props.clientId || hasSelectedChildren.length > 0,
+			isEditing: getSelectedBlockClientId() === props.clientId || anySelectedChildrenBlocks,
 		};
 	} );
 


### PR DESCRIPTION
This PR adds logic to the accordion item component to determine if the selected block client ID matches any of the inner blocks in a recursive manner.

Fixes #1645 

### Description
<!-- Please describe what you have changed or added -->
Previously, using an accordion block within the content of a parent accordion block would prohibit the user from entering content of the nested accordion block. The additional code will check if the selected block exists within the blocks hierarchy and will remain in an "open" state if this logic returns truthy.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Visually

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
