### PR TITLE
Fix Media Filter Controls Cypress tests in WP 5.9

### DIFF
--- a/src/components/media-filter-control/test/media-filter-control.cypress.js
+++ b/src/components/media-filter-control/test/media-filter-control.cypress.js
@@ -141,7 +141,7 @@ describe( 'Test CoBlocks Media Filter Control component', function() {
 
 			const filterSlug = filters[ i ].toLowerCase();
 
-			cy.get( '[data-type="core/gallery"]' )
+			cy.get( '[data-type="core/gallery"] figure, [data-type="core/gallery"]' )
 				.should( 'have.class', 'has-filter-' + filterSlug );
 
 			helpers.savePage();


### PR DESCRIPTION
### Description
Fix tests that were failing in WP 5.9 beta 2 because of the changes in the way the Gallery is working.

### How has this been tested?
By running Cypress tests on WP 5.9 beta 2
