### PR TITLE
Fix .icon scoping from Swiper component

### DIFF
--- a/src/components/swiper/style.scss
+++ b/src/components/swiper/style.scss
@@ -87,6 +87,13 @@
 
 		transform: translateY(-50%);
 		width: 62px;
+
+		.icon {
+			background-color: #fff;
+			height: 32px;
+			mask-image: url(/assets/lightbox/arrow-right.svg);
+			width: 32px;
+		}
 	}
 
 	&__prev {
@@ -120,10 +127,4 @@
 	pointer-events: none !important;
 	touch-action: none !important;
 	user-select: none !important;
-}
-
-.icon {
-	height: 32px;
-	mask-image: url(/assets/lightbox/arrow-right.svg);
-	width: 32px;
 }


### PR DESCRIPTION
### Description
- Fix `.icon` scoping
- Fix missing background color on arrows

### Screenshots
![image](https://user-images.githubusercontent.com/85305825/151855751-fc27ad41-df78-4732-a709-329b1e1b9297.png)


### Types of changes
Visual

### How has this been tested?
Visually tested

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
