### PR TITLE
WPEX-1661 - add preview for event and event-item

### DIFF
--- a/src/blocks/events/event-item/example.js
+++ b/src/blocks/events/event-item/example.js
@@ -1,0 +1,16 @@
+import { __ } from '@wordpress/i18n';
+
+const example = {
+	name: 'coblocks/event-item',
+	attributes: {
+		title: __( 'Soccer Practice', 'coblocks' ),
+		description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed placerat convallis porta.',
+		eventDay: '21',
+		eventMonth: __( 'April', 'coblocks' ),
+		eventYear: '2021',
+		eventTime: __( '10:30 AM', 'coblocks' ),
+		eventLocation: __( 'Middle School', 'coblocks' ),
+	},
+};
+
+export default example;

--- a/src/blocks/events/event-item/index.js
+++ b/src/blocks/events/event-item/index.js
@@ -8,6 +8,7 @@ import { EventItemIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import example from './example';
 import metadata from './block.json';
 import save from './save';
 
@@ -27,6 +28,7 @@ const settings = {
 	deprecated,
 	description: __( 'An event within the events block.', 'coblocks' ),
 	edit,
+	example,
 	icon: <Icon icon={ icon } />,
 	parent: [ 'coblocks/events' ],
 	save,

--- a/src/blocks/events/index.js
+++ b/src/blocks/events/index.js
@@ -8,6 +8,7 @@ import { EventsIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import example from './example';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -27,6 +28,7 @@ const settings = {
 	deprecated,
 	description: __( 'Add a list of events or display events from a public calendar.', 'coblocks' ),
 	edit,
+	example,
 	icon: <Icon icon={ icon } />,
 	keywords: [
 		'coblocks',
@@ -39,7 +41,6 @@ const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 	},
-	// example,
 	title: _x( 'Events', 'block name', 'coblocks' ),
 	transforms,
 };


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This PR adds a preview to the event and event-item blocks 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix / enhancement

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
