### PR TITLE
handle nonce value for image crop controls

### DIFF
--- a/includes/admin/class-coblocks-crop-settings.php
+++ b/includes/admin/class-coblocks-crop-settings.php
@@ -88,11 +88,9 @@ class CoBlocks_Crop_Settings {
 	public function get_original_image() {
 		$nonce = filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING );
 
-		if ( ! $nonce ) {
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'cropSettingsOriginalImageNonce' ) ) {
 			wp_send_json_error( 'No nonce value present' );
 		}
-
-		wp_verify_nonce( $nonce, 'cropSettingsOriginalImageNonce' );
 
 		$id = filter_input( INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT );
 
@@ -123,11 +121,9 @@ class CoBlocks_Crop_Settings {
 	public function api_crop() {
 		$nonce = filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING );
 
-		if ( ! $nonce ) {
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'cropSettingsNonce' ) ) {
 			wp_send_json_error( 'No nonce value present' );
 		}
-
-		wp_verify_nonce( $nonce, 'cropSettingsNonce' );
 
 		if (
 			! isset( $_POST['id'] ) ||


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Minor change to CoBlocks crop settings php file.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
PHP

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Manually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should throw an error if nonce is unset.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
