### PR TITLE
try using translation function with registerBlockType

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -14,6 +14,7 @@ import { supportsCollections } from './block-helpers';
 import { isBlobURL } from '@wordpress/blob';
 import { registerBlockType } from '@wordpress/blocks';
 import TokenList from '@wordpress/token-list';
+import { __, sprintf } from '@wordpress/i18n';
 
 // Set dim ratio.
 export function overlayToClass( ratio ) {
@@ -131,12 +132,19 @@ export const registerBlock = ( block ) => {
 	}
 
 	registerBlockType( name, {
-		category,
 		...settings,
+		category,
 		icon,
 
 		// V2 Block API Upgrades
 		...v2Settings,
+
+		// Title prop must be translated to appear in WP.org details page.
+		title: sprintf(
+			/* translators: %s: placeholder for a block title*/
+			__( '%s block', 'coblocks' ),
+			settings.title
+		),
 	} );
 };
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
I am pretty sure this will fix the issue with the blocks list on WordPress.org. I based the fix based on the [plugin details page for another popular plugin.](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/) I was not able to find any docs elsewhere to explain the requirements. Based on the aforementioned plugin details we know that three of the blocks are setup to display as expected.

[What the three blocks have in common are strings processed by the translation function. ](https://github.com/brainstormforce/ultimate-addons-for-gutenberg/blob/df0108b4e1d7116505e2d521baecbe424d0f0c80/src/blocks/advanced-heading/block.js#L16)

[All other blocks of this plugin are setup to use strings that are not translated.](https://github.com/brainstormforce/ultimate-addons-for-gutenberg/blob/196ea02be983307ad62dd79b3aa02da3eb240db6/src/blocks/buttons/block.js#L27)

### Alternatives considered
We are not able to use the `__` function in the same manner and must instead use a combination with `sprintf` and a suffix of `block` in order to satisfy all lint conditions around the translation function. If this proposed solution does not work that implies that we must register the block using only string literals and not variables. 

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
We will need to test this which I think may require a release. We need to update the JS side.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
