### PR TITLE
Fix Lightbox being opened with improper keypress

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -111,6 +111,7 @@
 		} );
 
 		close.addEventListener( 'click', function() {
+			removeKeyboardListener();
 			wrapper.style.display = 'none';
 		} );
 
@@ -156,31 +157,37 @@
 			counter.textContent = `${ ( index + 1 ) } / ${ images.length }`;
 		}
 
-		function setKeyboardListener( ) {
-			document.onkeydown = function( e ) {
-				const lightboxDisplayValue = wrapper;
-				const lightboxIsOpen = ( typeof lightboxDisplayValue !== 'undefined' && lightboxDisplayValue !== 'none' );
-				if ( lightboxIsOpen ) {
-					e = e || window.event;
-					switch ( e.keyCode ) {
-						case 27 : // Esc key
-							close.click();
-							break;
-						case 37 : // Arrow left or 'A' key.
-							arrowLeftContainer.click();
-							break;
-						case 65 : // 'A' key.
-							arrowLeftContainer.click();
-							break;
-						case 39 : // Arrow right.
-							arrowRightContainer.click();
-							break;
-						case 68 : // 'D' key.
-							arrowRightContainer.click();
-							break;
-					}
+		const setKeyboardListener = () => document.addEventListener( 'keydown', keyPressEventListener );
+		const removeKeyboardListener = () => document.removeEventListener( 'keydown', keyPressEventListener );
+
+		const keyPressEventListener = ( event ) => {
+			if ( ! event || ! event?.code ) {
+				return;
+			}
+
+			const lightboxDisplayValue = wrapper;
+			const lightboxIsOpen = ( typeof lightboxDisplayValue !== 'undefined' && lightboxDisplayValue?.style?.display === 'flex' );
+
+			if ( lightboxIsOpen ) {
+				const code = event.code;
+				switch ( code ) {
+					case 'Escape' : // Esc key
+						close.click();
+						break;
+					case 'ArrowLeft' : // Arrow left.
+						arrowLeftContainer.click();
+						break;
+					case 'KeyA' : // 'A' key.
+						arrowLeftContainer.click();
+						break;
+					case 'ArrowRight' : // Arrow right.
+						arrowRightContainer.click();
+						break;
+					case 'KeyD' : // 'D' key.
+						arrowRightContainer.click();
+						break;
 				}
-			};
-		}
+			}
+		};
 	}
 }() );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The Lightbox uses event listeners to navigate. Changes here remove the listener when the lightbox is closed.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript. Refactor from using deprecated standard `.keyCode` to using `.code` property.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
