### PR TITLE
Try removing .lock caches from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,27 +338,24 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - composer-deps-{{ .Environment.CACHE_VERSION }}-{{ checksum "composer.lock" }}
             - composer-deps-{{ .Environment.CACHE_VERSION }}
 
   restore_yarn_cache:
     steps:
       - restore_cache:
           keys:
-            - yarn-deps-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
             - yarn-deps-{{ .Environment.CACHE_VERSION }}
 
   restore_update_cypress_cache:
     steps:
       - restore_cache:
           keys:
-            - cypress-deps-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
             - cypress-deps-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install CyPress Binaries
           command: ./node_modules/.bin/cypress install
       - save_cache:
-          key: cypress-deps-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+          key: cypress-deps-{{ .Environment.CACHE_VERSION }}
           paths:
             - ~/.cache/Cypress
 
@@ -583,7 +580,7 @@ jobs:
             PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
             yarn install --frozen-lockfile
       - save_cache:
-          key: yarn-deps-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+          key: yarn-deps-{{ .Environment.CACHE_VERSION }}
           paths:
             - ~/project/node_modules
             - ~/.cache/yarn
@@ -595,7 +592,7 @@ jobs:
             composer validate --strict
             composer install
       - save_cache:
-          key: composer-deps-{{ .Environment.CACHE_VERSION }}-{{ checksum "composer.lock" }}
+          key: composer-deps-{{ .Environment.CACHE_VERSION }}
           paths:
             - ~/project/vendor
       - run:


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
The results of this test have been to reduce total cache consumption yet to persist a necessary minimal cache to each respective job.

We do have a minimal increase in build time of about ~2 minutes as caches are not quite as robust. In the face of around ~25 minutes for a run of a full test suite, this should be a satisfactory tradeoff of reduced stored cache for a small increase in computing.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Ci config changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in CI.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Not a clear AC. The reason for this PR is that we have a stored cache in Circle Ci that is seemingly ever-increasing in size and cost. This is an effort to reduce stored cache and trade for additional computing.

