### PR TITLE
Drop PHP tests in 7.3 and add them in 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node_latest:
     docker:
-      - image: cimg/node:latest
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -258,7 +258,6 @@ commands:
           name: Install WordPress
           command: |
             sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y subversion default-mysql-client
-            sudo -E docker-php-ext-install mysqli
             mkdir -p /tmp/wordpress
             ./vendor/bin/wp core download --version=$WPVERSION --path=/tmp/wordpress
             ./vendor/bin/wp config create --dbhost=127.0.0.1 --dbname=coblocks --dbuser=root --dbpass='' --path=/tmp/wordpress
@@ -381,7 +380,6 @@ commands:
             echo 127.0.0.1 localhost | sudo tee -a /etc/hosts
             sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y subversion default-mysql-client
             sudo mkdir /conf.d/
-            sudo -E docker-php-ext-install mysqli
 
   run_perf_tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,73 +6,49 @@ orbs:
 executors:
   node_latest:
     docker:
-      - image: circleci/node:latest
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-  php_73_node:
-    docker:
-      - image: circleci/php:7.3-node
+      - image: cimg/node:latest
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_56_mysql:
     docker:
-      - image: circleci/php:5.6
+      - image: cimg/php:5.6
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-      - image: circleci/mysql:5.7-ram
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-  php_73_mysql:
-    docker:
-      - image: circleci/php:7.3.31-apache-node
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-        environment:
-          XDEBUG_MODE=coverage
-      - image: circleci/mysql:5.7-ram
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-  php_73_node_browser_legacy:
-     docker:
-      - image: circleci/php:7.3-node-browsers-legacy
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_74_mysql:
     docker:
-      - image: circleci/php:7.4.24-apache-node
+      - image: cimg/php:7.4-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
           XDEBUG_MODE=coverage
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_74_node_browser_mysql:
     docker:
-      - image: circleci/php:7.4.24-node-browsers
+      - image: cimg/php:7.4-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_74_node_browser_mysql_mailhog:
     docker:
-      - image: circleci/php:7.4.24-node-browsers
+      - image: cimg/php:7.4-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -82,13 +58,13 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_80_mysql:
     docker:
-      - image: circleci/php:8.0.11-apache-node
+      - image: cimg/php:8.0.13-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
           XDEBUG_MODE=coverage
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -100,7 +76,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   go_node_browser_legacy:
     docker:
-      - image: circleci/golang:latest-node-browsers-legacy
+      - image: cimg/golang:1.17-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -135,18 +111,6 @@ workflows:
 
       # UNIT TESTING
       # Support PHP Versions: http://php.net/supported-versions.php
-      - unit_testing_php_56:
-          filters:
-            tags:
-              only: /^(?!canary).*$/
-          requires:
-            - php
-      - unit_testing_php_73:
-          filters:
-            tags:
-              only: /^(?!canary).*$/
-          requires:
-            - php
       - unit_testing_php_74:
           filters:
             tags:
@@ -216,8 +180,6 @@ workflows:
             branches:
               only: master
           requires:
-            - unit_testing_php_56
-            - unit_testing_php_73
             - unit_testing_php_74
             - unit_testing_php_80
             - js
@@ -226,21 +188,15 @@ workflows:
             branches:
               only: master
           requires:
-            - unit_testing_php_56
-            - unit_testing_php_73
             - unit_testing_php_74
             - unit_testing_php_80
             - js
 
       - deploy:
           requires:
-            - unit_testing_php_56
-            - unit_testing_php_73
             - unit_testing_php_74
             - unit_testing_php_80
             - js
-            # - e2e_firefox
-            # - e2e_chrome
           filters:
             tags:
               only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*)?(\+[0-9-]+(\.[0-9]+)*)?/ # Run on semantic version tags only
@@ -685,16 +641,6 @@ jobs:
   # Unit Testing
   # --------------------------------------------------
 
-  unit_testing_php_56:
-    executor: php_56_mysql
-    steps:
-      - run_php_unit_tests
-
-  unit_testing_php_73:
-    executor: php_73_mysql
-    steps:
-      - run_php_unit_tests
-
   unit_testing_php_74:
     executor: php_74_mysql
     steps:
@@ -841,7 +787,7 @@ jobs:
   # Internationalization Processes
   # --------------------------------------------------
   i18n:
-    executor: php_73_node_browser_legacy
+    executor: php_74_mysql
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   jq: circleci/jq@2.2.0
+  browser-tools: circleci/browser-tools@1.1
 
 executors:
   node_latest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,18 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+  php_81_mysql:
+    docker:
+      - image: cimg/php:8.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          XDEBUG_MODE=coverage
+      - image: cimg/mysql:5.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
   php_74_node:
     docker:
       - image: cimg/php:7.4-node
@@ -109,6 +121,12 @@ workflows:
           requires:
             - php
       - unit_testing_php_80:
+          filters:
+            tags:
+              only: /^(?!canary).*$/
+          requires:
+            - php
+      - unit_testing_php_81:
           filters:
             tags:
               only: /^(?!canary).*$/
@@ -168,6 +186,7 @@ workflows:
           requires:
             - unit_testing_php_74
             - unit_testing_php_80
+            - unit_testing_php_81
             - js
       - i18n:
           filters:
@@ -176,12 +195,14 @@ workflows:
           requires:
             - unit_testing_php_74
             - unit_testing_php_80
+            - unit_testing_php_81
             - js
 
       - deploy:
           requires:
             - unit_testing_php_74
             - unit_testing_php_80
+            - unit_testing_php_81
             - js
           filters:
             tags:
@@ -633,6 +654,12 @@ jobs:
 
   unit_testing_php_80:
     executor: php_80_mysql
+    steps:
+      - run_php_unit_tests:
+          reportCoverage: false # we are currently using an incompatible phpunit library for coverage reporting in PHP 8
+
+  unit_testing_php_81:
+    executor: php_81_mysql
     steps:
       - run_php_unit_tests:
           reportCoverage: false # we are currently using an incompatible phpunit library for coverage reporting in PHP 8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,6 +335,7 @@ commands:
         type: string
         default: latest
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - setup_e2e_env_var
       - changed_files_with_extension:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,7 +638,7 @@ jobs:
           reportCoverage: false # we are currently using an incompatible phpunit library for coverage reporting in PHP 8
 
   js:
-    executor: php_74_node
+    executor: node_latest
     steps:
       - checkout
       - changed_files_with_extension:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,19 +11,9 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_56_mysql:
-    docker:
-      - image: cimg/php:5.6
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: cimg/mysql:5.7
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
   php_74_mysql:
     docker:
-      - image: cimg/php:7.4-node
+      - image: cimg/php:7.4
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -33,7 +23,7 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_74_node_browser_mysql:
+  php_74_browsers_mysql:
     docker:
       - image: cimg/php:7.4-browsers
         auth:
@@ -43,7 +33,7 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_74_node_browser_mysql_mailhog:
+  php_74_browsers_mysql_mailhog:
     docker:
       - image: cimg/php:7.4-browsers
         auth:
@@ -59,7 +49,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_80_mysql:
     docker:
-      - image: cimg/php:8.0.13-node
+      - image: cimg/php:8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -71,13 +61,13 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_74_node:
     docker:
-      - image: cimg/php:7.4.24-node
+      - image: cimg/php:7.4-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  go_node_browser_legacy:
+  go_browsers:
     docker:
-      - image: cimg/golang:1.17-browsers
+      - image: cimg/go:1.17-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -150,12 +140,7 @@ workflows:
       #      tags:
       #        only: /^(?!canary).*$/
       #    requires:
-      #      - css
-      #      - unit_testing_php_56
-      #      - unit_testing_php_73
-      #      - unit_testing_php_74
-      #      - unit_testing_php_80
-      #      - js
+      #      - build
 
       # PERF TESTING
       - perf_tests_master:
@@ -519,7 +504,7 @@ jobs:
   # 3. Persist project folder to workspace for other jobs.
   build:
     docker:
-      - image: circleci/php:7.4-node
+      - image: cimg/php:7.4-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -582,7 +567,7 @@ jobs:
 
   pr_artifact_comment:
     docker:
-      - image: circleci/php:7.4-node
+      - image: cimg/php:7.4-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -694,21 +679,21 @@ jobs:
   # --------------------------------------------------
 
   e2e_chrome_wp_latest:
-    executor: php_74_node_browser_mysql_mailhog
+    executor: php_74_browsers_mysql_mailhog
     parallelism: 11
     steps:
       - run_e2e_tests:
           browser: chrome
 
   e2e_firefox_wp_latest:
-    executor: php_74_node_browser_mysql_mailhog
+    executor: php_74_browsers_mysql_mailhog
     parallelism: 11
     steps:
       - run_e2e_tests:
           browser: firefox
 
   e2e_chrome_wp_previous_major:
-    executor: php_74_node_browser_mysql_mailhog
+    executor: php_74_browsers_mysql_mailhog
     parallelism: 11
     steps:
       - run_e2e_tests:
@@ -716,7 +701,7 @@ jobs:
           wpversion: previous_major
 
   perf_tests_master:
-    executor: php_74_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - checkout
       - setup_perf_tests
@@ -732,7 +717,7 @@ jobs:
             - ./*-median-results.json
 
   perf_tests_current:
-    executor: php_74_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - checkout
       - setup_perf_tests
@@ -748,7 +733,7 @@ jobs:
             - ./*-median-results.json
 
   aggregate_perf_test_results:
-    executor: php_74_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - run:
           name: Check branch
@@ -821,7 +806,7 @@ jobs:
             fi
 
   canary-release:
-    executor: go_node_browser_legacy
+    executor: go_browsers
     steps:
       - checkout
       - attach_workspace:
@@ -878,7 +863,7 @@ jobs:
   # Plugin Deployment to WordPress.org
   # --------------------------------------------------
   deploy:
-    executor: go_node_browser_legacy
+    executor: go_browsers
     steps:
       - checkout
       - attach_workspace:

--- a/.dev/bin/install-dependencies.sh
+++ b/.dev/bin/install-dependencies.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 
 sudo apt-get update && sudo apt-get install -y subversion default-mysql-client
-sudo -E docker-php-ext-install mysqli
 
 .dev/bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest


### PR DESCRIPTION
### Description
- Drop unit tests in PHP 7.3
- Add unit tests in PHP 8.1
- Switch to Convenience Images (which are the recommended images since December 31st)