### PR TITLE
Fix Google Maps marker assets path, so that the marker shows on the Map block

### DIFF
--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -141,7 +141,7 @@ class Edit extends Component {
 
 		const marker = {
 			url:
-				'/wp-content/plugins/coblocks/assets/images/markers/' +
+				'/wp-content/plugins/coblocks/assets/markers/' +
 				skin +
 				'.svg',
 			scaledSize: { width: iconSize, height: iconSize },

--- a/src/js/coblocks-google-maps.js
+++ b/src/js/coblocks-google-maps.js
@@ -53,7 +53,7 @@ const renderMap = ( elements ) => {
 					gmapAttr.iconSize,
 					gmapAttr.iconSize
 				),
-				url: coblocksGoogleMaps.url + '/assets/images/markers/' + gmapAttr.skin + '.svg',
+				url: coblocksGoogleMaps.url + '/assets/markers/' + gmapAttr.skin + '.svg',
 			},
 			map,
 			position: new google.maps.LatLng( gmapAttr.lat, gmapAttr.lng ),


### PR DESCRIPTION
### Description
The files were moved, but this path was probably forgotten in the move.

Should also fix #2179 

### Screenshots
Before

<img width="670" alt="Screen Shot 2021-11-25 at 15 09 42" src="https://user-images.githubusercontent.com/85255688/143496276-a1b8f023-6742-4000-abbf-02be33d82cb4.png">

After
<img width="670" alt="Screen Shot 2021-11-25 at 15 12 34" src="https://user-images.githubusercontent.com/85255688/143496285-7a04ea57-f042-4ccf-91f5-85509491a605.png">

### Types of changes
Bug fix

### How has this been tested?
Visually

### Checklist:
- [X] My code is tested
- [X] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->