### PR TITLE
Fix some tests in Twenty Twenty-Two

### DIFF
--- a/src/blocks/social-profiles/test/social-profiles.cypress.js
+++ b/src/blocks/social-profiles/test/social-profiles.cypress.js
@@ -237,8 +237,10 @@ describe( 'Test CoBlocks Social Profiles Block', function() {
 	/**
 	 * Test the coblocks social profiles colors.
 	 * Go traditional style default color: rgb(200, 106, 25)
+	 * Skipped this test because it is Go specific, so would not work with Twenty Twenty-Two, for example
 	 */
-	it( 'Test the social profiles colors.', function() {
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Test the social profiles colors.', function() {
 		helpers.addBlockToPost( 'coblocks/social-profiles', true );
 
 		cy.get( '.wp-block-coblocks-social-profiles button[aria-label="Add Facebook profile"]' ).first().click();

--- a/src/extensions/lightbox-controls/test/lightbox-controls.cypress.js
+++ b/src/extensions/lightbox-controls/test/lightbox-controls.cypress.js
@@ -56,11 +56,11 @@ describe( 'Test CoBlocks Lightbox Controls extension', function() {
 
 			helpers.viewPage();
 
-			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).should( 'have.attr', 'src' ).should( 'include', imageBase );
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"], figure img[src*="http"][class^="wp-image-"]` ).should( 'have.attr', 'src' ).should( 'include', imageBase );
 
 			cy.get( '.coblocks-lightbox' ).should( 'be.hidden' );
 
-			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).click( { force: true } );
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"], figure img[src*="http"][class^="wp-image-"]` ).click( { force: true } );
 
 			cy.get( '.coblocks-lightbox' ).should( 'be.visible' );
 
@@ -120,11 +120,11 @@ describe( 'Test CoBlocks Lightbox Controls extension', function() {
 
 			helpers.viewPage();
 
-			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).should( 'have.attr', 'src' ).should( 'include', imageBase );
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"], figure img[src*="http"][class^="wp-image-"]` ).should( 'have.attr', 'src' ).should( 'include', imageBase );
 
 			cy.get( '.coblocks-lightbox' ).should( 'be.hidden' );
 
-			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"]` ).click( { force: true } );
+			cy.get( `figure[class*="align${ alignment }"] img[src*="http"][class^="wp-image-"], figure img[src*="http"][class^="wp-image-"]` ).click( { force: true } );
 
 			cy.get( '.coblocks-lightbox' ).should( 'be.visible' );
 

--- a/src/extensions/media-text-styles/test/media-text-styles.cypress.js
+++ b/src/extensions/media-text-styles/test/media-text-styles.cypress.js
@@ -12,7 +12,7 @@ describe( 'Test CoBlocks Media Text styles extension', function() {
 		helpers.addBlockToPost( 'core/media-text', true );
 		helpers.upload.imageToBlock( 'core/media-text' );
 
-		const selectBlock = () => cy.get( `img[src*="${ imageBase }"]` ).click();
+		const selectBlock = () => cy.get( `img[src*="${ imageBase }"]` ).click( { force: true } );
 
 		cy.get( `img[src*="${ imageBase }"]` );
 


### PR DESCRIPTION
### Description
- Removed a colors test in Social Profiles, because the colors were Go-specific
- Fixed Lightbox tests (align wide is the default, so the class is not there when align is wide)
- Fixed a Media Text styles test

### Types of changes
Tests fixes

### Checklist:
- [X] My code is tested
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included any necessary tests <!-- if applicable -->
- [X] I've added proper labels to this pull request <!-- if applicable -->
