### PR TITLE
Fix ical file parser issues and CSS overhaul

### DIFF
--- a/includes/ical-parser/class-coblocks-ical.php
+++ b/includes/ical-parser/class-coblocks-ical.php
@@ -1813,8 +1813,6 @@ class CoBlocks_ICal {
 										$event_start_timestamp += self::SECONDS_IN_A_WEEK;
 									} while ( $event_start_timestamp <= $last_day_time_stamp );
 
-									// Move forwards
-									//                                  $recurring_timestamp = strtotime($offset, Carbon::createFromTimestamp($recurring_timestamp)->day(1)->timestamp);
 								}
 							}
 
@@ -2338,7 +2336,7 @@ class CoBlocks_ICal {
 
 		unset( $valid[''] );
 
-		if ( isset( $valid[ $timezone ] ) || in_array( $timezone, timezone_identifiers_list( \date_timezone::ALL_WITH_BC ), true ) ) {
+		if ( isset( $valid[ $timezone ] ) || in_array( $timezone, timezone_identifiers_list( \DateTimeZone::ALL_WITH_BC ), true ) ) {
 			$this->valid_iana_timezones[] = $timezone;
 
 			return true;
@@ -2371,7 +2369,7 @@ class CoBlocks_ICal {
 	 * Parses a duration and applies it to a date
 	 *
 	 * @param  string $date
-	 * @param  string $duration
+	 * @param  object $duration
 	 * @param  string $format
 	 * @return integer|\DateTime
 	 */
@@ -2628,7 +2626,7 @@ class CoBlocks_ICal {
 						$current_time_zone = self::TIME_ZONE_UTC;
 					}
 
-					$output[] = new \DateTime( $ical_date, $current_time_zone );
+					$output[] = new \DateTime( $ical_date, new \DateTimeZone( $current_time_zone ) );
 
 					if ( $key === $final_key ) {
 						// Reset to default
@@ -2766,7 +2764,7 @@ class CoBlocks_ICal {
 	/**
 	 * Checks if an excluded date matches a given date by reconciling time zones.
 	 *
-	 * @param  Carbon  $exdate
+	 * @param  DateTime  $exdate
 	 * @param  array   $an_event
 	 * @param  integer $recurring_offset
 	 * @return boolean
@@ -2775,16 +2773,16 @@ class CoBlocks_ICal {
 		$search_date = $an_event['DTSTART'];
 
 		if ( substr( $search_date, -1 ) === 'Z' ) {
-			$timezone = self::TIME_ZONE_UTC;
+			$timezone = new \DateTimeZone(self::TIME_ZONE_UTC);
 		} elseif ( isset( $an_event['DTSTART_array'][0]['TZID'] ) ) {
 			$timezone = $this->timezone_string_to_date_timezone( $an_event['DTSTART_array'][0]['TZID'] );
 		} else {
-			$timezone = $this->default_time_zone;
+			$timezone = new \DateTimeZone($this->default_time_zone);
 		}
 
 		$a = new \DateTime( $search_date, $timezone );
-		$b = $exdate->addSeconds( $recurring_offset );
+		$b = $exdate->add( \DateInterval::createFromDateString( $recurring_offset . ' seconds' ) );
 
-		return $a->eq( $b );
+		return $a == $b;
 	}
 }

--- a/src/blocks/events/edit.js
+++ b/src/blocks/events/edit.js
@@ -148,16 +148,26 @@ const EventsEdit = ( props ) => {
 				<Placeholder
 					icon="rss"
 					label={ __( 'Calendar URL', 'coblocks' ) }
+					instructions={ __(
+						'Enter a URL that loads and iCal formatted calendar.',
+						'coblocks'
+					) }
 				>
-					<TextControl
-						placeholder={ __( 'Enter URL here…', 'coblocks' ) }
-						value={ stateExternalCalendarUrl }
-						onChange={ ( newExternalCalendarUrl ) => setStateExternalCalendarUrl( newExternalCalendarUrl ) }
-						className={ 'components-placeholder__input' }
-					/>
-					<Button type="button" onClick={ saveExternalCalendarUrl } disabled={ ! stateExternalCalendarUrl }>
-						{ __( 'Use URL', 'coblocks' ) }
-					</Button>
+					<form onSubmit={ saveExternalCalendarUrl }>
+						<TextControl
+							className={ 'components-placeholder__input' }
+							onChange={ ( newExternalCalendarUrl ) => setStateExternalCalendarUrl( newExternalCalendarUrl ) }
+							placeholder={ __( 'Enter URL here…', 'coblocks' ) }
+							value={ stateExternalCalendarUrl }
+						/>
+						<Button
+							disabled={ ! stateExternalCalendarUrl }
+							isPrimary
+							type="submit"
+						>
+							{ __( 'Use URL', 'coblocks' ) }
+						</Button>
+					</form>
 				</Placeholder>
 			}
 

--- a/src/blocks/events/styles/editor.scss
+++ b/src/blocks/events/styles/editor.scss
@@ -1,5 +1,7 @@
 [data-type="coblocks/events"] {
 
+	@include input-submit-placeholder;
+
 	.coblocks-block-appender {
 		margin-top: 28px;
 	}

--- a/src/blocks/map/styles/editor.scss
+++ b/src/blocks/map/styles/editor.scss
@@ -1,25 +1,6 @@
 [data-type="coblocks/map"] {
 
-	.components-placeholder {
-		height: 100%;
-
-		.components-placeholder__fieldset {
-
-			.components-placeholder__input {
-				margin-right: 5px;
-				min-width: 50%;
-
-				.components-base-control__field {
-					height: 36px;
-					margin-right: 8px;
-				}
-			}
-
-			input {
-				height: 36px;
-			}
-		}
-
+	@include input-submit-placeholder {
 		.components-placeholder__label {
 
 			svg {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -40,3 +40,27 @@
 		@content;
 	}
 }
+@mixin input-submit-placeholder {
+	.components-placeholder {
+		height: 100%;
+
+		.components-placeholder__fieldset {
+
+			.components-placeholder__input {
+				margin-right: 5px;
+				min-width: 50%;
+
+				.components-base-control__field {
+					height: 36px;
+					margin-right: 8px;
+				}
+			}
+
+			input {
+				height: 36px;
+			}
+		}
+
+		@content;
+	}
+}


### PR DESCRIPTION
### Description
This would fix some oddities related to #1435. 

### Screenshots
Before:

<img width="852" alt="Screen Shot 2021-10-14 at 2 24 48 PM" src="https://user-images.githubusercontent.com/1933681/137378947-80e31d02-e929-43f5-86b5-cb3aa54a3f4b.png">

After:

<img width="746" alt="Screen Shot 2021-10-14 at 2 26 37 PM" src="https://user-images.githubusercontent.com/1933681/137378974-aa78f4d5-11eb-463e-ab61-86e9ff902e5e.png">

### Types of changes
- Fix PHP errors in class-coblocks-ical related to old use of Carbon class. 
- Move iCal calendar placeholder to use form and submit action to improve accessibility.
- Overhaul CSS to look like maps placeholder.
