### PR TITLE
Add check for querySelector before using it for handle margins

### DIFF
--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -94,6 +94,10 @@ const withAdvancedControls = createHigherOrderComponent( ( BlockEdit ) => {
 		const withBlockSpacing = hasBlockSupport( name, 'coBlocksSpacing' );
 
 		const handleMargins = ( target ) => {
+			if ( ! target.querySelector ) {
+				return;
+			}
+
 			const innerAlignmentBlock = target.querySelector( '.wp-block[data-align]' );
 			const setInnerAlignmentBlock = ( margin, val ) => {
 				if ( !! innerAlignmentBlock ) {


### PR DESCRIPTION
### Description

When running `forEach` on `childNodes` not all nodes have the `querySelector` function and crashes and the message `This block has encountered an error and cannot be previewed` is displayed. It does not happen for all blocks. , As you can see in the screenshots we can different types of nodes and for example the text node type dosen't have a `querySelector` function.

We found this issue when we upgrade a WordPress site to 5.8.1 and had both CoBlocks 2.17.0 and Ghost Kit 2.19.4 installed. We started to investigate what caused this issue since we got it quiet often randomly and found that it crashed when `querySelector` didn't exists when updating margins on `wp-block` elements.

### Screenshots

![Screenshot 2021-10-08 at 14 08 04](https://user-images.githubusercontent.com/14610/136559626-ceadfd68-11da-45b1-a33a-1b6eb0ab43ca.png)

![image (19)](https://user-images.githubusercontent.com/14610/136559716-69d72237-b7da-49d0-985c-36712e6a8df7.png)

![Screenshot 2021-10-08 at 14 54 03](https://user-images.githubusercontent.com/14610/136560986-fda4d7f7-f190-46c5-9c37-d89d0146f0a1.png)
### Types of changes

The code change will check if the `target` has `querySelector` or not, for example:

```js
!document.querySelector
// => false
```

Or without that function it should crash and just stop doing anything

```js
const test = {}
!test.querySelector
// => true
```

So this change will prevent it from continue running `target.querySelector` function when it don't exists.

```js
if ( ! target.querySelector ) {
    return;
}
```

### How has this been tested?

We have just tested this locally and not sure how do automated the testing for this specific case in CoBlocks. 

We tested it by installing WordPress 5.8.1, CoBlocks 2.17.0 and Ghost Kit 2.19.4 on a fresh site, clicked `Add New` under `Pages` and hit enter key in the editor and then the "This block has encountered an error and cannot be previewed" message did show. 

### Checklist:
- [X] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
