### PR TITLE
Fix Cypress tests that were sometimes failing because of lazy loading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,24 +171,10 @@ workflows:
           filters:
             tags:
               only: /^(?!canary).*$/
-          requires:
-            - css
-            - unit_testing_php_56
-            - unit_testing_php_73
-            - unit_testing_php_74
-            - unit_testing_php_80
-            - js
       - e2e_firefox_wp_latest:
           filters:
             tags:
               only: /^(?!canary).*$/
-          requires:
-            - css
-            - unit_testing_php_56
-            - unit_testing_php_73
-            - unit_testing_php_74
-            - unit_testing_php_80
-            - js
 
       # - e2e_chrome_wp_previous_major:
       #    filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,10 +171,14 @@ workflows:
           filters:
             tags:
               only: /^(?!canary).*$/
+          requires:
+            - build
       - e2e_firefox_wp_latest:
           filters:
             tags:
               only: /^(?!canary).*$/
+          requires:
+            - build
 
       # - e2e_chrome_wp_previous_major:
       #    filters:

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -400,7 +400,6 @@ export function setColorSetting( settingName, hexColor ) {
  * @param {RegExp} panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
-	cy.wait( 500 );
 	cy.get( '.components-panel__body' )
 		.contains( panelText )
 		.then( ( $panelTop ) => {

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -138,7 +138,7 @@ export function addBlockToPost( blockName, clearEditor = false ) {
 	cy.get( '.block-editor-inserter__search-input,input.block-editor-inserter__search, .components-search-control__input' ).click().type( blockName );
 
 	const targetClassName = ( blockCategory === 'core' ? '' : `-${ blockCategory }` ) + `-${ blockID }`;
-	cy.get( '.editor-block-list-item' + targetClassName ).first().click( { force: true } );
+	cy.get( '.editor-block-list-item' + targetClassName ).first().click();
 
 	// Make sure the block was added to our page
 	cy.get( `[class*="-visual-editor"] [data-type="${ blockName }"]` ).should( 'exist' ).then( () => {

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -400,7 +400,8 @@ export function setColorSetting( settingName, hexColor ) {
  * @param {RegExp} panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
-	cy.contains( panelText )
+	cy.get( '.components-panel__body' )
+		.contains( panelText )
 		.then( ( $panelTop ) => {
 			const $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );
 			if ( ! $parentPanel.hasClass( 'is-opened' ) ) {

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -238,7 +238,7 @@ export function setBlockStyle( style ) {
 
 	cy.get( '.edit-post-sidebar [class*="editor-block-styles"]' )
 		.contains( RegExp( style, 'i' ) )
-		.click( { force: true } );
+		.click();
 }
 
 /**

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -400,8 +400,7 @@ export function setColorSetting( settingName, hexColor ) {
  * @param {RegExp} panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
-	cy.get( '.components-panel__body' )
-		.contains( panelText )
+	cy.contains( panelText )
 		.then( ( $panelTop ) => {
 			const $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );
 			if ( ! $parentPanel.hasClass( 'is-opened' ) ) {

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -400,6 +400,7 @@ export function setColorSetting( settingName, hexColor ) {
  * @param {RegExp} panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
+	cy.wait( 250 );
 	cy.get( '.components-panel__body' )
 		.contains( panelText )
 		.then( ( $panelTop ) => {

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -400,7 +400,7 @@ export function setColorSetting( settingName, hexColor ) {
  * @param {RegExp} panelText The panel label text to open. eg: Color Settings
  */
 export function openSettingsPanel( panelText ) {
-	cy.wait( 250 );
+	cy.wait( 500 );
 	cy.get( '.components-panel__body' )
 		.contains( panelText )
 		.then( ( $panelTop ) => {

--- a/src/blocks/icon/test/icon.cypress.js
+++ b/src/blocks/icon/test/icon.cypress.js
@@ -31,6 +31,8 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block style.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		cy.contains( 'Styles' );
+
 		helpers.openSettingsPanel( 'Styles' );
 
 		cy.get( '.block-editor-block-styles__item[aria-label="Filled"]' ).click();
@@ -89,6 +91,8 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block link settings.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		cy.contains( 'Link settings' );
+
 		helpers.openSettingsPanel( 'Link settings' );
 
 		cy.get( '.components-base-control__label' ).contains( 'Link URL' ).then( ( $settingLabel ) => {
@@ -123,6 +127,8 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block color settings.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		cy.contains( 'Color settings' );
+
 		helpers.openSettingsPanel( 'Color settings' );
 
 		helpers.setColorSetting( 'background', '#e60099' );
@@ -144,7 +150,8 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block custom class.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
-		cy.wait( 250 );
+		// Make sure that controls who are lazy loaded finished loading
+		cy.contains( 'Icon settings' );
 
 		cy.get( '.components-panel__body-title' ).contains( 'Icon settings' ).then( ( $panelTop ) => {
 			const $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );

--- a/src/blocks/icon/test/icon.cypress.js
+++ b/src/blocks/icon/test/icon.cypress.js
@@ -144,6 +144,8 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block custom class.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		cy.wait( 250 );
+
 		cy.get( '.components-panel__body-title' ).contains( 'Icon settings' ).then( ( $panelTop ) => {
 			const $parentPanel = Cypress.$( $panelTop ).closest( 'div.components-panel__body' );
 			if ( $parentPanel.hasClass( 'is-opened' ) ) {

--- a/src/blocks/icon/test/icon.cypress.js
+++ b/src/blocks/icon/test/icon.cypress.js
@@ -31,6 +31,7 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block style.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		// Make sure that controls who are lazy loaded finished loading
 		cy.contains( 'Styles' );
 
 		helpers.openSettingsPanel( 'Styles' );
@@ -91,6 +92,7 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block link settings.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		// Make sure that controls who are lazy loaded finished loading
 		cy.contains( 'Link settings' );
 
 		helpers.openSettingsPanel( 'Link settings' );
@@ -127,6 +129,7 @@ describe( 'Test CoBlocks Icon Block', function() {
 	it( 'Test the icon block color settings.', function() {
 		helpers.addBlockToPost( 'coblocks/icon', true );
 
+		// Make sure that controls who are lazy loaded finished loading
 		cy.contains( 'Color settings' );
 
 		helpers.openSettingsPanel( 'Color settings' );

--- a/src/blocks/posts/test/posts.cypress.js
+++ b/src/blocks/posts/test/posts.cypress.js
@@ -38,7 +38,7 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		helpers.checkForBlockErrors( 'coblocks/posts' );
 
-		cy.get( '.wp-block-coblocks-posts' ).click( { force: true } );
+		cy.get( '.wp-block-coblocks-posts' ).click();
 
 		helpers.setInputValue( 'feed settings', 'number of posts', 3 );
 

--- a/src/blocks/posts/test/posts.cypress.js
+++ b/src/blocks/posts/test/posts.cypress.js
@@ -42,7 +42,7 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		cy.get( '.wp-block-coblocks-posts' ).click();
 
-		cy.contains( 'feed settings' );
+		cy.contains( 'Feed settings' );
 
 		helpers.setInputValue( 'feed settings', 'number of posts', 3 );
 

--- a/src/blocks/posts/test/posts.cypress.js
+++ b/src/blocks/posts/test/posts.cypress.js
@@ -30,7 +30,7 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		cy.get( '.wp-block-coblocks-posts' ).find( '.has-2-columns' );
 
-		cy.contains( 'posts settings' );
+		cy.contains( 'Posts settings' );
 
 		helpers.setInputValue( 'posts settings', 'columns', 1 );
 

--- a/src/blocks/posts/test/posts.cypress.js
+++ b/src/blocks/posts/test/posts.cypress.js
@@ -30,6 +30,7 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		cy.get( '.wp-block-coblocks-posts' ).find( '.has-2-columns' );
 
+		// Make sure that controls who are lazy loaded finished loading
 		cy.contains( 'Posts settings' );
 
 		helpers.setInputValue( 'posts settings', 'columns', 1 );
@@ -42,6 +43,7 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		cy.get( '.wp-block-coblocks-posts' ).click();
 
+		// Make sure that controls who are lazy loaded finished loading
 		cy.contains( 'Feed settings' );
 
 		helpers.setInputValue( 'feed settings', 'number of posts', 3 );
@@ -96,6 +98,7 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		cy.get( '.wp-block-coblocks-posts' ).find( '.has-2-columns' ).should( 'exist' );
 
+		// Make sure that controls who are lazy loaded finished loading
 		cy.contains( 'Styles' );
 
 		helpers.setBlockStyle( 'horizontal' );

--- a/src/blocks/posts/test/posts.cypress.js
+++ b/src/blocks/posts/test/posts.cypress.js
@@ -30,6 +30,8 @@ describe( 'Test CoBlocks Posts Block', function() {
 
 		cy.get( '.wp-block-coblocks-posts' ).find( '.has-2-columns' );
 
+		cy.contains( 'posts settings' );
+
 		helpers.setInputValue( 'posts settings', 'columns', 1 );
 
 		cy.get( '.wp-block-coblocks-posts' ).find( '.has-1-columns' ).should( 'exist' );
@@ -39,6 +41,8 @@ describe( 'Test CoBlocks Posts Block', function() {
 		helpers.checkForBlockErrors( 'coblocks/posts' );
 
 		cy.get( '.wp-block-coblocks-posts' ).click();
+
+		cy.contains( 'feed settings' );
 
 		helpers.setInputValue( 'feed settings', 'number of posts', 3 );
 
@@ -91,6 +95,8 @@ describe( 'Test CoBlocks Posts Block', function() {
 		helpers.addBlockToPost( 'coblocks/posts', true );
 
 		cy.get( '.wp-block-coblocks-posts' ).find( '.has-2-columns' ).should( 'exist' );
+
+		cy.contains( 'Styles' );
 
 		helpers.setBlockStyle( 'horizontal' );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10168,7 +10168,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.1, node-fetch@^1.0.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^1.0.1, node-fetch@^2.6.0, node-fetch@^2.6.6:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==


### PR DESCRIPTION
### Description
Fix tests that started failing after #2206 was merged. There were errors because sometimes the controls were not loaded properly when Cypress was searching for them.

### Checklist:
- [X] My code is tested
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
