### PR TITLE
Change CSS of customer appender for 5.9 compat

### DIFF
--- a/src/blocks/events/styles/editor.scss
+++ b/src/blocks/events/styles/editor.scss
@@ -1,9 +1,27 @@
-[data-type="coblocks/events"] {
+.block-editor-block-list__block[data-type="coblocks/events"] {
 
 	@include input-submit-placeholder;
 
+	padding-bottom: 5px;
+
+	.block-list-appender {
+		bottom: -30px;
+		display: none;
+		// This is to override 5.8 style
+		margin: 0;
+		padding: 0;
+		// Those are 5.9 style that we force apply to 5.8
+		position: absolute;
+		right: 0;
+		z-index: 2;
+	}
+
 	.coblocks-block-appender {
 		margin-top: 28px;
+
+		.block-editor-button-block-appender {
+			padding: 3px 6px;
+		}
 	}
 
 	&.is-selected,
@@ -28,12 +46,6 @@
 
 [data-type="coblocks/events"] > .block-editor-block-list__block-edit > [data-block] {
 	margin-bottom: 0;
-}
-
-// Add selected padding.
-.block-editor-block-list__block[data-type="coblocks/events"].has-child-selected .wp-block-coblocks-events,
-.block-editor-block-list__block[data-type="coblocks/events"].is-selected .wp-block-coblocks-events {
-	padding: 14px 14px 0;
 }
 
 .block-editor-block-list__block[data-type="coblocks/events"].is-selected

--- a/src/blocks/faq/faq-item/styles/editor.scss
+++ b/src/blocks/faq/faq-item/styles/editor.scss
@@ -1,4 +1,6 @@
-[data-type="coblocks/faq-item"] {
+.block-editor-block-list__block[data-type="coblocks/faq-item"] {
+	min-height: 140px; // For the custom appender not to overlap.
+
 	&.wp-block {
 		margin: 0 !important;
 

--- a/src/blocks/faq/styles/editor.scss
+++ b/src/blocks/faq/styles/editor.scss
@@ -1,7 +1,16 @@
-[data-type="coblocks/faq"] {
+.block-editor-block-list__block[data-type="coblocks/faq"] {
 	.block-list-appender {
+		bottom: 0;
 		display: none;
+		// This is to override 5.8 style
 		margin: 0;
+		padding: 0;
+
+		// Those are 5.9 style that we force apply to 5.8
+		position: absolute;
+		right: 0;
+		width: 100%;
+		z-index: 2;
 	}
 
 	.coblocks-block-appender {

--- a/src/blocks/faq/styles/editor.scss
+++ b/src/blocks/faq/styles/editor.scss
@@ -1,4 +1,8 @@
 .block-editor-block-list__block[data-type="coblocks/faq"] {
+	.wp-block-coblocks-faq__heading {
+		min-height: 80px;
+	}
+
 	.block-list-appender {
 		bottom: 0;
 		display: none;
@@ -16,7 +20,6 @@
 	.coblocks-block-appender {
 		display: flex;
 		justify-content: space-between;
-		margin: 1.75em 0 0;
 
 		.block-editor-button-block-appender {
 			flex-direction: row;

--- a/src/blocks/faq/test/faq.cypress.js
+++ b/src/blocks/faq/test/faq.cypress.js
@@ -71,7 +71,7 @@ describe( 'Block: FAQ', () => {
 	 * Test the accordion block custom classes
 	 */
 	it( 'can have custom classes', () => {
-		cy.get( '[data-type="coblocks/faq-item"]' ).first().click( { force: true } );
+		cy.get( '[data-type="coblocks/faq-item"]' ).first().click();
 		helpers.addCustomBlockClass( 'my-custom-class', 'faq-item' );
 
 		helpers.checkForBlockErrors( 'coblocks/faq' );

--- a/src/blocks/faq/test/faq.cypress.js
+++ b/src/blocks/faq/test/faq.cypress.js
@@ -71,7 +71,7 @@ describe( 'Block: FAQ', () => {
 	 * Test the accordion block custom classes
 	 */
 	it( 'can have custom classes', () => {
-		cy.get( '[data-type="coblocks/faq-item"]' ).first().click();
+		cy.get( '[data-type="coblocks/faq-item"]' ).first().click( { force: true } );
 		helpers.addCustomBlockClass( 'my-custom-class', 'faq-item' );
 
 		helpers.checkForBlockErrors( 'coblocks/faq' );

--- a/src/blocks/pricing-table/pricing-table-item/styles/editor.scss
+++ b/src/blocks/pricing-table/pricing-table-item/styles/editor.scss
@@ -1,5 +1,17 @@
-[data-type="coblocks/pricing-table-item"] {
+.block-editor-block-list__block[data-type="coblocks/pricing-table-item"] {
 	width: 100%;
+
+	.block-list-appender {
+		bottom: -50px;
+		// This is to override 5.8 style
+		margin: 0;
+		padding: 0;
+		// Those are 5.9 style that we force apply to 5.8
+		position: absolute;
+		right: 0;
+		width: 100%;
+		z-index: 2;
+	}
 
 	> .block-editor-block-list__block-edit,
 	> div > [data-block] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7388,11 +7388,6 @@ grunt-text-replace@^0.4.0:
   resolved "https://registry.yarnpkg.com/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz#db9d9ce59e2fe49da277e9dbc195c3e11cfb16c2"
   integrity sha1-252c5Z4v5J2id+nbwZXD4Rz7FsI=
 
-grunt-wp-readme-to-markdown@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/grunt-wp-readme-to-markdown/-/grunt-wp-readme-to-markdown-2.1.0.tgz#89f9eeba5d709565f919b4955b4a247547bcd836"
-  integrity sha512-32OYDYNaKgykI2vxVsbqzvYBA9xHJI3XqXHSwXbLzUd1wa0ZepoceHYCs4rYFLo3ZxKpPExxvVuH3gLUS/Fq1Q==
-
 grunt@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.4.1.tgz#7d1e17db1f9c8108777f7273d6b9359755576f50"


### PR DESCRIPTION
### Description
Refactor customer Appender CSS to be compatible with 5.9. Backport 5.9 style into our own for 5.8.

### Screenshots

Event block
<img width="692" alt="image" src="https://user-images.githubusercontent.com/1933681/149578572-47748549-c159-4dfd-854c-2cd11f60f0d6.png">

Pricing block
<img width="680" alt="image" src="https://user-images.githubusercontent.com/1933681/149578607-a0dd21f4-a762-4726-b801-8d9896423ce8.png">

FAQ block
<img width="770" alt="image" src="https://user-images.githubusercontent.com/1933681/149578626-23da6e12-8771-4e4b-9a7e-1d8821eaf70d.png">
