### PR TITLE
Update readme formatting to fix Changelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -112,19 +112,16 @@ Developers can also apply minor style touch-ups to their themes if necessary. If
 
 == Changelog ==
 
-2.21.5 / 2022-01-31
-===================
+= 2.21.5 / 2022-01-31 =
 ### Bug fixes
 * Fix `.icon` class scoping from Swiper component [#2259](https://github.com/godaddy-wordpress/coblocks/pull/2259)
 * Fix Lightbox opening unexpectedly [#2258](https://github.com/godaddy-wordpress/coblocks/pull/2258)
 
-2.21.4 / 2022-01-28
-=====================
+= 2.21.4 / 2022-01-28 =
 ### Bug fixes
 * Fix console error related to blocks icons. [#2254](https://github.com/godaddy-wordpress/coblocks/pull/2254)
 
-2.21.3 / 2022-01-28
-===================
+= 2.21.3 / 2022-01-28 =
 ### Bug Fixes
 * Fix improperly enqueued dependency for Counter block [#2252](https://github.com/godaddy-wordpress/coblocks/pull/2252)
 * Fix React state errors in the browser console [#2245](https://github.com/godaddy-wordpress/coblocks/pull/2245)
@@ -132,21 +129,18 @@ Developers can also apply minor style touch-ups to their themes if necessary. If
 ### Misc
 * Improve stability of CoBlocks Block icon color [#2249](https://github.com/godaddy-wordpress/coblocks/pull/2249)
 
-2.21.2 / 2022-01-27
-===================
+= 2.21.2 / 2022-01-27 =
 ### Bug Fixes
 * Ensure SVGs are bundled with release [#2248](https://github.com/godaddy-wordpress/coblocks/pull/2248)
 
-2.21.1 / 2022-01-27
-===================
+= 2.21.1 / 2022-01-27 =
 ### Enhancements
 * Improve visual styles for CoBlocks blocks [#2242](https://github.com/godaddy-wordpress/coblocks/pull/2242)
 
 ### Bug Fixes
 * Fix occurrence of unregistered block [#2247](https://github.com/godaddy-wordpress/coblocks/pull/2247)
 
-2.21.0 / 2022-01-26
-===================
+= 2.21.0 / 2022-01-26 =
 ### Enhancements
 * Introduce Counter Block [#2224](https://github.com/godaddy-wordpress/coblocks/pull/2224)
 
@@ -156,13 +150,11 @@ Developers can also apply minor style touch-ups to their themes if necessary. If
 * Fix Lightbox for Gallery block in 5.9 [#2239](https://github.com/godaddy-wordpress/coblocks/pull/2239)
 * Fix Form block input styles in editor. [#2209](https://github.com/godaddy-wordpress/coblocks/pull/2209)
 
-2.20.1 / 2022-01-25
-===================
+= 2.20.1 / 2022-01-25 =
 ### Bug Fixes
 * Fix CSS issue with CoBlocks extensions [#2236](https://github.com/godaddy-wordpress/coblocks/pull/2236)
 
-2.20.0 / 2022-01-24
-==================
+= 2.20.0 / 2022-01-24 =
 ### Enhancements
 * Introduce Request a Quote variation to Form block [#2149](https://github.com/godaddy-wordpress/coblocks/pull/2149)
 * Add compatibility with WordPress 5.9 [#2232](https://github.com/godaddy-wordpress/coblocks/pull/2232)


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Simple formatting change here. This should allow the CoBlocks changelog to reside under the development section of the WP.org page.