### PR TITLE
Check global CoBlocks data to determine if typography controls are enabled

### DIFF
--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -20,9 +20,9 @@ import TypographyTransforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
+import { useEntityProp } from '@wordpress/core-data';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, ifCondition } from '@wordpress/compose';
-import { useEntityProp } from '@wordpress/core-data';
 import {
 	Dropdown,
 	RangeControl,
@@ -274,7 +274,7 @@ export default compose( [
 	ifCondition( () => {
 		const [ typographyEnabled ] = useEntityProp( 'root', 'site', 'coblocks_typography_controls_enabled' );
 
-		if ( Boolean( coblocksBlockData.typographyControlsEnabled ) === true && typographyEnabled !== false  ) {
+		if ( Boolean( coblocksBlockData.typographyControlsEnabled ) === true && typographyEnabled !== false ) {
 			return true;
 		}
 		return false;

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, ifCondition } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
 import {
 	Dropdown,
 	RangeControl,
@@ -271,7 +272,9 @@ class TypographyControls extends Component {
 export default compose( [
 	applyFallbackStyles,
 	ifCondition( () => {
-		if ( Boolean( coblocksBlockData.typographyControlsEnabled ) === true ) {
+		const [ typographyEnabled ] = useEntityProp( 'root', 'site', 'coblocks_typography_controls_enabled' );
+
+		if ( Boolean( coblocksBlockData.typographyControlsEnabled ) === true && typographyEnabled !== false  ) {
 			return true;
 		}
 		return false;

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -1,3 +1,5 @@
+/*global coblocksBlockData*/
+
 /**
  * External dependencies
  */
@@ -18,7 +20,6 @@ import TypographyTransforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
-import { useEntityProp } from '@wordpress/core-data';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, ifCondition } from '@wordpress/compose';
 import {
@@ -270,7 +271,9 @@ class TypographyControls extends Component {
 export default compose( [
 	applyFallbackStyles,
 	ifCondition( () => {
-		const [ typographyEnabled ] = useEntityProp( 'root', 'site', 'coblocks_typography_controls_enabled' );
-		return typographyEnabled;
+		if ( Boolean( coblocksBlockData.typographyControlsEnabled ) === true ) {
+			return true;
+		}
+		return false;
 	} ),
 ] )( TypographyControls );


### PR DESCRIPTION
### Description
This PR fixes an issue where in some cases the global variable `typographyControlsEnabled` was being found as undefined which would cause the Typography controls to render in some cases but not in others. By virtue of being able to access the editor, users should be able to edit typography controls (as long as this variable is set to true).

https://user-images.githubusercontent.com/18115694/146565874-6a977b00-ae6e-4604-9235-eb52e410ba8d.mov


Fixes #2103 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually, testing with different user roles

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
