### PR TITLE
Disable perf tests temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,23 +203,23 @@ workflows:
       #      - js
 
       # PERF TESTING
-      - master_perf_tests:
-          filters:
-            tags:
-              only: /^(?!canary).*$/
+      # - master_perf_tests:
+      #    filters:
+      #      tags:
+      #        only: /^(?!canary).*$/
 
-      - current_perf_tests:
-          filters:
-            tags:
-              only: /^(?!canary).*$/
+      # - current_perf_tests:
+      #    filters:
+      #      tags:
+      #        only: /^(?!canary).*$/
 
-      - aggregate_perf_test_results:
-          filters:
-            tags:
-              only: /^(?!canary).*$/
-          requires:
-            - current_perf_tests
-            - master_perf_tests
+      # - aggregate_perf_test_results:
+      #    filters:
+      #      tags:
+      #        only: /^(?!canary).*$/
+      #    requires:
+      #      - current_perf_tests
+      #      - master_perf_tests
 
       - canary-release:
           filters:


### PR DESCRIPTION
### Description
For the moment, these tests are broken and don't provide value, while breaking our build.
