### PR TITLE
Try to run E2E on final build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,8 +322,9 @@ commands:
           name: Activate CoBlocks
           command: |
             ln -s $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
-            npx grunt build && npx grunt compress
-            ./vendor/bin/wp plugin activate ./build/*.zip --path=/tmp/wordpress
+            npx grunt build
+            mv ./build/coblocks /tmp/wordpress/wp-content/plugins/coblocks-testing
+            ./vendor/bin/wp plugin activate coblocks-testing --path=/tmp/wordpress
 
   # Enable debug mode for use in E2E tests.
   enable_debug_mode_for_e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,8 @@ commands:
           name: Activate CoBlocks
           command: |
             ln -s $HOME/project /tmp/wordpress/wp-content/plugins/coblocks
-            ./vendor/bin/wp plugin activate coblocks --path=/tmp/wordpress
+            npx grunt build && npx grunt compress
+            ./vendor/bin/wp plugin activate ./build/*.zip --path=/tmp/wordpress
 
   # Enable debug mode for use in E2E tests.
   enable_debug_mode_for_e2e:
@@ -400,9 +401,6 @@ commands:
           command: |
             touch cypress.env.json
             echo '{"wpUsername":"admin","wpPassword":"password","testURL":"http://coblocks.test"}' | jq . > cypress.env.json
-            npx grunt build && npx grunt compress
-            wp plugin deactivate coblocks
-            wp plugin activate ./build/*.zip
             ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >>-wp-<< parameters.wpversion >>
 
   setup_perf_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,9 @@ commands:
           command: |
             touch cypress.env.json
             echo '{"wpUsername":"admin","wpPassword":"password","testURL":"http://coblocks.test"}' | jq . > cypress.env.json
+            npx grunt build && npx grunt compress
+            wp plugin deactivate coblocks
+            wp plugin activate ./build/*.zip
             ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >>-wp-<< parameters.wpversion >>
 
   setup_perf_tests:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ languages/*-coblocks-editor.json
 languages/*.mo
 languages/*.po
 cypress.env.json
+.wp-env.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ languages/*.mo
 languages/*.po
 cypress.env.json
 .wp-env.json
+.wp-env.override.json


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Enhance the CircleCI config to build and test E2E against the final build.
This change makes it so that we no longer activate the CoBlocks plugin dev version and instead run `coblocks-testing` which is a clone of the final build produced by `grunt build`.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
CI changes. Minimal Bash and WP-CLI.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
In CI.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
