### PR TITLE
Tweak form block styles

### DIFF
--- a/src/blocks/form/fields/field-label.js
+++ b/src/blocks/form/fields/field-label.js
@@ -7,24 +7,28 @@ import LabelColorWrapper from '../../../components/form-label-colors/label-color
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
+import classnames from 'classnames';
 import { RichText } from '@wordpress/block-editor';
+import { ToggleControl } from '@wordpress/components';
 
 const CoBlocksFieldLabel = ( { setAttributes, label, resetFocus, isSelected, required, name, textColor, customTextColor, showRequiredToggle = true } ) => {
+	const labelClassnames = classnames(
+		'coblocks-label',
+		'coblocks-field-label__input', {
+			required,
+		} );
 	return (
 		<div className="coblocks-field-label">
 			<div className="coblocks-field-label__input-wrapper">
 				{ label && (
 					<LabelColorWrapper
-						label={ label }
-						textColor={ textColor }
 						customTextColor={ customTextColor }
+						label={ label }
 						name={ name }
+						textColor={ textColor }
 					>
 						<RichText
-							tagName="label"
-							className="coblocks-label coblocks-field-label__input"
-							value={ label }
+							className={ labelClassnames }
 							onChange={ ( value ) => {
 								if ( resetFocus ) {
 									resetFocus();
@@ -32,19 +36,17 @@ const CoBlocksFieldLabel = ( { setAttributes, label, resetFocus, isSelected, req
 								setAttributes( { label: value } );
 							} }
 							placeholder={ __( 'Add label…', 'coblocks' ) }
+							tagName="label"
+							value={ label }
 						/>
 					</LabelColorWrapper>
-				) }
-
-				{ required && (
-					<span className="required">*</span>
 				) }
 			</div>
 			{ isSelected && showRequiredToggle && (
 				<ToggleControl
-					label={ __( 'Required', 'coblocks' ) }
-					className="coblocks-field-label__required"
 					checked={ required }
+					className="coblocks-field-label__required"
+					label={ __( 'Required', 'coblocks' ) }
 					onChange={ ( value ) => setAttributes( { required: value } ) }
 				/>
 			) }

--- a/src/blocks/form/variations.js
+++ b/src/blocks/form/variations.js
@@ -11,8 +11,8 @@ import {
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Template option choices for predefined form layouts.
@@ -112,7 +112,7 @@ const variations = [
 			[ 'coblocks/field-checkbox', {
 				label: sprintf(
 					/* translators: %1$s: opening anchor link. %2$s: closing anchor link */
-					__( 'By submitting this form, you agree to our %1$sterms and conditions%2$s and %1$sprivacy policy%2$s', 'coblocks' ),
+					__( 'By submitting this form, you agree to our %1$sterms and conditions%2$s and %1$sprivacy policy%2$s.', 'coblocks' ),
 					'<a href="#" target="_blank" rel="noreferrer noopener">',
 					'</a>'
 				),


### PR DESCRIPTION
### Description
Tweak the styles of the form block in the editor.
- [x] Unify spacing between form blocks (name, select, checkbox etc.).
- [x] Tweak `*` color in editor/frontend.
- [x] Tweak the way the `*` is generated in the editor, so it's properly appended to the end of the field label text.

### Screenshots
<img width="615" alt="image" src="https://user-images.githubusercontent.com/5321364/157114909-7a712ad3-7b13-4b42-9b75-9a3a2d4115cf.png">

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually inspected the spacing in the editor/frontend.

### Acceptance criteria
- The spacing between email/phone fields and services fields is inconsistent. It should be inline with name and email fields.
- The asterix (`*`) in the terms and condition section should be next to privacy policy. currently it is after AND.
- There should be a period after privacy policy.
- The fonts particularly in the services section and text field beneath the T&C section (I have read and agree to the terms and conditions and privacy policy.) don't match with Go theme fonts.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
