### PR TITLE
Fix custom icons not loading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,11 @@ commands:
           command: |
             ./vendor/bin/wp theme install go --activate --path=/tmp/wordpress
       - run:
+          name: Create custom icon
+          command: |
+            mkdir -p /tmp/wordpress/wp-content/themes/go/coblocks/icons
+            echo '<svg height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><circle class="inner-circle" cx="20" cy="20" r="8" stroke-width="8" stroke-dasharray="50.2655 50.2655" stroke-dashoffset="0"></circle></svg>' >> /tmp/wordpress/wp-content/themes/go/coblocks/icons/custom.svg
+      - run:
           name: Activate CoBlocks
           command: |
             ln -s $HOME/project /tmp/wordpress/wp-content/plugins/coblocks

--- a/src/blocks/icon/deprecated/svgsv1.js
+++ b/src/blocks/icon/deprecated/svgsv1.js
@@ -1,6 +1,11 @@
 /* global coblocksBlockData */
 
 /**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -1832,15 +1837,16 @@ let icons = bundledIconsEnabled ? {
 } : {};
 
 if ( typeof coblocksBlockData !== 'undefined' && Object.keys( coblocksBlockData.customIcons ).length ) {
-	Object.keys( coblocksBlockData.customIcons ).forEach( function( key ) {
-		const customIcon = ( coblocksBlockData.customIcons[ key ].icon ).replace( '<svg', '<svg data-coblocks-custom-icon="true" role="img" aria-hidden="true" focusable="false"' );
-		coblocksBlockData.customIcons[ key ].icon = parse( customIcon );
-		if ( 'icon_outlined' in coblocksBlockData.customIcons[ key ] ) {
-			const outlinedIcon = ( coblocksBlockData.customIcons[ key ].icon_outlined ).replace( '<svg', '<svg data-coblocks-custom-icon="true" role="img" aria-hidden="true" focusable="false"' );
-			coblocksBlockData.customIcons[ key ].icon_outlined = parse( outlinedIcon );
+	const customIcons = _.cloneDeep( coblocksBlockData.customIcons );
+	Object.keys( customIcons ).forEach( function( key ) {
+		const customIcon = ( customIcons[ key ].icon ).replace( '<svg', '<svg data-coblocks-custom-icon="true" role="img" aria-hidden="true" focusable="false"' );
+		customIcons[ key ].icon = parse( customIcon );
+		if ( 'icon_outlined' in customIcons[ key ] ) {
+			const outlinedIcon = ( customIcons[ key ].icon_outlined ).replace( '<svg', '<svg data-coblocks-custom-icon="true" role="img" aria-hidden="true" focusable="false"' );
+			customIcons[ key ].icon_outlined = parse( outlinedIcon );
 		}
 	} );
-	icons = { ...icons, ...coblocksBlockData.customIcons };
+	icons = { ...icons, ...customIcons };
 }
 
 // Disable reason: Mutation within execution context - no return value.

--- a/src/blocks/icon/svgs.js
+++ b/src/blocks/icon/svgs.js
@@ -1,6 +1,11 @@
 /* global coblocksBlockData */
 
 /**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import parse from 'html-react-parser';
@@ -20,15 +25,16 @@ const bundledIconsEnabled = ( typeof coblocksBlockData === 'undefined' || cobloc
 let icons = bundledIconsEnabled ? allSvgs : {};
 
 if ( typeof coblocksBlockData !== 'undefined' && Object.keys( coblocksBlockData.customIcons ).length ) {
-	Object.keys( coblocksBlockData.customIcons ).forEach( function( key ) {
-		const customIcon = ( coblocksBlockData.customIcons[ key ].icon ).replace( '<svg', '<svg data-coblocks-custom-icon="true" role="img" aria-hidden="true" focusable="false"' );
-		coblocksBlockData.customIcons[ key ].icon = parse( customIcon );
-		if ( 'icon_outlined' in coblocksBlockData.customIcons[ key ] ) {
-			const outlinedIcon = ( coblocksBlockData.customIcons[ key ].icon_outlined ).replace( '<svg', '<svg data-coblocks-custom-icon="true" role="img" aria-hidden="true" focusable="false"' );
-			coblocksBlockData.customIcons[ key ].icon_outlined = parse( outlinedIcon );
+	const customIcons = _.cloneDeep( coblocksBlockData.customIcons );
+	Object.keys( customIcons ).forEach( function( key ) {
+		const customIcon = ( customIcons[ key ].icon );
+		customIcons[ key ].icon = parse( customIcon );
+		if ( 'icon_outlined' in customIcons[ key ] ) {
+			const outlinedIcon = ( customIcons[ key ].icon_outlined );
+			customIcons[ key ].icon_outlined = parse( outlinedIcon );
 		}
 	} );
-	icons = { ...icons, ...coblocksBlockData.customIcons };
+	icons = { ...icons, ...customIcons };
 }
 
 // Disable reason: Mutation within execution context - no return value.


### PR DESCRIPTION
### Description
Fix custom icons crashing the Icons block.
See: https://github.com/godaddy-wordpress/coblocks/issues/2251

### Types of changes
Bug fix

### How has this been tested?
Manually tested. @olafleur we should find a way to cover custom icons in our tests :)

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
