### PR TITLE
Remove coverage from masonry block v1

### DIFF
--- a/.dev/tests/jest/jest.config.js
+++ b/.dev/tests/jest/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
 	collectCoverageFrom: [
 		'<rootDir>/src/blocks/**/save.js',
 		'<rootDir>/src/blocks/**/transforms.js',
+		'!<rootDir>/src/blocks/gallery-masonry/v1/*.js',
 	],
 	moduleNameMapper: {
 		'@godaddy-wordpress/coblocks-icons': require.resolve(


### PR DESCRIPTION
### Description
Disable coverage report for old masonry v1 block.
