### PR TITLE
Fix Row, Column and Posts blocks tests for WP 5.9

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -19,5 +19,6 @@
     "runMode": 0,
     "openMode": 0
   },
-  "pageLoadTimeout": 120000
+  "pageLoadTimeout": 120000,
+  "videoCompression": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -19,6 +19,5 @@
     "runMode": 0,
     "openMode": 0
   },
-  "pageLoadTimeout": 120000,
-  "videoCompression": false
+  "pageLoadTimeout": 120000
 }

--- a/src/blocks/posts/test/posts.cypress.js
+++ b/src/blocks/posts/test/posts.cypress.js
@@ -11,6 +11,9 @@ describe( 'Test CoBlocks Posts Block', function() {
 	it( 'Test posts block saves with empty values.', function() {
 		helpers.addBlockToPost( 'coblocks/posts', true );
 
+		// Make sure that controls who are lazy loaded finished loading
+		cy.contains( 'Posts settings' );
+
 		helpers.savePage();
 
 		helpers.checkForBlockErrors( 'coblocks/posts' );

--- a/src/blocks/row/column/test/column.cypress.js
+++ b/src/blocks/row/column/test/column.cypress.js
@@ -7,21 +7,13 @@ describe( 'Test CoBlocks column Block', function() {
 	//setup column block data.
 	const columnData = {
 		backgroundColor: '#ff0000',
-		textColor: '#ffffff',
 		backgroundColorRGB: 'rgb(255, 0, 0)',
+		textColor: '#ffffff',
 		textColorRGB: 'rgb(255, 255, 255)',
 	};
 
-	/**
-	 * Conditionally run tests on Variation picker or Classic picker depending on availability.
-	 *
-	 */
-	let testAgainstVariationsPicker;
 	before( function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
-		cy.get( 'div[data-type="coblocks/row"]' ).then( () => {
-			testAgainstVariationsPicker = Cypress.$( '.block-editor-block-variation-picker' ).length > 0;
-		} );
 	} );
 
 	/**
@@ -32,11 +24,7 @@ describe( 'Test CoBlocks column Block', function() {
 		const { textColor, backgroundColor, textColorRGB, backgroundColorRGB } = columnData;
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click( { force: true } );
 
 		cy.get( '.wp-block-coblocks-column' ).last().click( { force: true } );
 

--- a/src/blocks/row/test/row.cypress.js
+++ b/src/blocks/row/test/row.cypress.js
@@ -7,21 +7,13 @@ describe( 'Test CoBlocks Row Block', function() {
 	//setup row block data.
 	const rowData = {
 		backgroundColor: '#ff0000',
-		textColor: '#ffffff',
 		backgroundColorRGB: 'rgb(255, 0, 0)',
+		textColor: '#ffffff',
 		textColorRGB: 'rgb(255, 255, 255)',
 	};
 
-	/**
-	 * Conditionally run tests on Variation picker or Classic picker depending on availability.
-	 *
-	 */
-	let testAgainstVariationsPicker;
 	before( function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
-		cy.get( 'div[data-type="coblocks/row"]' ).then( () => {
-			testAgainstVariationsPicker = Cypress.$( '.block-editor-block-variation-picker' ).length > 0;
-		} );
 	} );
 
 	/**
@@ -31,11 +23,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with one column.', function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click();
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 1 );
 
@@ -49,12 +37,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with two columns.', function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(2) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(2) button' ).click( { force: true } );
-			cy.get( 'div[aria-label="Select row layout"]' ).find( 'div > button' ).first().click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(2) button' ).click();
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 2 );
 
@@ -68,12 +51,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with three columns.', function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(4) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(3) button' ).click( { force: true } );
-			cy.get( 'div[aria-label="Select row layout"]' ).find( 'div > button' ).first().click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(4) button' ).click();
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 3 );
 
@@ -87,12 +65,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test row block saves with four columns.', function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(5) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(4) button' ).click( { force: true } );
-			cy.get( 'div[aria-label="Select row layout"]' ).find( 'div > button' ).first().click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(5) button' ).click();
 
 		cy.get( 'div.wp-block-coblocks-column__inner' ).should( 'have.length', 4 );
 
@@ -107,11 +80,7 @@ describe( 'Test CoBlocks Row Block', function() {
 		const { backgroundColor, textColor } = rowData;
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click();
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 
@@ -127,11 +96,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test the row block custom classes.', function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click();
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 
@@ -151,11 +116,7 @@ describe( 'Test CoBlocks Row Block', function() {
 	it( 'Test the row block alignment controls.', function() {
 		helpers.addBlockToPost( 'coblocks/row', true );
 
-		if ( testAgainstVariationsPicker ) {
-			cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click( { force: true } );
-		} else {
-			cy.get( 'div[aria-label="Select row columns"]' ).find( 'div:nth-child(1) button' ).click( { force: true } );
-		}
+		cy.get( '.block-editor-block-variation-picker__variations' ).find( 'li:nth-child(1) button' ).click();
 
 		cy.get( '.wp-block-coblocks-row' ).click( { force: true } );
 


### PR DESCRIPTION
### Description
The condition for if there is a variation picker or not was causing problem because the expected class was not loaded enough quickly to take the right branch of the if.

Now we only test on 5.8 and 5.9, and they both have the variation picker, so this if is not necessary anymore and it resolve the problem with the tests failing in WP 5.9

I also took the opportunity to solidify flaky tests.

### Types of changes
Tests fix

### How has this been tested?
Cypress tests run on WP 5.9

### Checklist:
- [X] My code is tested
- [X] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've added proper labels to this pull request <!-- if applicable -->
