### PR TITLE
Remove the From header in the form block

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -961,7 +961,8 @@ class CoBlocks_Form {
 		 */
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
-		$reply_to = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
+		$sender_name  = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : '';
+		$sender_email = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : '';
 
 		/**
 		 * Filter the form email headers.
@@ -973,7 +974,7 @@ class CoBlocks_Form {
 		$email_headers = (array) apply_filters(
 			'coblocks_form_email_headers',
 			array(
-				"Reply-To: {$reply_to}",
+				"Reply-To: {$sender_name} <{$sender_email}>",
 			),
 			$_POST,
 			$post_id

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -964,7 +964,7 @@ class CoBlocks_Form {
 		$sender_email = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : '';
 		$sender_name  = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : '';
 
-		$headers = [];
+		$headers = array();
 
 		if ( ! empty( $sender_email ) ) {
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -961,8 +961,7 @@ class CoBlocks_Form {
 		 */
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
-		$reply_to  = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
-		$from_name = ( isset( $_POST[ $name_field_id ]['value'] ) && ! empty( $_POST[ $name_field_id ]['value'] ) ) ? esc_html( $_POST[ $name_field_id ]['value'] ) . " <{$reply_to}>" : /* translators: 1. Reply to email address; eg: email@example.com */ sprintf( __( 'Form Submission <%s>', 'coblocks' ), $reply_to );
+		$reply_to = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : esc_html( get_bloginfo( 'admin_email' ) );
 
 		/**
 		 * Filter the form email headers.
@@ -974,7 +973,6 @@ class CoBlocks_Form {
 		$email_headers = (array) apply_filters(
 			'coblocks_form_email_headers',
 			array(
-				"From: {$from_name}",
 				"Reply-To: {$reply_to}",
 			),
 			$_POST,

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -961,8 +961,16 @@ class CoBlocks_Form {
 		 */
 		$email_content = (string) apply_filters( 'coblocks_form_email_content', $this->email_content, $_POST, $post_id );
 
-		$sender_name  = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : '';
 		$sender_email = isset( $_POST[ $email_field_id ]['value'] ) ? esc_html( $_POST[ $email_field_id ]['value'] ) : '';
+		$sender_name  = isset( $_POST[ $name_field_id ]['value'] ) ? esc_html( $_POST[ $name_field_id ]['value'] ) : '';
+
+		$headers = [];
+
+		if ( ! empty( $sender_email ) ) {
+
+			$headers[] = empty( $sender_name ) ? "Reply-To: {$sender_email}" : "Reply-To: {$sender_name} <{$sender_email}>";
+
+		}
 
 		/**
 		 * Filter the form email headers.
@@ -973,9 +981,7 @@ class CoBlocks_Form {
 		 */
 		$email_headers = (array) apply_filters(
 			'coblocks_form_email_headers',
-			array(
-				"Reply-To: {$sender_name} <{$sender_email}>",
-			),
+			$headers,
 			$_POST,
 			$post_id
 		);


### PR DESCRIPTION
Resolves #1969 and #2148

### Description
Remove the "From" header when the form block sends an email address. This is to help mitigate the issue of email providers marking the emails as spam. In this solution we are leaving all default `wp_mail()` headers, except we are setting a custom `Reply-To` header.

### Screenshots

#### Email + Name
![image](https://user-images.githubusercontent.com/5321364/145636376-26a88220-79ec-41e4-b3a3-406fecc835b2.png)

#### Email + No Name
![image](https://user-images.githubusercontent.com/5321364/145636448-02cbd4d5-020b-451a-a973-78c83c47f267.png)

#### No Email + Name
![image](https://user-images.githubusercontent.com/5321364/145636566-9348a00a-1360-4fd0-bd83-c5d1aeb3affd.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
