### PR TITLE
Remove confusion on CoBlocks blocks and core blocks

### DIFF
--- a/src/blocks/accordion/index.js
+++ b/src/blocks/accordion/index.js
@@ -7,6 +7,7 @@ import { AccordionIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import transforms from './transforms';
 
@@ -27,7 +28,10 @@ const settings = {
 	title: __( 'Accordion', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Organize content within collapsable accordion items.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/alert/index.js
+++ b/src/blocks/alert/index.js
@@ -8,6 +8,7 @@ import { AlertIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -28,7 +29,10 @@ const settings = {
 	title: __( 'Alert', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Provide contextual feedback messages or notices.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/author/index.js
+++ b/src/blocks/author/index.js
@@ -8,6 +8,7 @@ import { AuthorIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -28,7 +29,10 @@ const settings = {
 	title: __( 'Author', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add an author biography to build credibility and authority.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/buttons/index.js
+++ b/src/blocks/buttons/index.js
@@ -1,4 +1,9 @@
 /**
+ * THIS BLOCK IS DEPRECRATED. IT WILL NOT SHOW UP IN THE INSERTER ANYMORE.
+ * SEE /src/js/deprecations/deprecate-coblocks-buttons.js
+ */
+
+/**
  * Internal dependencies
  */
 import deprecated from './deprecated';

--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
+import { Icon } from '@wordpress/components';
+import { TwitterIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
-import deprecated from './deprecated';
-import { Icon } from '@wordpress/components';
-import { TwitterIcon } from '@godaddy-wordpress/coblocks-icons';
 
 /**
  * WordPress dependencies
@@ -24,7 +25,10 @@ const settings = {
 	title: __( 'Click to Tweet', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add a quote for readers to tweet via Twitter.', 'coblocks' ),
-	icon: <Icon icon={ TwitterIcon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/dynamic-separator/index.js
+++ b/src/blocks/dynamic-separator/index.js
@@ -8,6 +8,7 @@ import { separator as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -28,7 +29,10 @@ const settings = {
 	title: __( 'Dynamic HR', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add a resizable spacer between other blocks.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		'hr',

--- a/src/blocks/events/index.js
+++ b/src/blocks/events/index.js
@@ -8,6 +8,7 @@ import { EventsIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import edit from './edit';
 import example from './example';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -26,7 +27,10 @@ const { name, category } = metadata;
 const settings = {
 	title: _x( 'Events', 'block name', 'coblocks' ),
 	description: __( 'Add a list of events or display events from a public calendar.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/faq/faq-item/index.js
+++ b/src/blocks/faq/faq-item/index.js
@@ -7,6 +7,7 @@ import { EventItemIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies.
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -25,7 +26,10 @@ const settings = {
 	attributes,
 	description: __( 'A question/answer within the FAQ block.', 'coblocks' ),
 	edit,
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	parent: [ 'coblocks/faq' ],
 	save,
 	supports: {

--- a/src/blocks/faq/index.js
+++ b/src/blocks/faq/index.js
@@ -8,6 +8,7 @@ import { FaqIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import edit from './edit';
 import example from './example';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -26,7 +27,10 @@ const settings = {
 	description: __( 'Add a list of questions and answers.', 'coblocks' ),
 	edit,
 	example,
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/features/feature/index.js
+++ b/src/blocks/features/feature/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { FeatureIcon } from '@godaddy-wordpress/coblocks-icons';
+import { FeatureIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 
 /**
  * Internal dependencies
@@ -9,6 +9,7 @@ import { FeatureIcon } from '@godaddy-wordpress/coblocks-icons';
 import { BackgroundAttributes } from '../../../components/background';
 import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 import edit from './edit';
+import { getBlockIconColor } from '../../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -34,7 +35,10 @@ const settings = {
 	title: __( 'Feature', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A singular child column within a parent features block.', 'coblocks' ),
-	icon: <Icon icon={ FeatureIcon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	parent: [ 'coblocks/features' ],
 	supports: {
 		inserter: false,

--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -8,6 +8,7 @@ import { FeatureIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -36,7 +37,10 @@ const settings = {
 	title: __( 'Features', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add up to four columns of small notes for your product or service.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 	],

--- a/src/blocks/food-and-drinks/index.js
+++ b/src/blocks/food-and-drinks/index.js
@@ -8,6 +8,7 @@ import { FoodDrinkIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -58,7 +59,10 @@ const settings = {
 	getEditWrapperProps( atts ) {
 		return { 'data-columns': atts.columns };
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/checkbox/index.js
+++ b/src/blocks/form/fields/checkbox/index.js
@@ -7,6 +7,7 @@ import { FormCheckboxIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import { editMultiField } from '../helpers';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -48,7 +49,10 @@ const settings = {
 	title: __( 'Checkbox', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A checkbox field with multiple options where multiple choices can be made.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/date/index.js
+++ b/src/blocks/form/fields/date/index.js
@@ -7,6 +7,7 @@ import { FormDateIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -40,7 +41,10 @@ const settings = {
 	title: __( 'Date', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A field for requesting date selections with a date picker.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/email/index.js
+++ b/src/blocks/form/fields/email/index.js
@@ -7,6 +7,7 @@ import { FormEmailIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 
 /**
  * WordPress dependencies
@@ -39,7 +40,10 @@ const settings = {
 	title: __( 'Email', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A field for collecting a validated email address.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/hidden/index.js
+++ b/src/blocks/form/fields/hidden/index.js
@@ -7,6 +7,7 @@ import { FormHiddenIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -40,7 +41,10 @@ const settings = {
 	title: __( 'Hidden', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A hidden text field for collecting additional data.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/name/index.js
+++ b/src/blocks/form/fields/name/index.js
@@ -7,6 +7,7 @@ import { FormNameIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -52,7 +53,10 @@ const settings = {
 	title: __( 'Name', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A text field for collecting the first and last names.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/radio/index.js
+++ b/src/blocks/form/fields/radio/index.js
@@ -7,6 +7,7 @@ import { FormRadioIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import { editMultiField } from '../helpers';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -48,7 +49,10 @@ const settings = {
 	title: __( 'Radio', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A field with multiple options where only one choice can be made.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/select/index.js
+++ b/src/blocks/form/fields/select/index.js
@@ -7,6 +7,7 @@ import { FormSelectIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import { editMultiField } from '../helpers';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -44,7 +45,10 @@ const settings = {
 	title: __( 'Select', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A dropdown field with multiple options where only one choice can be made.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/submit-button/index.js
+++ b/src/blocks/form/fields/submit-button/index.js
@@ -7,6 +7,7 @@ import { FormSubmitIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 
 /**
  * WordPress dependencies
@@ -52,7 +53,10 @@ const settings = {
 	description: __( 'A button for submitting form data.', 'coblocks' ),
 	edit,
 	/* translators: block description */
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/text/index.js
+++ b/src/blocks/form/fields/text/index.js
@@ -7,6 +7,7 @@ import { FormTextIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -40,7 +41,10 @@ const settings = {
 	title: __( 'Text', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A text box for custom responses.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/textarea/index.js
+++ b/src/blocks/form/fields/textarea/index.js
@@ -7,6 +7,7 @@ import { FormTextareaIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -40,7 +41,10 @@ const settings = {
 	title: __( 'Textarea', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A text box for longer responses.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/fields/website/index.js
+++ b/src/blocks/form/fields/website/index.js
@@ -7,6 +7,7 @@ import { FormWebsiteIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../../utils/helper';
 import transforms from './transforms';
 
 /**
@@ -40,7 +41,10 @@ const settings = {
 	title: __( 'Website', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A text field for collecting a URL.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -9,6 +9,7 @@ import { FormIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import variations from './variations';
 
 /**
@@ -55,7 +56,10 @@ const settings = {
 			subject: __( 'Subject example', 'coblocks' ),
 		},
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -16,6 +16,7 @@ import { lazy, Suspense } from '@wordpress/element';
 import deprecated from './deprecated';
 const Edit = lazy( () => import( './edit' ) );
 import { GalleryAttributes } from '../../components/block-gallery/shared';
+import { getBlockIconColor } from '../../utils/helper';
 import { hasFormattingCategory } from '../../utils/block-helpers';
 import metadata from './block.json';
 import save from './save';
@@ -40,7 +41,10 @@ const settings = {
 	category: hasFormattingCategory ? 'coblocks-galleries' : 'media',
 	attributes,
 	variations,
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gallery-collage/index.js
+++ b/src/blocks/gallery-collage/index.js
@@ -16,6 +16,7 @@ import { lazy, Suspense } from '@wordpress/element';
 import deprecated from './deprecated';
 const Edit = lazy( () => import( './edit' ) );
 import { GalleryAttributes } from '../../components/block-gallery/shared';
+import { getBlockIconColor } from '../../utils/helper';
 import { hasFormattingCategory } from '../../utils/block-helpers';
 import metadata from './block.json';
 import save from './save';
@@ -41,7 +42,10 @@ const settings = {
 	/* translators: block description */
 	description: __( 'Assemble images into a beautiful collage gallery.', 'coblocks' ),
 	category: hasFormattingCategory ? 'coblocks-galleries' : 'media',
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -16,6 +16,7 @@ import { lazy, Suspense } from '@wordpress/element';
 import deprecated from './deprecated';
 const Edit = lazy( () => import( './edit' ) );
 import { GalleryAttributes } from '../../components/block-gallery/shared';
+import { getBlockIconColor } from '../../utils/helper';
 import { hasFormattingCategory } from '../../utils/block-helpers';
 import metadata from './block.json';
 import save from './save';
@@ -69,7 +70,10 @@ const settings = {
 			},
 		],
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gallery-offset/index.js
+++ b/src/blocks/gallery-offset/index.js
@@ -6,13 +6,14 @@ import { GalleryOffsetIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 /**
  * Internal dependencies
  */
-import edit from './edit';
 import deprecated from './deprecated';
+import edit from './edit';
+import { GalleryAttributes } from '../../components/block-gallery/shared';
+import { getBlockIconColor } from '../../utils/helper';
+import { hasFormattingCategory } from '../../utils/block-helpers';
+import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
-import metadata from './block.json';
-import { GalleryAttributes } from '../../components/block-gallery/shared';
-import { hasFormattingCategory } from '../../utils/block-helpers';
 
 /**
  * WordPress dependencies
@@ -40,7 +41,10 @@ const settings = {
 	/* translators: block description */
 	description: __( 'Display images in an offset brick pattern gallery.', 'coblocks' ),
 	category: hasFormattingCategory ? 'coblocks-galleries' : 'media',
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -8,11 +8,12 @@ import { GalleryStackedIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { GalleryAttributes } from '../../components/block-gallery/shared';
+import { getBlockIconColor } from '../../utils/helper';
+import { hasFormattingCategory } from '../../utils/block-helpers';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
-import { GalleryAttributes } from '../../components/block-gallery/shared';
-import { hasFormattingCategory } from '../../utils/block-helpers';
 
 /**
  * WordPress dependencies
@@ -36,7 +37,10 @@ const settings = {
 	/* translators: block description */
 	description: __( 'Display multiple images in a single column stacked gallery.', 'coblocks' ),
 	category: hasFormattingCategory ? 'coblocks-galleries' : 'media',
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gif/index.js
+++ b/src/blocks/gif/index.js
@@ -8,6 +8,7 @@ import { GifIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import edit from './edit';
 import { hasFormattingCategory } from '../../utils/block-helpers';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -39,7 +40,10 @@ const settings = {
 			return { 'data-align': align, 'data-resized': !! width };
 		}
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/gist/index.js
+++ b/src/blocks/gist/index.js
@@ -7,6 +7,7 @@ import { GithubIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import deprecated from './deprecated';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import transforms from './transforms';
 
@@ -36,7 +37,10 @@ const settings = {
 		);
 		return null;
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	parent: [],
 	save: () => null,
 	supports: {
@@ -54,7 +58,10 @@ registerBlockVariation( 'core/embed', {
 	attributes: { providerNameSlug: 'gist' },
 	/* translators: block description */
 	description: __( 'Embed a GitHub Gist.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	isActive: [ 'providerNameSlug' ],
 	keywords: [
 		'coblocks',

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -18,6 +18,7 @@ import CSSGridAttributes from '../../components/grid-control/attributes';
 import deprecated from './deprecated';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 const Edit = lazy( () => import( './edit' ) );
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import ResponsiveBaseControlAttributes from '../../components/responsive-base-control/attributes';
 import save from './save';
@@ -85,7 +86,10 @@ const settings = {
 			},
 		],
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/highlight/index.js
+++ b/src/blocks/highlight/index.js
@@ -7,6 +7,7 @@ import { HighlightIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -27,7 +28,10 @@ const settings = {
 	title: __( 'Highlight', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Draw attention and emphasize important narrative.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -8,6 +8,7 @@ import { IconIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import { hasFormattingCategory } from '../../utils/block-helpers';
 import metadata from './block.json';
 
@@ -36,7 +37,10 @@ const settings = {
 	edit,
 	// We can't enable example on this block without breaking style previews as attributes are completely replaced by the example.
 	//example: {}
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		'svg',

--- a/src/blocks/logos/index.js
+++ b/src/blocks/logos/index.js
@@ -8,6 +8,7 @@ import { LogosIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -27,7 +28,10 @@ const settings = {
 	title: __( 'Logos', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add logos, badges, or certifications to build credibility.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/map/index.js
+++ b/src/blocks/map/index.js
@@ -8,6 +8,7 @@ import { MapIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -35,7 +36,10 @@ const settings = {
 			align: 'wide',
 		},
 	},
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/media-card/index.js
+++ b/src/blocks/media-card/index.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
+import { BackgroundAttributes } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
+import { MediaCardIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
-import { BackgroundAttributes } from '../../components/background';
-import { MediaCardIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 
 /**
  * WordPress dependencies
@@ -31,7 +32,10 @@ const settings = {
 	title: __( 'Media Card', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add an image or video with an offset card side-by-side.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	supports: {
 		align: [ 'wide', 'full' ],
 		stackedOnMobile: true,

--- a/src/blocks/opentable/index.js
+++ b/src/blocks/opentable/index.js
@@ -7,6 +7,7 @@ import { OpentableIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -26,7 +27,10 @@ const settings = {
 	title: __( 'OpenTable', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Embed an OpenTable Reservations Widget.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/post-carousel/index.js
+++ b/src/blocks/post-carousel/index.js
@@ -17,6 +17,7 @@ import deprecated from './deprecated';
 const Edit = lazy( () => import( './edit' ) );
 import metadata from './block.json';
 import transforms from './transforms';
+import { getBlockIconColor } from '../../utils/helper';
 
 /**
  * Block constants
@@ -28,7 +29,10 @@ const settings = {
 	title: __( 'Post Carousel (CoBlocks)', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Display posts or an external blog feed as a carousel.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/post-carousel/index.js
+++ b/src/blocks/post-carousel/index.js
@@ -25,7 +25,7 @@ const { name, category } = metadata;
 
 const settings = {
 	/* translators: block name */
-	title: __( 'Post Carousel', 'coblocks' ),
+	title: __( 'Post Carousel (CoBlocks)', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Display posts or an external blog feed as a carousel.', 'coblocks' ),
 	icon: <Icon icon={ icon } />,

--- a/src/blocks/posts/index.js
+++ b/src/blocks/posts/index.js
@@ -25,7 +25,7 @@ const { name, category } = metadata;
 
 const settings = {
 	/* translators: block name */
-	title: __( 'Posts', 'coblocks' ),
+	title: __( 'Posts (CoBlocks)', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Display posts or an RSS feed as stacked or horizontal cards.', 'coblocks' ),
 	icon: <Icon icon={ icon } />,

--- a/src/blocks/posts/index.js
+++ b/src/blocks/posts/index.js
@@ -15,6 +15,7 @@ import { lazy, Suspense } from '@wordpress/element';
  */
 import deprecated from './deprecated';
 const Edit = lazy( () => import( './edit' ) );
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import transforms from './transforms';
 
@@ -28,7 +29,10 @@ const settings = {
 	title: __( 'Posts (CoBlocks)', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Display posts or an RSS feed as stacked or horizontal cards.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/pricing-table/index.js
+++ b/src/blocks/pricing-table/index.js
@@ -6,12 +6,13 @@ import { PricingTableIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import example from './example';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
-import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -29,7 +30,10 @@ const settings = {
 	title: __( 'Pricing Table', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add pricing tables to help visitors compare products and plans.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/pricing-table/pricing-table-item/index.js
+++ b/src/blocks/pricing-table/pricing-table-item/index.js
@@ -7,9 +7,10 @@ import { PricingTableItemIcon as icon } from '@godaddy-wordpress/coblocks-icons'
  * Internal dependencies
  */
 import edit from './edit';
-import transforms from './transforms';
-import save from './save';
+import { getBlockIconColor } from '../../../utils/helper';
 import metadata from './block.json';
+import save from './save';
+import transforms from './transforms';
 
 /**
  * WordPress dependencies
@@ -27,7 +28,10 @@ const settings = {
 	title: __( 'Pricing Table Item', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A pricing table to help visitors compare products and plans.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/row/column/index.js
+++ b/src/blocks/row/column/index.js
@@ -6,12 +6,13 @@ import { ColumnIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 /**
  * Internal dependencies
  */
+import { BackgroundAttributes } from '../../../components/background';
 import deprecated from './deprecated';
 import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 import edit from './edit';
+import { getBlockIconColor } from '../../../utils/helper';
 import metadata from './block.json';
 import save from './save';
-import { BackgroundAttributes } from '../../../components/background';
 
 /**
  * WordPress dependencies
@@ -35,7 +36,10 @@ const settings = {
 	title: __( 'Column', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'An immediate child of a row.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	parent: [ 'coblocks/row' ],
 	supports: {
 		inserter: false,

--- a/src/blocks/row/index.js
+++ b/src/blocks/row/index.js
@@ -16,6 +16,7 @@ import { lazy, Suspense } from '@wordpress/element';
 import { BackgroundAttributes } from '../../components/background';
 import deprecated from './deprecated';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
+import { getBlockIconColor } from '../../utils/helper';
 const Edit = lazy( () => import( './edit' ) );
 import { getEditWrapperProps } from './utilities';
 import metadata from './block.json';
@@ -39,7 +40,10 @@ const settings = {
 	title: __( 'Row', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add a structured wrapper for column blocks, then add content blocks you’d like to the columns.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/services/index.js
+++ b/src/blocks/services/index.js
@@ -9,6 +9,7 @@ import { ServicesIcon as icon } from '@godaddy-wordpress/coblocks-icons';
 import deprecated from './deprecated';
 import edit from './edit';
 import example from './example';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -28,7 +29,10 @@ const settings = {
 	title: __( 'Services', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add up to four columns of services to display.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/blocks/services/service/index.js
+++ b/src/blocks/services/service/index.js
@@ -7,6 +7,7 @@ import { ServiceItemIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies.
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../../utils/helper';
 import metadata from './block.json';
 import save from './save';
 
@@ -26,7 +27,10 @@ const settings = {
 	title: __( 'Service', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'A single service item within a services block.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [],
 	supports: {
 		reusable: false,

--- a/src/blocks/shape-divider/index.js
+++ b/src/blocks/shape-divider/index.js
@@ -8,6 +8,7 @@ import { ShapeDividerIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
 import metadata from './block.json';
 import transforms from './transforms';
 
@@ -27,7 +28,10 @@ const settings = {
 	title: __( 'Shape Divider', 'coblocks' ),
 	/* translators: block description */
 	description: __( 'Add a shape divider to visually distinquish page sections.', 'coblocks' ),
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		'hr',

--- a/src/blocks/social-profiles/index.js
+++ b/src/blocks/social-profiles/index.js
@@ -7,9 +7,10 @@ import { SocialProfilesIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import { getBlockIconColor } from '../../utils/helper';
+import { hasFormattingCategory } from '../../utils/block-helpers';
 import metadata from './block.json';
 import { transforms } from './transforms';
-import { hasFormattingCategory } from '../../utils/block-helpers';
 
 /**
  * WordPress dependencies
@@ -28,7 +29,10 @@ const settings = {
 	/* translators: block description */
 	description: __( 'Grow your audience with links to social media profiles.', 'coblocks' ),
 	category: hasFormattingCategory ? 'common' : 'widgets',
-	icon: <Icon icon={ icon } />,
+	icon: {
+		foreground: getBlockIconColor(),
+		src: <Icon icon={ icon } />,
+	},
 	keywords: [
 		'coblocks',
 		/* translators: block keyword */

--- a/src/utils/block-category.js
+++ b/src/utils/block-category.js
@@ -1,14 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { getCategories, setCategories, registerBlockCollection } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { getCategories, setCategories, registerBlockCollection } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { supportsCollections } from './block-helpers';
 import { CoblocksIcon } from '@godaddy-wordpress/coblocks-icons';
+import { getBlockIconColor } from './helper';
+import { supportsCollections } from './block-helpers';
 
 const categories = [
 	{
@@ -24,13 +26,13 @@ const categories = [
 if ( supportsCollections() ) {
 	registerBlockCollection( 'coblocks', {
 		title: 'CoBlocks',
-		icon: CoblocksIcon,
+		icon: <Icon icon={ CoblocksIcon } style={ { color: getBlockIconColor() } } />,
 	} );
 } else {
 	categories.unshift( {
 		slug: 'coblocks',
 		title: 'CoBlocks',
-		icon: CoblocksIcon,
+		icon: <Icon icon={ CoblocksIcon } style={ { color: getBlockIconColor() } } />,
 	}, );
 }
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -108,3 +108,10 @@ export const registerBlock = ( block ) => {
 		...v2Settings,
 	} );
 };
+
+/**
+ * Returns the color used for Icon Color in the block editor.
+ */
+export function getBlockIconColor() {
+	return '#00a4a6';
+}

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -113,5 +113,5 @@ export const registerBlock = ( block ) => {
  * Returns the color used for Icon Color in the block editor.
  */
 export function getBlockIconColor() {
-	return '#1BDBDB';
+	return '#09757A';
 }

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -113,5 +113,5 @@ export const registerBlock = ( block ) => {
  * Returns the color used for Icon Color in the block editor.
  */
 export function getBlockIconColor() {
-	return '#00a4a6';
+	return '#09757A';
 }

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -113,5 +113,5 @@ export const registerBlock = ( block ) => {
  * Returns the color used for Icon Color in the block editor.
  */
 export function getBlockIconColor() {
-	return '#09757A';
+	return '#1BDBDB';
 }


### PR DESCRIPTION
### Description
This PR is trying to prevent confusion on core blocks by applying a custom color to CoBlocks block and by suffixing (CoBlocks) to posts related blocks (to prevent confusion with the post list block).

<img width="323" alt="image" src="https://user-images.githubusercontent.com/1933681/151400264-f270ade2-146e-4135-be8a-61d7ae465724.png">
