### PR TITLE
enhance restore cache to also install missing deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_56_mysql:
     docker:
-      - image: cimg/php:5.6-8.0-node
+      - image: cimg/php:5.6-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -23,7 +23,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_74_mysql:
     docker:
-      - image: cimg/php:7.4-8.0-node
+      - image: cimg/php:7.4-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -59,7 +59,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_80_mysql:
     docker:
-      - image: cimg/php:8.0-8.0-node
+      - image: cimg/php:8.0-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -71,7 +71,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_81_mysql:
     docker:
-      - image: cimg/php:8.1-8.0-node
+      - image: cimg/php:8.1-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_56_mysql:
     docker:
-      - image: cimg/node:16.14
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: cimg/php:5.6
+      - image: cimg/php:5.6-8.0-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -27,11 +23,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_74_mysql:
     docker:
-      - image: cimg/node:16.14
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: cimg/php:7.4
+      - image: cimg/php:7.4-8.0-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -67,11 +59,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_80_mysql:
     docker:
-      - image: cimg/node:16.14
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: cimg/php:8.0
+      - image: cimg/php:8.0-8.0-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -83,11 +71,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_81_mysql:
     docker:
-      - image: cimg/node:16.14
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: cimg/php:8.1
+      - image: cimg/php:8.1-8.0-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   jq: circleci/jq@2.2.0
   browser-tools: circleci/browser-tools@1.1
+  node: circleci/node@5.0.0
 
 executors:
   node_latest:
@@ -535,6 +536,8 @@ commands:
         default: false
     steps:
       - checkout
+      - node/install:
+          node-version: '16.14'
       - attach_workspace:
           at: ~/project
       - restore_yarn_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_56_mysql:
     docker:
+      - image: cimg/node:16.14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
       - image: cimg/php:5.6
         auth:
           username: $DOCKERHUB_USERNAME
@@ -23,6 +27,10 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_74_mysql:
     docker:
+      - image: cimg/node:16.14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
       - image: cimg/php:7.4
         auth:
           username: $DOCKERHUB_USERNAME
@@ -59,6 +67,10 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_80_mysql:
     docker:
+      - image: cimg/node:16.14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
       - image: cimg/php:8.0
         auth:
           username: $DOCKERHUB_USERNAME
@@ -71,6 +83,10 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_81_mysql:
     docker:
+      - image: cimg/node:16.14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
       - image: cimg/php:8.1
         auth:
           username: $DOCKERHUB_USERNAME
@@ -345,6 +361,11 @@ commands:
       - restore_cache:
           keys:
             - yarn-deps-{{ .Environment.CACHE_VERSION }}
+      - run:
+          name: Install dependencies missing from cache
+          command: |
+            PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+            yarn install --frozen-lockfile
 
   restore_update_cypress_cache:
     steps:
@@ -532,6 +553,7 @@ commands:
       - checkout
       - attach_workspace:
           at: ~/project
+      - restore_yarn_cache
       - restore_composer_cache
       - wait_for_mysql
       - when:


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Presently in CI the cache is not being updated because of the nature of read-only cache storage in Circle CI. This enhancement will ensure that any missing or superfluous dependencies are updated on the fly as part of the restore cache job.

This change requires having Node and Yarn pre-installed in the container before installation.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor Ci changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in CI.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
This should ensure that `yarn install` is run against the present package.json regardless of cache status.