### PR TITLE
@wordpress/no-global-event-listener disable is not needed anymore

### DIFF
--- a/src/js/coblocks-accordion-polyfill.js
+++ b/src/js/coblocks-accordion-polyfill.js
@@ -19,9 +19,6 @@ void ( function( root, factory ) {
 	// Add a classname
 	document.documentElement.className += ' no-details';
 
-	// Disable note: This rule is only meant to be used for React components
-	// See https://github.com/WordPress/gutenberg/pull/26810
-	// eslint-disable-next-line @wordpress/no-global-event-listener
 	window.addEventListener( 'click', clickHandler );
 
 	injectStyle( 'details-polyfill-style',

--- a/src/js/coblocks-checkbox-required.js
+++ b/src/js/coblocks-checkbox-required.js
@@ -1,6 +1,3 @@
-// Disable note: This rule is only meant to be used for React components
-// See https://github.com/WordPress/gutenberg/pull/26810
-// eslint-disable-next-line @wordpress/no-global-event-listener
 document.addEventListener( 'DOMContentLoaded', function() {
 	document.querySelectorAll( '.coblocks-form form' ).forEach( ( form ) => {
 		const requiredErrorDiv = form.getElementsByClassName( 'required-error' )[ 0 ];


### PR DESCRIPTION
### Description
It seems to have been removed as a warning, at least for pure JS files.