### PR TITLE
Cleanup helpers.js + remove a warning

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -106,21 +106,12 @@ export function disableGutenbergFeatures() {
 			safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
 		}
 
-		if ( !! safeWin.wp.data.select( 'core/nux' ) ) { // < GB 7.2 || < WP 5.4
-			if ( ! safeWin.wp.data.select( 'core/nux' ).areTipsEnabled() ) {
-				return;
-			}
-
-			safeWin.wp.data.dispatch( 'core/nux' ).disableTips();
-			safeWin.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
-		} else { // GB 7.2 || WP 5.4
-			if ( ! safeWin.wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
-				return;
-			}
-
-			safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-			safeWin.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
+		if ( ! safeWin.wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
+			return;
 		}
+
+		safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+		safeWin.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
 	} );
 }
 
@@ -233,9 +224,8 @@ export function clearBlocks() {
  */
 export function getBlockSlug() {
 	const specFile = Cypress.spec.name;
-	const fileBase = ( specFile.split( '/' ).pop().replace( '.cypress.js', '' ) );
 
-	return fileBase;
+	return ( specFile.split( '/' ).pop().replace( '.cypress.js', '' ) );
 }
 
 /**
@@ -476,20 +466,6 @@ export function addCustomBlockClass( classes, blockID = '' ) {
 }
 
 /**
- * Press the Undo button in the header toolbar.
- */
-export function doEditorUndo() {
-	cy.get( '.editor-history__undo' ).click( { force: true } );
-}
-
-/**
- * Press the Redo button in the header toolbar.
- */
-export function doEditorRedo() {
-	cy.get( '.editor-history__redo' ).click();
-}
-
-/**
  * Open the Editor Settings panel.
  */
 export function openEditorSettingsModal() {
@@ -501,38 +477,6 @@ export function openEditorSettingsModal() {
 
 	// Ensure settings have loaded.
 	cy.get( '.coblocks-settings-modal input[type="checkbox"]' ).should( 'have.length', 6 );
-}
-
-/**
- * Turn off a setting from the Editor Settings panel.
- *
- * @param {string} settingName The label of the setting control.
- */
-export function turnOffEditorSetting( settingName ) {
-	cy.get( '.components-base-control' ).contains( settingName ).parent().find( 'input[type=checkbox]' )
-		.then( ( element ) => {
-			if ( element[ 0 ].checked ) {
-				element.click();
-			}
-		} );
-
-	cy.get( '.components-base-control' ).contains( settingName ).parent().find( 'input[type=checkbox]' ).should( 'not.be.checked' );
-}
-
-/**
- * Turn on a setting from the Editor Settings panel.
- *
- * @param {string} settingName The label of the setting control.
- */
-export function turnOnEditorSetting( settingName ) {
-	cy.get( '.components-base-control' ).contains( settingName ).parent().find( 'input[type=checkbox]' )
-		.then( ( element ) => {
-			if ( ! element[ 0 ].checked ) {
-				element.click();
-			}
-		} );
-
-	cy.get( '.components-base-control' ).contains( settingName ).parent().find( 'input[type=checkbox]' ).should( 'be.checked' );
 }
 
 /**
@@ -559,19 +503,6 @@ export function hexToRGB( hex ) {
 	}
 
 	return 'rgb(' + +r + ', ' + +g + ', ' + +b + ')';
-}
-
-/**
- * Capitalize the first letter of each word in a string.
- * eg: hello world => Hello World
- *
- * @param {string} string The text to capitalize.
- * @return {string} Altered string with capitalized letters.
- */
-export function capitalize( string ) {
-	return string.replace( /(?:^|\s)\S/g, function( a ) {
-		return a.toUpperCase();
-	} );
 }
 
 function getIframeDocument( containerClass ) {

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -190,7 +190,7 @@ const withAdvancedControls = createHigherOrderComponent( ( BlockEdit ) => {
 									} );
 
 									const nextBlockClientId = wp.data
-										.select( 'core/editor' )
+										.select( 'core/block-editor' )
 										.getNextBlockClientId( clientId );
 									if ( nextBlockClientId && ! noBottomMargin ) {
 										wp.data


### PR DESCRIPTION
### Description
This is essentially a PR to remove dead code : 
- In the first if, we remove the condition that was used before WP 5.4 (we now support > 5.5 and test only > 5.7)
- In the getBlockSlug it is only a simplification of the code
- After that, it's just removing unused functions
- The last line modified in index.js it's using `select( 'core/block-editor' )` instead of `select( 'core/editor' )`, which is deprecated (there was a warning message about it).
