### PR TITLE
Add additional E2E test job for last major WP release 5.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,7 @@ commands:
         type: string
       wpversion:
         type: string
+        default: latest
     steps:
       - checkout
       - setup_e2e_env_var


### PR DESCRIPTION
This PR renames the current end-to-end jobs to `e2e_chrome_wp_latest` and `e2e_firefox_wp_latest` to indicate they are testing the latest WordPress release.

A new job has been added name `e2e_chrome_wp_5_7` to indicate it is testing the last major release of WordPress.