### PR TITLE
Resolve issue with style bleed

### DIFF
--- a/src/blocks/gallery-carousel/styles/style.scss
+++ b/src/blocks/gallery-carousel/styles/style.scss
@@ -1,9 +1,8 @@
-.coblocks-gallery--item {
-	height: 100%;
-	width: 100% !important;
-}
-
 .wp-block-coblocks-gallery-carousel {
+	.coblocks-gallery--item {
+		height: 100%;
+		width: 100% !important;
+	}
 
 	&,
 	.coblocks-gallery {
@@ -16,9 +15,7 @@
 	}
 
 	@for $i from 2 through 20 {
-
 		.carousel-nav.has-border-radius-#{ $i } {
-
 			img {
 				border-radius: #{$i}px;
 			}
@@ -136,13 +133,11 @@
 }
 
 body.rtl {
-
 	.flickity-viewport {
 		position: relative;
 	}
 
 	.flickity-prev-next-button {
-
 		&.next {
 			left: 0;
 		}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
The issue is with the Offset block rendering issue and maybe old Masonry galleries too.

### Screenshots
<!-- if applicable -->
Before
![image](https://user-images.githubusercontent.com/30462574/158878181-e0b3f353-1fae-4b5d-a085-8412d6714f78.png)

After
![image](https://user-images.githubusercontent.com/30462574/158878152-d6aece30-d9c7-4fa7-8b95-95d4d480e55e.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
SCSS change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should resolve display issue from style bleed.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
