### PR TITLE
Fix: Recaptcha can be skipped by just not posting the g-recaptcha-token field

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -914,9 +914,10 @@ class CoBlocks_Form {
 
 		unset( $_POST['form-submit'], $_POST['_wp_http_referer'], $_POST['action'], $_POST['form-hash'], $_POST['coblocks-verify-email'], $_POST['email-field-id'], $_POST['name-field-id'] );
 
-		if ( isset( $_POST['g-recaptcha-token'] ) ) {
-
-			if ( ! $this->verify_recaptcha( $_POST['g-recaptcha-token'] ) ) {
+		$recaptcha_site_key   = get_option( 'coblocks_google_recaptcha_site_key' );
+		$recaptcha_secret_key = get_option( 'coblocks_google_recaptcha_secret_key' );
+		if ( $recaptcha_site_key && $recaptcha_secret_key ) {
+			if ( ! isset( $_POST['g-recaptcha-token'] ) || ! $this->verify_recaptcha( $_POST['g-recaptcha-token'] ) ) {
 
 				$this->remove_url_form_hash();
 


### PR DESCRIPTION
This pull request requires the g-recaptcha-token always if recaptcha is enabled.

Without this fix, a spammer can simply omit the g-recaptcha-token from the POST and nothing will be verified.

### Description

I changed the clause whether to check the recaptcha token based on the configuration (if both values are set, it is enabled)

### Types of changes
Bug fix / security issue (spam-protection is not reliable)

### How has this been tested?
I tested it:

First I sent the form normally and got the success message:

![image](https://user-images.githubusercontent.com/1087128/137596114-2cc9e9f5-0e48-4571-84c8-9517c1bb9270.png)

![image](https://user-images.githubusercontent.com/1087128/137596098-7af030e9-9d74-4499-84fb-58c9769eb0a0.png)

Now I deleted this part in the DOM:

![image](https://user-images.githubusercontent.com/1087128/137596120-9e3c4246-d59b-45f2-bb5a-0e3428081136.png)

I sent the form again -> I did not get a success message

