### PR TITLE
Add translated email string into email subject

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -47,8 +47,8 @@ class CoBlocks_Form {
 	 * @var string
 	 */
 	public function default_subject() {
-		// translators: placeholder for email shortcode.
-		return sprintf( __( 'Form submission from [%1$s]', 'coblocks' ), 'email' );
+		// translators: placeholder for 'email' string.
+		return sprintf( __( 'Form submission from [%1$s]', 'coblocks' ), __( 'email', 'coblocks' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Description
Se have seen reports that the email string in the form subject is not translated correctly. This PR fixes that issue. The shortcode is already using the site language for replacement so simply adding the email string on the sprintf method will work in that scenario.


![image](https://user-images.githubusercontent.com/1933681/137198433-41c7bf16-9fcf-44a1-8d4c-d58491017675.png)

