### PR TITLE
Fix path to coblocks extensions CSS

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -164,7 +164,7 @@ class CoBlocks_Block_Assets {
 
 		wp_enqueue_style(
 			'coblocks-extensions',
-			COBLOCKS_PLUGIN_URL . $filepath . $rtl . '.css',
+			COBLOCKS_PLUGIN_URL . 'dist/style-coblocks-extensions' . $rtl . '.css',
 			array(),
 			$asset_file['version']
 		);

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -163,8 +163,8 @@ class CoBlocks_Block_Assets {
 		$rtl        = ! is_rtl() ? '' : '-rtl';
 
 		wp_enqueue_style(
-			'coblocks-extensions',
-			COBLOCKS_PLUGIN_URL . 'dist/style-coblocks-extensions' . $rtl . '.css',
+			$name,
+			COBLOCKS_PLUGIN_URL . 'dist/style-' . $name . $rtl . '.css',
 			array(),
 			$asset_file['version']
 		);


### PR DESCRIPTION
### Description
Fixes #2233 

Not sure if this is the proper way to fix it, but it seems to solve the 404 error on `coblocks-extensions.css` (which should be `style-coblocks-extensions.css`).