### PR TITLE
Add a check in the aggregate_perf_test_results build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -815,7 +815,7 @@ jobs:
     steps:
       - run:
           name: Check branch
-          run: |
+          command: |
             if [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "develop" ]; then
               echo "Performance tests are not run on this branch."
               circleci-agent step halt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -813,6 +813,13 @@ jobs:
   aggregate_perf_test_results:
     executor: php_74_node_browser_mysql
     steps:
+      - run:
+          name: Check branch
+          run: |
+            if [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "develop" ]; then
+              echo "Performance tests are not run on this branch."
+              circleci-agent step halt
+            fi
       - checkout
       - attach_workspace:
           at: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,6 +823,13 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/project
+      - run:
+          name: Check for performance test result files.
+          command: |
+            if [ ! -f "../master-median-results.json" ] || [ ! -f "../$CIRCLE_BRANCH-median-results.json" ]; then
+              echo "Performance tests results not found."
+              exit 1
+            fi
       - changed_files_with_extension:
           ext: ".js"
       - setup_spec_files_diff_tree


### PR DESCRIPTION
### Description
Fix the `aggregate` job, by not running the job on `master` or `develop` branches. 
https://app.circleci.com/pipelines/github/godaddy-wordpress/coblocks/7772/workflows/33689bef-f795-4944-aff8-15308a05462f/jobs/35982

### Types of changes
Bug fix (non-breaking change which fixes an issue) 