### PR TITLE
issue-2026 handle undefined href from ImageURLInputUI

### DIFF
--- a/src/blocks/services/service/edit.js
+++ b/src/blocks/services/service/edit.js
@@ -198,7 +198,7 @@ const Edit = ( props ) => {
 	const onSetHref = ( { href: newHref, ...restArgs } ) => {
 		const newAttributes = { ...restArgs };
 
-		if ( newHref !== undefined || newHref !== href ) {
+		if ( newHref !== undefined ) {
 			newAttributes.href = newHref;
 		}
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR fixes an undefined href being set as a result of changing other fields within the `ImageURLInputUI` component.
Currently within the onChange event from `ImageURLInputUI` , any field that is touched will send an undefined value for the href key. When clearing the href using the UI, only an empty string will be passed. Undefined is only used if other fields are changed within the form (ie linkTarget, linkRel, linkClass). 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Visually, unit

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
