### PR TITLE
Refactor DimensionsControl to functional component

### DIFF
--- a/src/components/dimensions-control/index.js
+++ b/src/components/dimensions-control/index.js
@@ -359,9 +359,9 @@ const DimensionsControl = ( props ) => {
 						<Button
 							className="components-coblocks-dimensions-control_sync"
 							aria-label={ __( 'Sync units', 'coblocks' ) }
-							isPrimary={ syncMode ? true : false }
-							isSecondary={ syncMode ? false : true }
-							aria-pressed={ syncMode ? true : false }
+							isPrimary={ !! syncMode }
+							isSecondary={ ! syncMode }
+							aria-pressed={ !! syncMode }
 							onClick={ () => syncUnitsOverwrite( device ) }
 							data-device-type={ device }
 							isSmall
@@ -461,7 +461,7 @@ const DimensionsControl = ( props ) => {
 							<span className="components-coblocks-dimensions-control__number-label">{ __( 'Right', 'coblocks' ) }</span>
 							<span className="components-coblocks-dimensions-control__number-label">{ __( 'Bottom', 'coblocks' ) }</span>
 							<span className="components-coblocks-dimensions-control__number-label">{ __( 'Left', 'coblocks' ) }</span>
-							<span className="components-coblocks-dimensions-control__number-label-blank"></span>
+							<span className="components-coblocks-dimensions-control__number-label-blank" />
 						</div>
 					</>
 					: <BaseControl id="textarea-1" label={ label } help={ help }>


### PR DESCRIPTION
### Description
Refactor DimensionsControl to fucntional component
Major code refactor to stop having ifs between padding and margin types
Use useDispatch instead of dispatch

### Types of changes
Code refactoring

### How has this been tested?
Manually testes

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
