### PR TITLE
Don't make the build pipeline fail if the perf tests fail

### DIFF
--- a/.dev/performance/index.js
+++ b/.dev/performance/index.js
@@ -11,6 +11,7 @@ const { mapValues } = require( 'lodash' );
 const { formats, log } = require( './logger' );
 const {
 	runShellScript,
+	runShellScriptIgnoreFailing,
 	readJSONFile,
 	askForConfirmation,
 	getRandomTemporaryPath,
@@ -20,9 +21,9 @@ const config = require( './config' );
 
 /**
  * @typedef WPPerformanceCommandOptions
- * @property {boolean=} ci          Run on CI.
- * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
- * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
+ * @property {boolean} ci          Run on CI.
+ * @property {string}  testsBranch The branch whose performance test files will be used for testing.
+ * @property {string}  wpVersion   The WordPress version to be used as the base install for testing.
  */
 
 /**
@@ -37,22 +38,22 @@ const config = require( './config' );
 
 /**
  * @typedef WPPerformanceResults
- * @property {number=} load              Load Time.
- * @property {number=} type              Average type time.
- * @property {number=} minType           Minium type time.
- * @property {number=} maxType           Maximum type time.
- * @property {number=} focus             Average block selection time.
- * @property {number=} minFocus          Min block selection time.
- * @property {number=} maxFocus          Max block selection time.
- * @property {number=} inserterOpen      Average time to open global inserter.
- * @property {number=} minInserterOpen   Min time to open global inserter.
- * @property {number=} maxInserterOpen   Max time to open global inserter.
- * @property {number=} inserterSearch    Average time to open global inserter.
- * @property {number=} minInserterSearch Min time to open global inserter.
- * @property {number=} maxInserterSearch Max time to open global inserter.
- * @property {number=} inserterHover     Average time to move mouse between two block item in the inserter.
- * @property {number=} minInserterHover  Min time to move mouse between two block item in the inserter.
- * @property {number=} maxInserterHover  Max time to move mouse between two block item in the inserter.
+ * @property {number} load              Load Time.
+ * @property {number} type              Average type time.
+ * @property {number} minType           Minium type time.
+ * @property {number} maxType           Maximum type time.
+ * @property {number} focus             Average block selection time.
+ * @property {number} minFocus          Min block selection time.
+ * @property {number} maxFocus          Max block selection time.
+ * @property {number} inserterOpen      Average time to open global inserter.
+ * @property {number} minInserterOpen   Min time to open global inserter.
+ * @property {number} maxInserterOpen   Max time to open global inserter.
+ * @property {number} inserterSearch    Average time to open global inserter.
+ * @property {number} minInserterSearch Min time to open global inserter.
+ * @property {number} maxInserterSearch Max time to open global inserter.
+ * @property {number} inserterHover     Average time to move mouse between two block item in the inserter.
+ * @property {number} minInserterHover  Min time to move mouse between two block item in the inserter.
+ * @property {number} maxInserterHover  Max time to move mouse between two block item in the inserter.
  */
 
 /**
@@ -98,22 +99,22 @@ function formatTime( number ) {
  */
 function curateResults( results ) {
 	return {
-		load: average( results.load ),
-		type: average( results.type ),
-		minType: Math.min( ...results.type ),
-		maxType: Math.max( ...results.type ),
 		focus: average( results.focus ),
-		minFocus: Math.min( ...results.focus ),
-		maxFocus: Math.max( ...results.focus ),
-		inserterOpen: average( results.inserterOpen ),
-		minInserterOpen: Math.min( ...results.inserterOpen ),
-		maxInserterOpen: Math.max( ...results.inserterOpen ),
-		inserterSearch: average( results.inserterSearch ),
-		minInserterSearch: Math.min( ...results.inserterSearch ),
-		maxInserterSearch: Math.max( ...results.inserterSearch ),
 		inserterHover: average( results.inserterHover ),
-		minInserterHover: Math.min( ...results.inserterHover ),
+		inserterOpen: average( results.inserterOpen ),
+		inserterSearch: average( results.inserterSearch ),
+		load: average( results.load ),
+		maxFocus: Math.max( ...results.focus ),
 		maxInserterHover: Math.max( ...results.inserterHover ),
+		maxInserterOpen: Math.max( ...results.inserterOpen ),
+		maxInserterSearch: Math.max( ...results.inserterSearch ),
+		maxType: Math.max( ...results.type ),
+		minFocus: Math.min( ...results.focus ),
+		minInserterHover: Math.min( ...results.inserterHover ),
+		minInserterOpen: Math.min( ...results.inserterOpen ),
+		minInserterSearch: Math.min( ...results.inserterSearch ),
+		minType: Math.min( ...results.type ),
+		type: average( results.type ),
 	};
 }
 
@@ -146,7 +147,7 @@ async function setUpGitBranch( branch, environmentDirectory ) {
  * @return {Promise<WPPerformanceResults>} Performance results for the branch.
  */
 async function runTestSuite( testSuite, performanceTestDirectory ) {
-	await runShellScript(
+	await runShellScriptIgnoreFailing(
 		`npx wp-scripts test-e2e --config .dev/performance/jest.performance.config.js -- .dev/performance/tests/post-editor.test.js`,
 		performanceTestDirectory
 	);
@@ -265,40 +266,40 @@ async function runPerformanceTests( branches, options ) {
 		for ( const branch of branches ) {
 			const medians = mapValues(
 				{
-					load: rawResults.map( ( r ) => r[ branch ].load ),
-					type: rawResults.map( ( r ) => r[ branch ].type ),
-					minType: rawResults.map( ( r ) => r[ branch ].minType ),
-					maxType: rawResults.map( ( r ) => r[ branch ].maxType ),
 					focus: rawResults.map( ( r ) => r[ branch ].focus ),
-					minFocus: rawResults.map( ( r ) => r[ branch ].minFocus ),
-					maxFocus: rawResults.map( ( r ) => r[ branch ].maxFocus ),
+					inserterHover: rawResults.map(
+						( r ) => r[ branch ].inserterHover
+					),
 					inserterOpen: rawResults.map(
 						( r ) => r[ branch ].inserterOpen
-					),
-					minInserterOpen: rawResults.map(
-						( r ) => r[ branch ].minInserterOpen
-					),
-					maxInserterOpen: rawResults.map(
-						( r ) => r[ branch ].maxInserterOpen
 					),
 					inserterSearch: rawResults.map(
 						( r ) => r[ branch ].inserterSearch
 					),
-					minInserterSearch: rawResults.map(
-						( r ) => r[ branch ].minInserterSearch
+					load: rawResults.map( ( r ) => r[ branch ].load ),
+					maxFocus: rawResults.map( ( r ) => r[ branch ].maxFocus ),
+					maxInserterHover: rawResults.map(
+						( r ) => r[ branch ].maxInserterHover
+					),
+					maxInserterOpen: rawResults.map(
+						( r ) => r[ branch ].maxInserterOpen
 					),
 					maxInserterSearch: rawResults.map(
 						( r ) => r[ branch ].maxInserterSearch
 					),
-					inserterHover: rawResults.map(
-						( r ) => r[ branch ].inserterHover
-					),
+					maxType: rawResults.map( ( r ) => r[ branch ].maxType ),
+					minFocus: rawResults.map( ( r ) => r[ branch ].minFocus ),
 					minInserterHover: rawResults.map(
 						( r ) => r[ branch ].minInserterHover
 					),
-					maxInserterHover: rawResults.map(
-						( r ) => r[ branch ].maxInserterHover
+					minInserterOpen: rawResults.map(
+						( r ) => r[ branch ].minInserterOpen
 					),
+					minInserterSearch: rawResults.map(
+						( r ) => r[ branch ].minInserterSearch
+					),
+					minType: rawResults.map( ( r ) => r[ branch ].minType ),
+					type: rawResults.map( ( r ) => r[ branch ].type ),
 				},
 				median
 			);

--- a/.dev/performance/utils.js
+++ b/.dev/performance/utils.js
@@ -28,9 +28,9 @@ function runShellScript( script, cwd, env = {} ) {
 			{
 				cwd,
 				env: {
+					HOME: process.env.HOME,
 					NO_CHECKS: 'true',
 					PATH: process.env.PATH,
-					HOME: process.env.HOME,
 					...env,
 				},
 			},
@@ -39,6 +39,33 @@ function runShellScript( script, cwd, env = {} ) {
 					// eslint-disable-next-line no-console
 					console.log( stderr );
 					reject( error );
+				} else {
+					resolve( true );
+				}
+			}
+		);
+	} );
+}
+
+function runShellScriptIgnoreFailing( script, cwd, env = {} ) {
+	return new Promise( ( resolve ) => {
+		childProcess.exec(
+			script,
+			{
+				cwd,
+				env: {
+					HOME: process.env.HOME,
+					NO_CHECKS: 'true',
+					PATH: process.env.PATH,
+					...env,
+				},
+			},
+			function( error, _, stderr ) {
+				if ( error ) {
+					// eslint-disable-next-line no-console
+					console.log( stderr );
+					// We make the promise resolve even if the script fails
+					resolve( true );
 				} else {
 					resolve( true );
 				}
@@ -71,10 +98,10 @@ async function askForConfirmation(
 ) {
 	const { isReady } = await inquirer.prompt( [
 		{
-			type: 'confirm',
-			name: 'isReady',
 			default: isDefault,
 			message,
+			name: 'isReady',
+			type: 'confirm',
 		},
 	] );
 
@@ -95,7 +122,8 @@ function getRandomTemporaryPath() {
 
 module.exports = {
 	askForConfirmation,
+	getRandomTemporaryPath,
 	readJSONFile,
 	runShellScript,
-	getRandomTemporaryPath,
+	runShellScriptIgnoreFailing,
 };


### PR DESCRIPTION
### Description
The perf tests sometimes fail for a mysterious reason. Instead of making the build pipeline fail, we take what data has been calculated and show it on the PR (when it fails, it is always the second time it calculates the value, so there are already some calculated values).

So, basically, we allow the execution of the performance tests to fail on the pipeline, because it does not represent a failure of our product.