### PR TITLE
Restore mailhog php plugin install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,7 @@ commands:
       - wait_for_mysql
       - install_wordpress_with_coblocks
       - enable_debug_mode_for_e2e
+      - install_mailhog_plugin
       - start_wpcli_server
       - run:
           name: Run end to end tests (Cypress.io) - << parameters.browser >>
@@ -406,6 +407,14 @@ commands:
           command: |
             echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >> $BASH_ENV
             source /home/circleci/.bashrc
+
+  install_mailhog_plugin:
+    steps:
+      - run:
+          name: "Install Mailhog WP Plugin"
+          command: |
+            mkdir /tmp/wordpress/wp-content/mu-plugins
+            cp /home/circleci/project/.dev/mailhog.php /tmp/wordpress/wp-content/mu-plugins/mailhog.php
 
   setup_spec_files_diff_tree:
     steps:


### PR DESCRIPTION
### Description
Restore Mailhog php plugin install. Missing step to make WordPress interact with the mailhog server.
