### PR TITLE
Try new editorScript property in block.json

### DIFF
--- a/src/blocks/accordion/accordion-item/block.json
+++ b/src/blocks/accordion/accordion-item/block.json
@@ -25,5 +25,8 @@
 		"borderColor": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Accordion Item",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-1"
 }

--- a/src/blocks/accordion/block.json
+++ b/src/blocks/accordion/block.json
@@ -12,5 +12,6 @@
 		}
 	},
 	"title": "Accordion",
+	"textdomain": "coblocks",
 	"editorScript": "file:./src/blocks-1.js"
 }

--- a/src/blocks/accordion/block.json
+++ b/src/blocks/accordion/block.json
@@ -10,5 +10,7 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"title": "Accordion",
+	"editorScript": "file:./src/blocks-1.js"
 }

--- a/src/blocks/alert/block.json
+++ b/src/blocks/alert/block.json
@@ -42,5 +42,5 @@
 		}
 	},
 	"title": "Alert",
-	"editorScript": "file:../../blocks-1.js"
+	"editorScript": "file:./../../blocks-1.js"
 }

--- a/src/blocks/alert/block.json
+++ b/src/blocks/alert/block.json
@@ -40,5 +40,7 @@
 		"textAlign": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Alert",
+	"editorScript": "file:../../blocks-1.js"
 }

--- a/src/blocks/alert/block.json
+++ b/src/blocks/alert/block.json
@@ -42,5 +42,6 @@
 		}
 	},
 	"title": "Alert",
+	"textdomain": "coblocks",
 	"editorScript": "file:./../../blocks-1.js"
 }

--- a/src/blocks/counter/block.json
+++ b/src/blocks/counter/block.json
@@ -45,5 +45,6 @@
 		}
 	},
 	"editorStyle": "wp-block-coblocks-counter-editor",
+	"editorScript": "coblocks-editor",
 	"style": "wp-block-coblocks-counter"
 }

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -14,7 +14,6 @@ import { supportsCollections } from './block-helpers';
 import { isBlobURL } from '@wordpress/blob';
 import { registerBlockType } from '@wordpress/blocks';
 import TokenList from '@wordpress/token-list';
-import { __, sprintf } from '@wordpress/i18n';
 
 // Set dim ratio.
 export function overlayToClass( ratio ) {
@@ -138,13 +137,6 @@ export const registerBlock = ( block ) => {
 
 		// V2 Block API Upgrades
 		...v2Settings,
-
-		// Title prop must be translated to appear in WP.org details page.
-		title: sprintf(
-			/* translators: %s: placeholder for a block title*/
-			__( '%s block', 'coblocks' ),
-			settings.title
-		),
 	} );
 };
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This is take-two at attempting to fix the WordPress.org plugin details page for CoBlocks.

The #Meta team in WordPress slack has identified that this block.json property is one that is required for block registration. Going to give a shot at specifying both paths and slugs to check if there is a difference.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Removing a [previous modification here](https://github.com/godaddy-wordpress/coblocks/pull/2332) that adds a translation function.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
This will need to be deployed in a versioned release in order to test this proposed fix.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
The AC should be resolving the issue with improper block names on the plugin details page. Unfortunately, we will need to test this by releasing a version of CoBlocks.
