### PR TITLE
Convert dispatch to useDispatch

### DIFF
--- a/src/blocks/events/edit.js
+++ b/src/blocks/events/edit.js
@@ -18,7 +18,7 @@ import { Toolbar, Placeholder, Button, TextControl, ServerSideRender } from '@wo
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { dispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
 import { edit } from '@wordpress/icons';
 
@@ -44,6 +44,8 @@ const EventsEdit = ( props ) => {
 		setAttributes,
 		clientId,
 	} = props;
+
+	const { insertBlock } = useDispatch( 'core/block-editor' );
 
 	const { innerBlocks } = useSelect( ( select ) => ( {
 		innerBlocks: select( 'core/block-editor' ).getBlocks( clientId ),
@@ -116,7 +118,7 @@ const EventsEdit = ( props ) => {
 
 	const insertNewItem = () => {
 		const newEvent = createBlock( 'coblocks/event-item' );
-		dispatch( 'core/block-editor' ).insertBlock( newEvent, innerBlocks.length, clientId );
+		insertBlock( newEvent, innerBlocks.length, clientId );
 	};
 
 	const toolbarControls = [

--- a/src/blocks/features/feature/edit.js
+++ b/src/blocks/features/feature/edit.js
@@ -20,7 +20,7 @@ import { useEffect } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
-import { dispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Constants
@@ -85,6 +85,8 @@ const Edit = ( props ) => {
 
 	const prevHeadingLevel = usePrevious( headingLevel );
 
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
 	useEffect( () => {
 		if (
 			headingLevel !== prevHeadingLevel
@@ -106,7 +108,7 @@ const Edit = ( props ) => {
 	const updateInnerAttributes = ( blockName, newAttributes ) => {
 		innerBlocks.forEach( ( item ) => {
 			if ( item.name === blockName ) {
-				dispatch( 'core/block-editor' ).updateBlockAttributes(
+				updateBlockAttributes(
 					item.clientId,
 					newAttributes
 				);


### PR DESCRIPTION
### Description
Converting `dispatch` to `useDispatch`. Only one `dispatch` will be remaining after this, in `components/dimensions-control` but I need to convert this file to a functional component first.

### How has this been tested?
Manually tested

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
