### PR TITLE
Add styling to hide Safari default marker on FAQ items

### DIFF
--- a/src/blocks/faq/styles/style.scss
+++ b/src/blocks/faq/styles/style.scss
@@ -6,4 +6,8 @@
 	&__heading {
 		margin: 1.25rem 0 0 !important;
 	}
+
+	summary::-webkit-details-marker {
+		display: none;
+	}
 }


### PR DESCRIPTION
### Description
Safari adds a marker that conflicts visually with the default marker we add for the FAQ items list. This removes it.

Before:
<img width="974" alt="Screen Shot 2022-02-04 at 2 34 40 PM" src="https://user-images.githubusercontent.com/1933681/152592485-803c5fd3-c3ae-4b78-a76b-ffa8d8fdab00.png">

After: 
<img width="940" alt="Screen Shot 2022-02-04 at 2 35 08 PM" src="https://user-images.githubusercontent.com/1933681/152592497-1277bc4e-8dbe-43f2-b48a-b692a8967bf3.png">

