### PR TITLE
WPEX-1663 allow spacer block as an inner block of feature block

### DIFF
--- a/src/blocks/features/feature/edit.js
+++ b/src/blocks/features/feature/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Controls from './controls';
-import { BackgroundStyles, BackgroundClasses, BackgroundVideo, BackgroundDropZone } from '../../../components/background';
+import { BackgroundClasses, BackgroundDropZone, BackgroundStyles, BackgroundVideo } from '../../../components/background';
 import applyWithColors from './colors';
 import Inspector from './inspector';
 
@@ -25,7 +25,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Constants
  */
-const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/image', 'coblocks/highlight' ];
+const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/image', 'coblocks/highlight', 'core/spacer' ];
 
 const TEMPLATE = [
 	[
@@ -167,12 +167,12 @@ const Edit = ( props ) => {
 					{ isBlobURL( backgroundImg ) && <Spinner /> }
 					{ BackgroundVideo( attributes ) }
 					<InnerBlocks
-						allowedBlocks={ ALLOWED_BLOCKS }
-						template={ TEMPLATE }
-						templateLock={ false }
-						templateInsertUpdatesSelection={ false }
-						renderAppender={ () => ( null ) }
 						__experimentalCaptureToolbars={ true }
+						allowedBlocks={ ALLOWED_BLOCKS }
+						renderAppender={ () => ( null ) }
+						template={ TEMPLATE }
+						templateInsertUpdatesSelection={ false }
+						templateLock={ false }
 					/>
 				</div>
 			</div>

--- a/src/blocks/opentable/test/opentable.cypress.js
+++ b/src/blocks/opentable/test/opentable.cypress.js
@@ -29,7 +29,7 @@ describe( 'Test CoBlocks OpenTable Block', function() {
 	it( 'Test OpenTable block saves with single restaurant selection.', function() {
 		helpers.addBlockToPost( 'coblocks/opentable', true );
 
-		cy.intercept( 'GET', 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*', { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
+		cy.intercept( 'GET', new RegExp( 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*' ), { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
 
 		cy.get( '.wp-block-coblocks-opentable .components-form-token-field__input' ).type( 'test' );
 
@@ -53,7 +53,7 @@ describe( 'Test CoBlocks OpenTable Block', function() {
 	it( 'Test OpenTable changing to Tall style.', function() {
 		helpers.addBlockToPost( 'coblocks/opentable', true );
 
-		cy.intercept( 'GET', 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*', { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
+		cy.intercept( 'GET', new RegExp( 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*' ), { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
 
 		cy.get( '.wp-block-coblocks-opentable .components-form-token-field__input' ).type( 'test' );
 
@@ -83,7 +83,7 @@ describe( 'Test CoBlocks OpenTable Block', function() {
 	it( 'Test OpenTable block properly shows No results found on a superflouous query.', function() {
 		helpers.addBlockToPost( 'coblocks/opentable', true );
 
-		cy.intercept( 'GET', 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*', { fixture: '../.dev/tests/cypress/fixtures/network/none.json' } );
+		cy.intercept( 'GET', new RegExp( 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*' ), { fixture: '../.dev/tests/cypress/fixtures/network/none.json' } );
 
 		cy.get( '.wp-block-coblocks-opentable .components-form-token-field__input' ).type( 'thereisnowaythiswouldeverreturnarealrestaurant' );
 

--- a/src/blocks/opentable/test/opentable.cypress.js
+++ b/src/blocks/opentable/test/opentable.cypress.js
@@ -29,7 +29,7 @@ describe( 'Test CoBlocks OpenTable Block', function() {
 	it( 'Test OpenTable block saves with single restaurant selection.', function() {
 		helpers.addBlockToPost( 'coblocks/opentable', true );
 
-		cy.intercept( 'GET', new RegExp( 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*' ), { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
+		cy.intercept( 'GET', 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*', { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
 
 		cy.get( '.wp-block-coblocks-opentable .components-form-token-field__input' ).type( 'test' );
 
@@ -53,7 +53,7 @@ describe( 'Test CoBlocks OpenTable Block', function() {
 	it( 'Test OpenTable changing to Tall style.', function() {
 		helpers.addBlockToPost( 'coblocks/opentable', true );
 
-		cy.intercept( 'GET', new RegExp( 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*' ), { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
+		cy.intercept( 'GET', 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*', { fixture: '../.dev/tests/cypress/fixtures/network/restaurants.json' } );
 
 		cy.get( '.wp-block-coblocks-opentable .components-form-token-field__input' ).type( 'test' );
 
@@ -83,7 +83,7 @@ describe( 'Test CoBlocks OpenTable Block', function() {
 	it( 'Test OpenTable block properly shows No results found on a superflouous query.', function() {
 		helpers.addBlockToPost( 'coblocks/opentable', true );
 
-		cy.intercept( 'GET', new RegExp( 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*' ), { fixture: '../.dev/tests/cypress/fixtures/network/none.json' } );
+		cy.intercept( 'GET', 'index.php?rest_route=%2Fcoblocks%2Fopentable%2Fsearch*', { fixture: '../.dev/tests/cypress/fixtures/network/none.json' } );
 
 		cy.get( '.wp-block-coblocks-opentable .components-form-token-field__input' ).type( 'thereisnowaythiswouldeverreturnarealrestaurant' );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This PR allows the Spacer block to be used within the Feature block.

Fixes #2032


### Screenshots
<!-- if applicable -->
<img width="1156" alt="Screen Shot 2022-03-02 at 11 33 51 AM" src="https://user-images.githubusercontent.com/18115694/156405555-aa0963f1-38c5-49a2-8108-f96183ea8b72.png">


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
new feature / enhancement

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Visually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Allow for Spacer block to be used within the Feature block.


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
