### PR TITLE
Replace `cypress-file-upload` with Cypress built-in upload

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -339,7 +339,7 @@ export const upload = {
 	imageToBlock: ( blockName ) => {
 		const { fileName, pathToFixtures } = upload.spec;
 		cy.fixture( pathToFixtures + fileName, { encoding: null } ).then( ( fileContent ) => {
-			cy.get( `[data-type="${ blockName }"] input[type="file"]` )
+			cy.get( `[data-type="${ blockName }"] input[type="file"]` ).first()
 				.selectFile( { contents: fileContent, fileName: pathToFixtures + fileName, mimeType: 'image/png' }, { force: true } );
 
 			// Now validate upload is complete and is not a blob.

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -320,12 +320,10 @@ export const upload = {
 		// Replace the image.
 		const newImageBase = 'R150x150';
 		const newFilePath = `../.dev/tests/cypress/fixtures/images/${ newImageBase }.png`;
-		/* eslint-disable */
-		cy.fixture( newFilePath ).then( ( fileContent ) => {
-			cy.get( '[class^="moxie"] [type="file"]' )
-			.attachFile( { fileContent, filePath: newFilePath, mimeType: 'image/png' }, { force: true } );
+
+		cy.fixture( newFilePath, { encoding: null } ).then( ( fileContent ) => {
+			cy.get( '[class^="moxie"] [type="file"]' ).selectFile( { contents: fileContent, fileName: newFilePath, mimeType: 'image/png' }, { force: true } );
 		} );
-		/* eslint-enable */
 
 		cy.get( '.attachment.selected.save-ready' );
 		cy.get( '.media-modal .media-button-select' ).click();
@@ -340,9 +338,9 @@ export const upload = {
 	 */
 	imageToBlock: ( blockName ) => {
 		const { fileName, pathToFixtures } = upload.spec;
-		cy.fixture( pathToFixtures + fileName ).then( ( fileContent ) => {
+		cy.fixture( pathToFixtures + fileName, { encoding: null } ).then( ( fileContent ) => {
 			cy.get( `[data-type="${ blockName }"] input[type="file"]` )
-				.attachFile( { fileContent, filePath: pathToFixtures + fileName, mimeType: 'image/png' }, { force: true } );
+				.selectFile( { contents: fileContent, fileName: pathToFixtures + fileName, mimeType: 'image/png' }, { force: true } );
 
 			// Now validate upload is complete and is not a blob.
 			cy.get( `[class*="-visual-editor"] [data-type="${ blockName }"] [src^="http"]` );

--- a/.dev/tests/cypress/support/commands.js
+++ b/.dev/tests/cypress/support/commands.js
@@ -1,5 +1,4 @@
 import { loginToSite, disableGutenbergFeatures } from '../helpers';
-import 'cypress-file-upload';
 
 before( function() {
 	loginToSite();

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
 		"copy-webpack-plugin": "^10.2.0",
 		"counterup2": "^2.0.2",
 		"cypress": "^9.4.1",
-		"cypress-file-upload": "^5.0.8",
 		"cypress-log-to-output": "1.1.2",
 		"email-validator": "^2.0.4",
 		"eslint-plugin-cypress": "^2.10.3",

--- a/src/blocks/author/test/author.cypress.js
+++ b/src/blocks/author/test/author.cypress.js
@@ -59,11 +59,9 @@ describe( 'Test CoBlocks Author Block', function() {
 		helpers.selectBlock( 'author' );
 
 		// Upload the Author avatar
-		// Disable reason: cy.fixture should not return a value.
-		// eslint-disable-next-line jest/valid-expect-in-promise
-		cy.fixture( pathToFixtures + fileName ).then( ( fileContent ) => {
+		cy.fixture( pathToFixtures + fileName, { encoding: null } ).then( ( fileContent ) => {
 			cy.get( 'div[data-type="coblocks/author"] .wp-block-coblocks-author__avatar' ).click();
-			cy.get( '[class^="moxie"] [type="file"]' ).attachFile( { fileContent, filePath: pathToFixtures + fileName, mimeType: 'image/png', subjectType: 'drag-n-drop' }, { force: true } );
+			cy.get( '[class^="moxie"] [type="file"]' ).selectFile( { action: 'drag-drop', contents: fileContent, fileName: pathToFixtures + fileName, mimeType: 'image/png' }, { force: true } );
 
 			cy.get( '.attachment.selected.save-ready' );
 

--- a/src/blocks/gallery-collage/test/gallery-collage.cypress.js
+++ b/src/blocks/gallery-collage/test/gallery-collage.cypress.js
@@ -2,7 +2,6 @@
  * Include our constants
  */
 import * as helpers from '../../../../.dev/tests/cypress/helpers';
-import 'cypress-file-upload';
 
 describe( 'Test CoBlocks Gallery Collage Block', function() {
 	/**

--- a/src/blocks/hero/test/hero.cypress.js
+++ b/src/blocks/hero/test/hero.cypress.js
@@ -7,8 +7,8 @@ describe( 'Test CoBlocks Hero Block', function() {
 	// Setup Hero data.
 	const heroData = {
 		backgroundColor: '#ff0000',
-		textColor: '#ffffff',
 		backgroundColorRGB: 'rgb(255, 0, 0)',
+		textColor: '#ffffff',
 		textColorRGB: 'rgb(255, 255, 255)',
 	};
 
@@ -99,10 +99,8 @@ describe( 'Test CoBlocks Hero Block', function() {
 
 		const { pathToFixtures, fileName } = helpers.upload.spec;
 
-		// Disable reason: cy.fixture should not return a value.
-		// eslint-disable-next-line jest/valid-expect-in-promise
-		cy.fixture( pathToFixtures + fileName, 'base64' ).then( ( fileContent ) => {
-			cy.get( '[class^="moxie"] [type="file"]' ).attachFile( { fileContent, filePath: pathToFixtures + fileName, mimeType: 'image/png', subjectType: 'drag-n-drop' }, { force: true } );
+		cy.fixture( pathToFixtures + fileName, { encoding: null } ).then( ( fileContent ) => {
+			cy.get( '[class^="moxie"] [type="file"]' ).selectFile( { action: 'drag-drop', contents: fileContent, fileName: pathToFixtures + fileName, mimeType: 'image/png' }, { force: true } );
 		} );
 
 		cy.get( '.attachment.selected.save-ready' );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5993,11 +5993,6 @@ cwd@^0.10.0:
     find-pkg "^0.1.2"
     fs-exists-sync "^0.1.0"
 
-cypress-file-upload@^5.0.8:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
-  integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
-
 cypress-log-to-output@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cypress-log-to-output/-/cypress-log-to-output-1.1.2.tgz#b9635a907ed06961cd53cc1bff8d6f55a981a773"


### PR DESCRIPTION
### Description
Since Cypress 9.3, a `selectFile` function is available, that works almost like the `attachFile` function from `cypress-file-upload`. By switching to the built-in version, we remove this dependency.

### Types of changes
Refactoring

### How has this been tested?
Cypress tests locally and on the CI
