### PR TITLE
Use wp_get_inline_script_tag for Gist embed

### DIFF
--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -76,9 +76,8 @@ function coblocks_block_gist_handler( $matches ) {
 	}
 
 	return sprintf(
-		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		'<script src="https://gist.github.com/%1$s"></script><noscript><a href="%2$s">%3$s</a></noscript>',
-		esc_attr( $script_src ),
+		'%1$s<a href="%2$s">%3$s</a></noscript>',
+		wp_get_inline_script_tag( '', array( 'src' => esc_url( 'https://gist.github.com/' . $script_src ) ) ),
 		esc_url( $gist_url ),
 		esc_html( __( 'View this gist on GitHub', 'coblocks' ) )
 	);


### PR DESCRIPTION
Resolves this linting issue:

```
FILE: coblocks/src/blocks/gist/index.php
------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
LINE 80: ERROR Scripts must be registered/enqueued via wp_enqueue_script
 (WordPress.WP.EnqueuedResources.NonEnqueuedScript)
------------------------------------------------------------------------------------------------------------------------
 78: »return·sprintf(
 79: » //·phpcs:ignore·WordPress.WP.EnqueuedResources.NonEnqueuedScript
>> 80: » '<script·src="https://gist.github.com/%1$s"></script><noscript><a·href="%2$s">%3$s</a></noscript>',
 81: » esc_attr(·$script_src·),
 82: » esc_url(·$gist_url·),
------------------------------------------------------------------------------------------------------------------------
Time: 595ms; Memory: 40MB
```