### PR TITLE
Fix Gist file embed

### DIFF
--- a/src/blocks/gist/index.js
+++ b/src/blocks/gist/index.js
@@ -14,8 +14,8 @@ import transforms from './transforms';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
+import { Icon } from '@wordpress/components';
 import { registerBlockVariation, switchToBlockType } from '@wordpress/blocks';
 
 /**
@@ -24,18 +24,10 @@ import { registerBlockVariation, switchToBlockType } from '@wordpress/blocks';
 const { name, category, attributes } = metadata;
 
 const settings = {
-	/* translators: block name */
-	title: __( 'Gist', 'coblocks' ),
+	attributes,
+	deprecated,
 	/* translators: block description */
 	description: __( 'Embed a GitHub Gist.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
-	supports: {
-		html: false,
-		align: [ 'wide' ],
-	},
-	parent: [],
-	attributes,
-	transforms,
 	edit: ( props ) => {
 		const { replaceBlocks } = dispatch( 'core/block-editor' );
 		replaceBlocks(
@@ -44,26 +36,34 @@ const settings = {
 		);
 		return null;
 	},
+	icon: <Icon icon={ icon } />,
+	parent: [],
 	save: () => null,
-	deprecated,
+	supports: {
+		align: [ 'wide' ],
+		html: false,
+	},
+	/* translators: block name */
+	title: __( 'Gist', 'coblocks' ),
+	transforms,
 };
 
 export { name, category, metadata, settings };
 
 registerBlockVariation( 'core/embed', {
-	name: 'gist',
-	/* translators: block name */
-	title: __( 'Gist', 'coblocks' ),
+	attributes: { providerNameSlug: 'gist' },
 	/* translators: block description */
 	description: __( 'Embed a GitHub Gist.', 'coblocks' ),
 	icon: <Icon icon={ icon } />,
+	isActive: [ 'providerNameSlug' ],
 	keywords: [
 		'coblocks',
 		'github',
 		/* translators: block keyword */
 		__( 'code', 'coblocks' ),
 	],
+	name: 'gist',
 	patterns: [ /https?:\/\/gist\.github\.com\/.+/i ],
-	attributes: { providerNameSlug: 'gist' },
-	isActive: () => [ 'providerNameSlug' ],
+	/* translators: block name */
+	title: __( 'Gist', 'coblocks' ),
 } );

--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -24,7 +24,7 @@ function coblocks_block_gist_handler( $matches ) {
 	$gist_url  = empty( $matches[0] ) ? '' : $matches[0];
 	$gist_path = empty( $matches[1] ) ? '' : $matches[1];
 	$gist_file = empty( $matches[2] ) ? '' : $matches[2];
-	$gist_id   = explode( '/', $gist_path )[1];
+	$gist_id   = empty( $gist_path ) ? '' : explode( '/', $gist_path )[1];
 
 	if (
 		empty( $gist_url ) ||

--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -24,6 +24,29 @@ function coblocks_block_gist_handler( $matches ) {
 	$gist_url  = empty( $matches[0] ) ? '' : $matches[0];
 	$gist_path = empty( $matches[1] ) ? '' : $matches[1];
 	$gist_file = empty( $matches[2] ) ? '' : $matches[2];
+	$gist_id   = explode( '/', $gist_path )[1];
+
+	// Fetch from API list of all files.
+	// in cases where only uppercase files are present.
+	$api_resp = wp_remote_get(
+		'https://api.github.com/gists/' . $gist_id,
+		array(
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		)
+	);
+
+	$body  = json_decode( $api_resp['body'], true );
+	$files = empty( $body['files'] ) ? array() : $body['files'];
+
+	// Map all files into filenames array.
+	$file_list = array_map(
+		function( $file ) {
+			return $file['filename'];
+		},
+		$files
+	);
 
 	if (
 		empty( $gist_url ) ||
@@ -34,18 +57,20 @@ function coblocks_block_gist_handler( $matches ) {
 	}
 
 	$script_src = untrailingslashit( $gist_path );
-
-	if ( ! preg_match( '/\.js$/', $script_src ) ) {
-		$script_src .= '.js';
-	}
+	// .js suffix is needed after gist path for proper embed.
+	$script_src .= '.js';
 
 	if ( ! empty( $gist_file ) ) {
+		// We replace the fash to obtain true filename.
 		$dash_position = strrpos( $gist_file, '-' );
 		if ( false !== $dash_position ) {
 			$gist_file = substr_replace( $gist_file, '.', $dash_position, 1 );
 		}
 
-		$script_src .= '?file=' . $gist_file;
+		// Compare against files from API request. Return the first matching filename regardless of case.
+		$matched_file = array_search( $gist_file, array_map( 'strtolower', $file_list ), true );
+		$script_src  .= '?file=' . $matched_file;
+
 	}
 
 	return sprintf(

--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -26,8 +26,16 @@ function coblocks_block_gist_handler( $matches ) {
 	$gist_file = empty( $matches[2] ) ? '' : $matches[2];
 	$gist_id   = explode( '/', $gist_path )[1];
 
-	// Fetch from API list of all files.
-	// in cases where only uppercase files are present.
+	if (
+		empty( $gist_url ) ||
+		empty( $gist_path ) ||
+		! preg_match( '/https?:\/\/gist\.github\.com/', $gist_url )
+	) {
+		return '';
+	}
+
+	// Fetch from GitHub API list of all files.
+	// in cases where only uppercase files are present this allows us to embed the proper file.
 	$api_resp = wp_remote_get(
 		'https://api.github.com/gists/' . $gist_id,
 		array(
@@ -37,10 +45,12 @@ function coblocks_block_gist_handler( $matches ) {
 		)
 	);
 
+	// JSON decode the response body.
+	// Then grab files from JSON object.
 	$body  = json_decode( $api_resp['body'], true );
 	$files = empty( $body['files'] ) ? array() : $body['files'];
 
-	// Map all files into filenames array.
+	// Map files object into filenames array.
 	$file_list = array_map(
 		function( $file ) {
 			return $file['filename'];
@@ -48,26 +58,18 @@ function coblocks_block_gist_handler( $matches ) {
 		$files
 	);
 
-	if (
-		empty( $gist_url ) ||
-		empty( $gist_path ) ||
-		! preg_match( '/https?:\/\/gist\.github\.com/', $gist_url )
-	) {
-		return '';
-	}
-
 	$script_src = untrailingslashit( $gist_path );
 	// .js suffix is needed after gist path for proper embed.
 	$script_src .= '.js';
 
 	if ( ! empty( $gist_file ) ) {
-		// We replace the fash to obtain true filename.
+		// We replace the dash to obtain true filename.
 		$dash_position = strrpos( $gist_file, '-' );
 		if ( false !== $dash_position ) {
 			$gist_file = substr_replace( $gist_file, '.', $dash_position, 1 );
 		}
 
-		// Compare against files from API request. Return the first matching filename regardless of case.
+		// Return the first matching filename regardless of case to mimic GitHub behavior.
 		$matched_file = array_search( $gist_file, array_map( 'strtolower', $file_list ), true );
 		$script_src  .= '?file=' . $matched_file;
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Gist embed seemed to have an issue embedding when any files were specified within the Gist URI. Similar to previous Gist solutions we need a custom solution to load files that include uppercase.

There was another issue where `isActive` was being evaluated as true regardless of `providerNameSlug`. This means that if a user were to select the `core/embed` block from the inserter, that the Gist variation would show regardless. Changes here allow for Gist variation to show when inserting `coblocks/gist`.

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/148810224-41b07bcb-9561-4272-8159-c958fe26e138.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
New PHP logic and minor change to JS.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in the browser using test Gists.

https://gist.github.com/AnthonyLedesma/33ad1a8cd86da3b6bddbdefa432cb51d
https://gist.github.com/AnthonyLedesma/7d0352e8bc50a8a009c2b930f23d110d

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
