### PR TITLE
Fix Icon block PHPCS warning

### DIFF
--- a/src/blocks/icon/index.php
+++ b/src/blocks/icon/index.php
@@ -78,7 +78,10 @@ function coblocks_render_icon_block( $attrs ) {
 	$icon_path        = is_readable( "$icon_path$icon_style.svg" ) ? "$icon_path$icon_style.svg" : $icon_path . '.svg';
 
 	// Needed for the call to $wp_filesystem->get_contents(...) .
-	require_once ABSPATH . 'wp-admin/includes/file.php';
+	if ( ! class_exists( 'WP_Filesystem' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+	}
+
 	global $wp_filesystem;
 	WP_Filesystem();
 

--- a/src/blocks/icon/index.php
+++ b/src/blocks/icon/index.php
@@ -78,6 +78,7 @@ function coblocks_render_icon_block( $attrs ) {
 	$icon_path        = is_readable( "$icon_path$icon_style.svg" ) ? "$icon_path$icon_style.svg" : $icon_path . '.svg';
 
 	// Needed for the call to $wp_filesystem->get_contents(...) .
+	global $wp_filesystem;
 	WP_Filesystem();
 
 	if ( is_readable( $custom_icon_path ) ) {

--- a/src/blocks/icon/index.php
+++ b/src/blocks/icon/index.php
@@ -77,12 +77,13 @@ function coblocks_render_icon_block( $attrs ) {
 	$custom_icon_path = is_readable( "$custom_icon_path$icon_style.svg" ) ? "$custom_icon_path$icon_style.svg" : $custom_icon_path . '.svg';
 	$icon_path        = is_readable( "$icon_path$icon_style.svg" ) ? "$icon_path$icon_style.svg" : $icon_path . '.svg';
 
+	// Needed for the call to $wp_filesystem->get_contents(...) .
+	WP_Filesystem();
+
 	if ( is_readable( $custom_icon_path ) ) {
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		$icon = file_get_contents( $custom_icon_path );
+		$icon = $wp_filesystem->get_contents( $custom_icon_path );
 	} elseif ( is_readable( $icon_path ) ) {
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		$icon = file_get_contents( $icon_path );
+		$icon = $wp_filesystem->get_contents( $icon_path );
 	}
 
 	if ( ! empty( $attrs['href'] ) ) {

--- a/src/blocks/icon/index.php
+++ b/src/blocks/icon/index.php
@@ -78,6 +78,7 @@ function coblocks_render_icon_block( $attrs ) {
 	$icon_path        = is_readable( "$icon_path$icon_style.svg" ) ? "$icon_path$icon_style.svg" : $icon_path . '.svg';
 
 	// Needed for the call to $wp_filesystem->get_contents(...) .
+	require_once ABSPATH . 'wp-admin/includes/file.php';
 	global $wp_filesystem;
 	WP_Filesystem();
 


### PR DESCRIPTION
### Description
Usage of `file_get_contents` is now discouraged. Replace it with the proper way to do it.

### Types of changes
Fix warning

### Acceptance criteria
No more PHPCS warning on icon/index.php file.


### Checklist:
- [X] My code is tested
- [X] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation <!-- if applicable -->
