### PR TITLE
Add a sudo apt update so that PHP installs properly in canary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -879,7 +879,7 @@ jobs:
       - restore_composer_cache
       - run:
           name: Install PHP
-          command: sudo apt-get install php libapache2-mod-php php-mbstring php-xml php-curl
+          command: sudo apt update && sudo apt-get install php libapache2-mod-php php-mbstring php-xml php-curl
       - run:
           name: Install gettext
           command: sudo apt-get install gettext

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -939,7 +939,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install subversion
       - run:
           name: Install PHP
-          command: sudo apt-get install php libapache2-mod-php php-mbstring php-xml php-curl
+          command: sudo apt update && sudo apt-get install php libapache2-mod-php php-mbstring php-xml php-curl
       - disable_xdebug_php_extension
       - run:
           name: Install Composer


### PR DESCRIPTION
### Description
Added an update to the list of packages so that PHP installs properly when building `canary` .

### Screenshots
For the moment, this is the situation : 
<img width="1365" alt="Screen Shot 2022-01-17 at 16 07 20" src="https://user-images.githubusercontent.com/85255688/149837140-1228f82b-5325-4252-9582-a97c7b301d42.png">

After this PR, the step is running properly and PHP is installed.