### PR TITLE
issue-2304 remove tab index from accordion item content div on front end

### DIFF
--- a/src/blocks/accordion/accordion-item/deprecated.js
+++ b/src/blocks/accordion/accordion-item/deprecated.js
@@ -55,12 +55,66 @@ const deprecated = [
 					{ ! RichText.isEmpty( title ) &&
 					<details open={ open }>
 						<RichText.Content
-							tagName="summary"
 							className={ titleClasses }
-							value={ title }
 							style={ titleStyles }
+							tagName="summary"
+							value={ title }
 						/>
 						<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle }>
+							<InnerBlocks.Content />
+						</div>
+					</details>
+					}
+				</div>
+			);
+		},
+	},
+	{
+		attributes: {
+			...currentBlock.attributes,
+		},
+		save( { attributes } ) {
+			const {
+				backgroundColor,
+				customBackgroundColor,
+				customTextColor,
+				open,
+				textColor,
+				borderColor,
+				title,
+			} = attributes;
+
+			const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
+			const textColorClass = getColorClassName( 'color', textColor );
+
+			const titleClasses = classnames(
+				'wp-block-coblocks-accordion-item__title', {
+					'has-background': backgroundColor || customBackgroundColor,
+					[ backgroundColorClass ]: backgroundColorClass,
+					'has-text-color': textColor || customTextColor,
+					[ textColorClass ]: textColorClass,
+				} );
+
+			const titleStyles = {
+				backgroundColor: backgroundColorClass ? undefined : customBackgroundColor,
+				color: textColorClass ? undefined : customTextColor,
+			};
+
+			const borderStyle = {
+				borderColor: borderColor ? borderColor : customBackgroundColor,
+			};
+
+			return (
+				<div>
+					{ ! RichText.isEmpty( title ) &&
+					<details open={ open }>
+						<RichText.Content
+							className={ titleClasses }
+							style={ titleStyles }
+							tagName="summary"
+							value={ title }
+						/>
+						<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle } tabIndex="0">
 							<InnerBlocks.Content />
 						</div>
 					</details>

--- a/src/blocks/accordion/accordion-item/save.js
+++ b/src/blocks/accordion/accordion-item/save.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText, InnerBlocks, getColorClassName } from '@wordpress/block-editor';
+import { getColorClassName, InnerBlocks, RichText } from '@wordpress/block-editor';
 
 const save = ( { attributes } ) => {
 	const {
@@ -44,12 +44,12 @@ const save = ( { attributes } ) => {
 			{ ! RichText.isEmpty( title ) &&
 			<details open={ open }>
 				<RichText.Content
-					tagName="summary"
 					className={ titleClasses }
-					value={ title }
 					style={ titleStyles }
+					tagName="summary"
+					value={ title }
 				/>
-				<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle } tabIndex="0">
+				<div className="wp-block-coblocks-accordion-item__content" style={ borderStyle }>
 					<InnerBlocks.Content />
 				</div>
 			</details>

--- a/src/blocks/accordion/accordion-item/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/accordion/accordion-item/test/__snapshots__/save.spec.js.snap
@@ -14,13 +14,13 @@ exports[`coblocks/accordion-item should render with border color 1`] = `
 
 exports[`coblocks/accordion-item should render with content 1`] = `
 "<!-- wp:coblocks/accordion-item {\\"title\\":\\"Accordion title\\"} -->
-<div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title\\">Accordion title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\" tabindex=\\"0\\"></div></details></div>
+<div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title\\">Accordion title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\"></div></details></div>
 <!-- /wp:coblocks/accordion-item -->"
 `;
 
 exports[`coblocks/accordion-item should render with custom background color 1`] = `
 "<!-- wp:coblocks/accordion-item {\\"title\\":\\"Accordion Item title\\",\\"customBackgroundColor\\":\\"#111111\\"} -->
-<div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title has-background\\" style=\\"background-color:#111111\\">Accordion Item title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\" style=\\"border-color:#111111\\" tabindex=\\"0\\"></div></details></div>
+<div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title has-background\\" style=\\"background-color:#111111\\">Accordion Item title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\" style=\\"border-color:#111111\\"></div></details></div>
 <!-- /wp:coblocks/accordion-item -->"
 `;
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This PR resolves an issue for keyboard users where the opened accordion would focus on the accordion body in the front end. As the area is not editable, it is unecessary.

Fixes #2304 


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
manually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should not be able to tab focus the accordion body on the front end



### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
