### PR TITLE
WPEX-1829 refactor color settings helper function to be compatible with 5.9.1

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -367,10 +367,12 @@ export function setColorSetting( settingName, hexColor ) {
 	const formattedHex = hexColor.split( '#' )[ 1 ];
 
 	cy.get( '.block-editor-panel-color-gradient-settings__dropdown' ).contains( settingName, { matchCase: false } ).click();
-	cy.get( '.components-color-palette__custom-color' );
 	cy.get( '.components-color-palette__custom-color' ).click();
+
 	cy.get( '[aria-label="Show detailed inputs"]' ).click();
 	cy.get( '.components-color-picker' ).find( '.components-input-control__input' ).click().clear().type( formattedHex );
+
+	cy.get( '.block-editor-panel-color-gradient-settings__dropdown' ).contains( settingName, { matchCase: false } ).click();
 }
 
 /**

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -370,9 +370,7 @@ export function setColorSetting( settingName, hexColor ) {
 	cy.get( '.components-color-palette__custom-color' );
 	cy.get( '.components-color-palette__custom-color' ).click();
 	cy.get( '[aria-label="Show detailed inputs"]' ).click();
-	cy.get( '.components-input-control__input' ).click().clear().type( formattedHex );
-
-	cy.get( '.block-editor-writing-flow' ).click();
+	cy.get( '.components-color-picker' ).find( '.components-input-control__input' ).click().clear().type( formattedHex );
 }
 
 /**

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -363,37 +363,16 @@ export const upload = {
  */
 export function setColorSetting( settingName, hexColor ) {
 	openSettingsPanel( /color settings|color/i );
-	cy.get( '.components-base-control__field' )
-		.contains( RegExp( settingName, 'i' ) )
-		.then( ( $subColorPanel ) => {
-			// < WP 5.9
-			if ( Cypress.$( '.components-color-palette__custom-color' ).length === 0 ) {
-				cy.get( Cypress.$( $subColorPanel ).closest( '.components-base-control' ) )
-					.contains( /custom color/i )
-					.click();
-				cy.get( '.components-color-picker__inputs-field input[type="text"]' )
-					.clear()
-					.type( hexColor );
-				cy.get( Cypress.$( $subColorPanel ).closest( '.components-base-control' ) )
-					.contains( /custom color/i )
-					.click();
-			// WP 5.9
-			} else {
-				cy.get( Cypress.$( $subColorPanel ).closest( '.components-flex' ) )
-					.find( '.components-color-palette__custom-color' )
-					.click( { force: true } );
-				cy.get( '.components-color-picker' )
-					.find( '.components-button' )
-					.click( { force: true } );
-				cy.get( '.components-color-picker' )
-					.find( '.components-input-control' )
-					.clear()
-					.type( hexColor.substring( 1 ) ); // remove the #
-				cy.get( Cypress.$( $subColorPanel ).closest( '.components-flex' ) )
-					.find( '.components-color-palette__custom-color' )
-					.click( { force: true } );
-			}
-		} );
+
+	const formattedHex = hexColor.split( '#' )[ 1 ];
+
+	cy.get( '.block-editor-panel-color-gradient-settings__dropdown' ).contains( settingName, { matchCase: false } ).click();
+	cy.get( '.components-color-palette__custom-color' );
+	cy.get( '.components-color-palette__custom-color' ).click();
+	cy.get( '[aria-label="Show detailed inputs"]' ).click();
+	cy.get( '.components-input-control__input' ).click().clear().type( formattedHex );
+
+	cy.get( '.block-editor-writing-flow' ).click();
 }
 
 /**

--- a/src/blocks/dynamic-separator/test/dynamic-separator.cypress.js
+++ b/src/blocks/dynamic-separator/test/dynamic-separator.cypress.js
@@ -69,13 +69,13 @@ describe( 'Test CoBlocks Dynamic Seperator Block', function() {
 	it( 'Test dynamic separator colors.', function() {
 		helpers.addBlockToPost( 'coblocks/dynamic-separator', true );
 
-		helpers.setColorSetting( 'color', '#55e7ff' );
+		helpers.setColorSetting( 'background', '#55e7ff' );
 
 		cy.get( '.wp-block-coblocks-dynamic-separator' )
 			.should( 'have.css', 'color' )
 			.and( 'equal', helpers.hexToRGB( '#55e7ff' ) );
 
-		helpers.setColorSetting( 'color', '#f70479' );
+		helpers.setColorSetting( 'background', '#f70479' );
 
 		cy.get( '.wp-block-coblocks-dynamic-separator' )
 			.should( 'have.css', 'color' )

--- a/src/extensions/colors/test/settings-modal-control.cypress.js
+++ b/src/extensions/colors/test/settings-modal-control.cypress.js
@@ -53,8 +53,6 @@ describe( 'Settings Modal: Colors feature', () => {
 
 	it( 'can turn off all color settings', () => {
 		cy.get( '.components-panel__body-title' ).contains( /Overlay/i ).should( 'exist' );
-		cy.get( '.components-circular-option-picker__dropdown-link-action, .components-color-palette__custom-color' ).should( 'exist' );
-		cy.get( '.block-editor-color-gradient-control__button-tabs button, .components-toggle-group-control' ).should( 'exist' );
 
 		cy.get( '.coblocks-settings-modal' ).contains( 'Color settings' ).click();
 
@@ -67,8 +65,6 @@ describe( 'Settings Modal: Colors feature', () => {
 
 	it( 'can turn off custom color settings', () => {
 		cy.get( '.components-panel__body-title' ).contains( /Overlay/i ).should( 'exist' );
-		cy.get( '.components-circular-option-picker__dropdown-link-action, .components-color-palette__custom-color' ).should( 'exist' );
-		cy.get( '.block-editor-color-gradient-control__button-tabs button, .components-toggle-group-control' ).should( 'exist' );
 
 		cy.get( '.coblocks-settings-modal' ).contains( 'Custom color pickers' ).click();
 
@@ -80,7 +76,6 @@ describe( 'Settings Modal: Colors feature', () => {
 
 	it( 'can turn off gradient settings', () => {
 		cy.get( '.components-panel__body-title' ).contains( /Overlay/i ).should( 'exist' );
-		cy.get( '.block-editor-color-gradient-control__button-tabs button, .components-toggle-group-control' ).should( 'exist' );
 
 		cy.get( '.coblocks-settings-modal' ).contains( 'Gradient styles' ).click();
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR refactors the `setColorSetting` helper function to be compatible with the updated color UX.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Refactor/Bug fix

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
