### PR TITLE
Remove jQuery from Recaptcha script

### DIFF
--- a/src/js/coblocks-google-recaptcha.js
+++ b/src/js/coblocks-google-recaptcha.js
@@ -1,26 +1,17 @@
 /*global grecaptcha coblocksFormBlockAtts*/
-import jQuery from 'jquery';
 
-( function( $ ) {
-	const coblocksRecaptcha = {
+const initRecaptcha = () => {
+	const recaptchaFields = Array.from( document.getElementsByClassName( 'g-recaptcha-token' ) );
 
-		init() {
-			const recaptchaFields = $( '.g-recaptcha-token' );
+	if ( ! recaptchaFields.length ) {
+		return;
+	}
 
-			if ( ! recaptchaFields.length ) {
-				return;
-			}
+	recaptchaFields.forEach( ( field ) => {
+		grecaptcha.execute( coblocksFormBlockAtts.recaptchaSiteKey, { action: 'coblocks' } ).then( ( token ) => {
+			field.value = token;
+		} );
+	} );
+};
 
-			recaptchaFields.each( function() {
-				const $recaptchaTokenField = $( this );
-
-				grecaptcha.execute( coblocksFormBlockAtts.recaptchaSiteKey, { action: 'coblocks' } ).then( function( token ) {
-					$recaptchaTokenField.val( token );
-				} );
-			} );
-		},
-
-	};
-
-	grecaptcha.ready( coblocksRecaptcha.init );
-}( jQuery ) );
+grecaptcha.ready( initRecaptcha );


### PR DESCRIPTION
### Description
Another task in #1365 

### Types of changes
Refactor

### How has this been tested?
Manually, by making sure that the Recaptcha script is still called when using a form.

### Checklist:
- [X] My code is tested
- [X] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
