### PR TITLE
Don't lint the files if there is no files found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,7 +655,7 @@ jobs:
       - run:
           name: "Linting JS"
           command: |
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
+            if [[ "$CIRCLE_BRANCH" == "master" || -z "$FILES" ]]; then
               exit 0
             else
               yarn lint:js $FILES


### PR DESCRIPTION
### Description
I just added a condition to not lint the JS files when there is no files changed because when doing PRs like #2134 where there is no JS file modified, it will lint everything (and fail because of the 5k+ linting errors due to ordering).