### PR TITLE
Exclude test directory from coverage reporting

### DIFF
--- a/.dev/tests/jest/jest.config.js
+++ b/.dev/tests/jest/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
 	},
 	collectCoverageFrom: [
 		'<rootDir>/src/**/*.js',
+		'!<rootDir>/src/**/test/*.js',
 	],
 };


### PR DESCRIPTION
### Description
test folder inside blocks are not meant to be unit tested or shoulnd't count towards coverage value.
