### PR TITLE
Filter comments to return godaddy bot comments only

### DIFF
--- a/.dev/bin/comment-on-pr.sh
+++ b/.dev/bin/comment-on-pr.sh
@@ -50,7 +50,7 @@ BOT_COMMENTS=$(curl -sS \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_ID/comments")
 
-COMMENT=$(echo $BOT_COMMENTS | jq '[.[] | select( .user.login == "godaddy-wordpress-bot" and ( .body | contains( "Code Coverage" ) | not ) and ( .body | contains( "Test summary" ) | not ) )]' | jq '.[-1]')
+COMMENT=$(echo $BOT_COMMENTS | jq '[.[] | select( .user.login == "godaddy-wordpress-bot" and ( .body | contains( "Code Coverage" ) | not ) )]' | jq '.[-1]')
 
 # Bot has not commented on the issue, create new comment
 if [ 'null' == "$COMMENT" ]; then

--- a/.dev/bin/comment-on-pr.sh
+++ b/.dev/bin/comment-on-pr.sh
@@ -50,7 +50,7 @@ BOT_COMMENTS=$(curl -sS \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_ID/comments")
 
-COMMENT=$(echo $BOT_COMMENTS | jq '.[-1]')
+COMMENT=$(echo $BOT_COMMENTS | jq '[.[] | select( .user.login == "godaddy-wordpress-bot" and ( .body | contains("Code Coverage") | not ) )]' | jq '.[-1]')
 
 # Bot has not commented on the issue, create new comment
 if [ 'null' == "$COMMENT" ]; then

--- a/.dev/bin/comment-on-pr.sh
+++ b/.dev/bin/comment-on-pr.sh
@@ -50,7 +50,7 @@ BOT_COMMENTS=$(curl -sS \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_ID/comments")
 
-COMMENT=$(echo $BOT_COMMENTS | jq '[.[] | select( .user.login == "godaddy-wordpress-bot" and ( .body | contains("Code Coverage") | not ) )]' | jq '.[-1]')
+COMMENT=$(echo $BOT_COMMENTS | jq '[.[] | select( .user.login == "godaddy-wordpress-bot" and ( .body | contains( "Code Coverage" ) | not ) and ( .body | contains( "Test summary" ) | not ) )]' | jq '.[-1]')
 
 # Bot has not commented on the issue, create new comment
 if [ 'null' == "$COMMENT" ]; then


### PR DESCRIPTION
There is a small bug where the bot overwrites the last comment left. This PR adds a check for latest comment by the godaddy WordPress bot, that does not contain "Code Coverage" in it. The Cypress bot currently uses the same github key to leave comments.

If you push multiple times on your first commit, there may be multiple comments because the github API hasn't updated to reflect the last comment by the bot. This usually takes a few minutes. Once one comment is left, the same comment should be updated for each push.