### PR TITLE
Fix superfluous slash with enqueued scripts

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -409,7 +409,7 @@ class CoBlocks_Block_Assets {
 			$asset_file = $this->get_asset_file( 'dist/js/coblocks-counter' );
 			wp_enqueue_script(
 				'coblocks-counter-script',
-				$dir . '/coblocks-counter.js',
+				$dir . 'coblocks-counter.js',
 				$asset_file['dependencies'],
 				COBLOCKS_VERSION,
 				true

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -367,7 +367,7 @@ class CoBlocks_Block_Assets {
 		if ( $this->is_page_gutenberg() || has_block( 'coblocks/gallery-carousel' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
 				'coblocks-tiny-swiper',
-				$vendors_dir . '/tiny-swiper.js',
+				$vendors_dir . 'tiny-swiper.js',
 				array(),
 				COBLOCKS_VERSION,
 				true


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Removes unnecessary slash within the script path for wp_enqueue_script function for the tiny swiper package

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
