### PR TITLE
Update minimum WP version to 5.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author URI: https://www.godaddy.com
 Contributors: godaddy, richtabor, eherman24, jonathanbardo, jrtashjian, paranoia1906, fjarrett
 Tags: page builder, Gutenberg blocks, WordPress blocks, gutenberg, blocks
-Requires at least: 5.0
+Requires at least: 5.5
 Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 2.18.1


### PR DESCRIPTION
### Description
This is a documentation change and a change that will be reflected in the plugin website.
When trying the current version of CoBlocks (2.18.1) on earlier versions of WordPress, it works well on WordPress 5.5 but everything breaks in WordPress 5.4.

### How has this been tested?
With automated tests for the latest versions but manually for 5.6 and 5.5 (because the automated tests are failing not because of bugs but because of API changes).
