### PR TITLE
Fix Lightbox for Gallery block.

### DIFF
--- a/src/extensions/lightbox-controls/index.js
+++ b/src/extensions/lightbox-controls/index.js
@@ -7,8 +7,8 @@ import classnames from 'classnames';
  * WordPress Dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
+import { store as blockEditorStore, InspectorControls } from '@wordpress/block-editor';
 import { PanelRow, ToggleControl } from '@wordpress/components';
 
 /**
@@ -24,7 +24,7 @@ const blocksWithLightboxSupport = [ 'core/gallery', 'core/image' ];
  * @return {JSX} Wrapped component.
  */
 const useLightbox = ( props ) => {
-	const { name, attributes, setAttributes, isSelected } = props;
+	const { name, attributes, setAttributes, isSelected, clientId } = props;
 	const { lightbox, images, id } = attributes;
 
 	const hasParentGallery = select( 'core/block-editor' ).
@@ -32,6 +32,12 @@ const useLightbox = ( props ) => {
 			props.clientId,
 			[ 'core/gallery', 'coblocks/gallery-masonry' ]
 		)?.length === 0;
+
+	let hasInnerImageBlocks = false;
+
+	if ( name === 'core/gallery' ) {
+		hasInnerImageBlocks = select( blockEditorStore )?.getBlock( clientId )?.innerBlocks?.length > 0;
+	}
 
 	let supportsLightbox = false;
 	supportsLightbox = blocksWithLightboxSupport.includes( name ) && !! hasParentGallery;
@@ -42,7 +48,7 @@ const useLightbox = ( props ) => {
 			: __( 'Toggle to enable the image lightbox.', 'coblocks' );
 	};
 
-	return isSelected && supportsLightbox && ( !! images?.length || !! id ) ? (
+	return isSelected && supportsLightbox && ( !! images?.length || !! id || !! hasInnerImageBlocks ) ? (
 		<InspectorControls>
 			<PanelRow className={ 'coblocks-lightbox-controls' }>
 				<ToggleControl

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -51,6 +51,7 @@
 
 		const imageSelector = [
 			`.has-lightbox.lightbox-${ lightboxIndex } > :not(.carousel-nav) figure img`,
+			`.has-lightbox.lightbox-${ lightboxIndex } > figure img`,
 			`figure.has-lightbox.lightbox-${ lightboxIndex } > img`,
 			`.has-lightbox.lightbox-${ lightboxIndex } > figure[class^="align"] img`,
 			`.masonry-grid.has-lightbox.lightbox-${ lightboxIndex } figure img`,


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
New selector in the script and logic to check the innerBlocks. This has changed since the old Gallery block had used attributes.images as opposed to innerBlocks. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested Manually in 5.9-RC4

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
