### PR TITLE
Fix block.json schema props across all blocks

### DIFF
--- a/src/blocks/accordion/accordion-item/block.json
+++ b/src/blocks/accordion/accordion-item/block.json
@@ -28,5 +28,7 @@
 	},
 	"title": "Accordion Item",
 	"textdomain": "coblocks",
-	"editorScript": "blocks-1"
+	"editorScript": "blocks-1",
+	"description": "Add collapsable accordion items to accordions.",
+	"parent": [ "coblocks/accordion" ]
 }

--- a/src/blocks/accordion/block.json
+++ b/src/blocks/accordion/block.json
@@ -13,5 +13,6 @@
 	},
 	"title": "Accordion",
 	"textdomain": "coblocks",
-	"editorScript": "file:./src/blocks-1.js"
+	"editorScript": "blocks-1",
+	"description": "Organize content within collapsable accordion items."
 }

--- a/src/blocks/alert/block.json
+++ b/src/blocks/alert/block.json
@@ -43,5 +43,6 @@
 	},
 	"title": "Alert",
 	"textdomain": "coblocks",
-	"editorScript": "file:./../../blocks-1.js"
+	"editorScript": "blocks-1",
+	"description": "Provide contextual feedback messages or notices."
 }

--- a/src/blocks/author/block.json
+++ b/src/blocks/author/block.json
@@ -43,5 +43,8 @@
 			}
 		}
 	},
-	"title": "Author"
+	"title": "Author",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-1",
+	"description": "Add an author biography to build credibility and authority."
 }

--- a/src/blocks/buttons/block.json
+++ b/src/blocks/buttons/block.json
@@ -14,5 +14,9 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"title": "Buttons (Deprecated)",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-1",
+	"description": "This block is replaced by core Buttons block."
 }

--- a/src/blocks/click-to-tweet/block.json
+++ b/src/blocks/click-to-tweet/block.json
@@ -47,5 +47,9 @@
 				"fontSize": true
 			}
 		}
-	}
+	},
+	"title": "Click to Tweet",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "Add a quote for readers to tweet via Twitter."
 }

--- a/src/blocks/counter/block.json
+++ b/src/blocks/counter/block.json
@@ -45,6 +45,6 @@
 		}
 	},
 	"editorStyle": "wp-block-coblocks-counter-editor",
-	"editorScript": "coblocks-editor",
+	"editorScript": "blocks-13",
 	"style": "wp-block-coblocks-counter"
 }

--- a/src/blocks/dynamic-separator/block.json
+++ b/src/blocks/dynamic-separator/block.json
@@ -12,5 +12,9 @@
 		"customColor": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Dynamic HR",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "Add a resizable spacer between other blocks."
 }

--- a/src/blocks/events/block.json
+++ b/src/blocks/events/block.json
@@ -27,5 +27,9 @@
 			"type": "boolean",
 			"default": true
 		}
-	}
+	},
+	"title": "Events",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "Add a list of events or display events from a public calendar."
 }

--- a/src/blocks/events/event-item/block.json
+++ b/src/blocks/events/event-item/block.json
@@ -43,5 +43,10 @@
 		"customTextColor": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Event Item",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "An event within the events block.",
+	"parent": [ "coblocks/events" ]
 }

--- a/src/blocks/faq/block.json
+++ b/src/blocks/faq/block.json
@@ -8,5 +8,9 @@
 		"textColor": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "FAQ",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "Add a list of questions and answers."
 }

--- a/src/blocks/faq/faq-item/block.json
+++ b/src/blocks/faq/faq-item/block.json
@@ -11,5 +11,10 @@
 			"source": "html",
 			"selector": ".wp-block-coblocks-faq-item__question__content"
 		}
-	}
+	},
+	"title": "FAQ Item",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "A question/answer within the FAQ block.",
+	"parent": [ "coblocks/faq" ]
 }

--- a/src/blocks/features/block.json
+++ b/src/blocks/features/block.json
@@ -14,5 +14,9 @@
 			"type": "string",
 			"default": "center"
 		}
-	}
+	},
+	"title": "Features",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "Add up to four columns of small notes for your product or service."
 }

--- a/src/blocks/features/feature/block.json
+++ b/src/blocks/features/feature/block.json
@@ -15,5 +15,10 @@
 		"contentAlign": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Feature",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "A singular child column within a parent features block.",
+	"parent": [ "coblocks/features" ]
 }

--- a/src/blocks/food-and-drinks/block.json
+++ b/src/blocks/food-and-drinks/block.json
@@ -22,5 +22,9 @@
 			"type": "integer",
 			"default": 4
 		}
-	}
+	},
+	"title": "Food & Drink",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-4",
+	"description": "Display a menu or price list."
 }

--- a/src/blocks/food-and-drinks/food-item/block.json
+++ b/src/blocks/food-and-drinks/food-item/block.json
@@ -70,5 +70,10 @@
 			"type": "integer",
 			"default": 4
 		}
-	}
+	},
+	"title": "Food Item",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-4",
+	"description": "A food and drink item within the Food & Drinks block.",
+	"parent": [ "coblocks/food-and-drinks" ]
 }

--- a/src/blocks/form/block.json
+++ b/src/blocks/form/block.json
@@ -1,5 +1,5 @@
 {
-    "attributes": {
+	"attributes": {
 		"subject": {
 			"default": null,
 			"type": "string"
@@ -15,7 +15,7 @@
 	},
 	"category": "layout",
 	"name": "coblocks/form",
-    "title": "Form",
+	"title": "Form",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-4",
 	"description": "Add a contact form to your page."

--- a/src/blocks/form/block.json
+++ b/src/blocks/form/block.json
@@ -1,0 +1,22 @@
+{
+    "attributes": {
+		"subject": {
+			"default": null,
+			"type": "string"
+		},
+		"successText": {
+			"default": "Your message was sent:",
+			"type": "string"
+		},
+		"to": {
+			"default": null,
+			"type": "string"
+		}
+	},
+	"category": "layout",
+	"name": "coblocks/form",
+    "title": "Form",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-4",
+	"description": "Add a contact form to your page."
+}

--- a/src/blocks/form/fields/checkbox/block.json
+++ b/src/blocks/form/fields/checkbox/block.json
@@ -1,0 +1,27 @@
+{
+    "name": "coblocks/field-checkbox",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Checkbox"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"options": {
+			"type": "array",
+			"default": []
+		},
+		"isInline": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"category": "layout",
+    "title": "Checkbox",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A checkbox field with multiple options where multiple choices can be made.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/checkbox/block.json
+++ b/src/blocks/form/fields/checkbox/block.json
@@ -1,5 +1,5 @@
 {
-    "name": "coblocks/field-checkbox",
+	"name": "coblocks/field-checkbox",
 	"attributes": {
 		"label": {
 			"type": "string",
@@ -19,9 +19,11 @@
 		}
 	},
 	"category": "layout",
-    "title": "Checkbox",
+	"title": "Checkbox",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A checkbox field with multiple options where multiple choices can be made.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/checkbox/index.js
+++ b/src/blocks/form/fields/checkbox/index.js
@@ -7,6 +7,7 @@ import { FormCheckboxIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import { editMultiField } from '../helpers';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,32 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-checkbox',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Checkbox', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-		options: {
-			type: 'array',
-			default: [],
-		},
-		isInline: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/date/block.json
+++ b/src/blocks/form/fields/date/block.json
@@ -11,9 +11,11 @@
 			"default": false
 		}
 	},
-    "title": "Date",
+	"title": "Date",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A field for requesting date selections with a date picker.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/date/block.json
+++ b/src/blocks/form/fields/date/block.json
@@ -1,0 +1,19 @@
+{
+	"name": "coblocks/field-date",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Date"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Date",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A field for requesting date selections with a date picker.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/date/index.js
+++ b/src/blocks/form/fields/date/index.js
@@ -7,6 +7,7 @@ import { FormDateIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,24 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-date',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Date', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/email/block.json
+++ b/src/blocks/form/fields/email/block.json
@@ -1,5 +1,5 @@
 {
-    "name": "coblocks/field-email",
+	"name": "coblocks/field-email",
 	"category": "layout",
 	"attributes": {
 		"label": {
@@ -11,9 +11,11 @@
 			"default": false
 		}
 	},
-    "title": "Email",
+	"title": "Email",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A field for collecting a validated email address.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/email/block.json
+++ b/src/blocks/form/fields/email/block.json
@@ -1,0 +1,19 @@
+{
+    "name": "coblocks/field-email",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Email"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Email",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A field for collecting a validated email address.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/email/index.js
+++ b/src/blocks/form/fields/email/index.js
@@ -7,30 +7,13 @@ import { FormEmailIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-email',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Email', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/hidden/block.json
+++ b/src/blocks/form/fields/hidden/block.json
@@ -1,5 +1,5 @@
 {
-    "name": "coblocks/field-hidden",
+	"name": "coblocks/field-hidden",
 	"category": "layout",
 	"attributes": {
 		"label": {
@@ -11,9 +11,11 @@
 			"default": ""
 		}
 	},
-    "title": "Hidden",
+	"title": "Hidden",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A hidden text field for collecting additional data.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/hidden/block.json
+++ b/src/blocks/form/fields/hidden/block.json
@@ -1,0 +1,19 @@
+{
+    "name": "coblocks/field-hidden",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Hidden"
+		},
+		"value": {
+			"type": "string",
+			"default": ""
+		}
+	},
+    "title": "Hidden",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A hidden text field for collecting additional data.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/hidden/index.js
+++ b/src/blocks/form/fields/hidden/index.js
@@ -7,6 +7,7 @@ import { FormHiddenIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,24 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-hidden',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Hidden', 'coblocks' ),
-		},
-		value: {
-			type: 'string',
-			default: '',
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/name/block.json
+++ b/src/blocks/form/fields/name/block.json
@@ -1,0 +1,31 @@
+{
+    "name": "coblocks/field-name",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Name"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"hasLastName": {
+			"type": "boolean",
+			"default": false
+		},
+		"labelFirstName": {
+			"type": "string",
+			"default": "First"
+		},
+		"labelLastName": {
+			"type": "string",
+			"default": "Last"
+		}
+	},
+    "title": "Name",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A text field for collecting the first and last names.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/name/block.json
+++ b/src/blocks/form/fields/name/block.json
@@ -1,5 +1,5 @@
 {
-    "name": "coblocks/field-name",
+	"name": "coblocks/field-name",
 	"category": "layout",
 	"attributes": {
 		"label": {
@@ -23,9 +23,11 @@
 			"default": "Last"
 		}
 	},
-    "title": "Name",
+	"title": "Name",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A text field for collecting the first and last names.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/name/index.js
+++ b/src/blocks/form/fields/name/index.js
@@ -7,6 +7,7 @@ import { FormNameIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,36 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-name',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Name', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-		hasLastName: {
-			type: 'boolean',
-			default: false,
-		},
-		labelFirstName: {
-			type: 'string',
-			default: __( 'First', 'coblocks' ),
-		},
-		labelLastName: {
-			type: 'string',
-			default: __( 'Last', 'coblocks' ),
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/phone/block.json
+++ b/src/blocks/form/fields/phone/block.json
@@ -11,9 +11,11 @@
 			"default": false
 		}
 	},
-    "title": "Phone",
+	"title": "Phone",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A text field for collecting a phone number.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/phone/block.json
+++ b/src/blocks/form/fields/phone/block.json
@@ -1,0 +1,19 @@
+{
+	"name": "coblocks/field-phone",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Phone"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Phone",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A text field for collecting a phone number.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/phone/index.js
+++ b/src/blocks/form/fields/phone/index.js
@@ -7,6 +7,7 @@ import { FormPhoneIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -15,31 +16,13 @@ import transforms from './transforms';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
 
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-phone',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Phone', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
-
 const { name, category, attributes } = metadata;
 
 const settings = {
 	/* translators: block name */
 	title: __( 'Phone', 'coblocks' ),
 	/* translators: block description */
-	description: __( 'A phone number to allow visitors to give you a phone number.', 'coblocks' ),
+	description: __( 'A text field for collecting a phone number.', 'coblocks' ),
 	icon: <Icon icon={ icon } />,
 	keywords: [
 		'coblocks',

--- a/src/blocks/form/fields/radio/block.json
+++ b/src/blocks/form/fields/radio/block.json
@@ -4,7 +4,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"default":  "Choose one"
+			"default": "Choose one"
 		},
 		"required": {
 			"type": "boolean",
@@ -19,9 +19,11 @@
 			"default": false
 		}
 	},
-    "title": "Radio",
+	"title": "Radio",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A field with multiple options where only one choice can be made.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/radio/block.json
+++ b/src/blocks/form/fields/radio/block.json
@@ -1,0 +1,27 @@
+{
+	"name": "coblocks/field-radio",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default":  "Choose one"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"options": {
+			"type": "array",
+			"default": []
+		},
+		"isInline": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Radio",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A field with multiple options where only one choice can be made.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/radio/index.js
+++ b/src/blocks/form/fields/radio/index.js
@@ -7,6 +7,7 @@ import { FormRadioIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import { editMultiField } from '../helpers';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,32 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-radio',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Choose one', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-		options: {
-			type: 'array',
-			default: [],
-		},
-		isInline: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/select/block.json
+++ b/src/blocks/form/fields/select/block.json
@@ -15,9 +15,11 @@
 			"default": []
 		}
 	},
-    "title": "Select",
+	"title": "Select",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A dropdown field with multiple options where only one choice can be made.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/select/block.json
+++ b/src/blocks/form/fields/select/block.json
@@ -1,0 +1,23 @@
+{
+	"name": "coblocks/field-select",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Select"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"options": {
+			"type": "array",
+			"default": []
+		}
+	},
+    "title": "Select",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A dropdown field with multiple options where only one choice can be made.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/select/index.js
+++ b/src/blocks/form/fields/select/index.js
@@ -7,6 +7,7 @@ import { FormSelectIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import { editMultiField } from '../helpers';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,28 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-select',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Select', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-		options: {
-			type: 'array',
-			default: [],
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/submit-button/block.json
+++ b/src/blocks/form/fields/submit-button/block.json
@@ -1,0 +1,32 @@
+{
+	"name": "coblocks/field-submit-button",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Submit"
+		},
+		"required": {
+			"type": "boolean",
+			"default": true
+		},
+		"submitButtonText": {
+			"type": "string",
+			"default": "Submit"
+		},
+		"customBackgroundButtonColor": {
+			"type": "string"
+		},
+		"customTextButtonColor": {
+			"type": "string"
+		},
+		"submitButtonClasses": {
+			"type": "string"
+		}
+	},
+    "title": "Submit",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A button for submitting form data.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/submit-button/block.json
+++ b/src/blocks/form/fields/submit-button/block.json
@@ -24,9 +24,11 @@
 			"type": "string"
 		}
 	},
-    "title": "Submit",
+	"title": "Submit",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A button for submitting form data.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/submit-button/index.js
+++ b/src/blocks/form/fields/submit-button/index.js
@@ -7,43 +7,13 @@ import { FormSubmitIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-submit-button',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Submit', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: true,
-		},
-		submitButtonText: {
-			type: 'string',
-			default: __( 'Submit', 'coblocks' ),
-		},
-		customBackgroundButtonColor: {
-			type: 'string',
-		},
-		customTextButtonColor: {
-			type: 'string',
-		},
-		submitButtonClasses: {
-			type: 'string',
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/text/block.json
+++ b/src/blocks/form/fields/text/block.json
@@ -1,0 +1,19 @@
+{
+    "name": "coblocks/field-text",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Text"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Text",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A text box for custom responses.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/text/block.json
+++ b/src/blocks/form/fields/text/block.json
@@ -1,5 +1,5 @@
 {
-    "name": "coblocks/field-text",
+	"name": "coblocks/field-text",
 	"category": "layout",
 	"attributes": {
 		"label": {
@@ -11,9 +11,11 @@
 			"default": false
 		}
 	},
-    "title": "Text",
+	"title": "Text",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A text box for custom responses.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/text/index.js
+++ b/src/blocks/form/fields/text/index.js
@@ -7,6 +7,7 @@ import { FormTextIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,24 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-text',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Text', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/textarea/block.json
+++ b/src/blocks/form/fields/textarea/block.json
@@ -11,9 +11,11 @@
 			"default": false
 		}
 	},
-    "title": "Textarea",
+	"title": "Textarea",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A text box for longer responses.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/textarea/block.json
+++ b/src/blocks/form/fields/textarea/block.json
@@ -1,0 +1,19 @@
+{
+	"name": "coblocks/field-textarea",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Message"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Textarea",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A text box for longer responses.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/textarea/index.js
+++ b/src/blocks/form/fields/textarea/index.js
@@ -7,6 +7,7 @@ import { FormTextareaIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,24 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-textarea',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Message', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/fields/website/block.json
+++ b/src/blocks/form/fields/website/block.json
@@ -1,0 +1,19 @@
+{
+	"name": "coblocks/field-website",
+	"category": "layout",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Website"
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+    "title": "Website",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "A text field for collecting a URL.",
+	"parent": [ "coblocks/form" ]
+}

--- a/src/blocks/form/fields/website/block.json
+++ b/src/blocks/form/fields/website/block.json
@@ -11,9 +11,11 @@
 			"default": false
 		}
 	},
-    "title": "Website",
+	"title": "Website",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-3",
 	"description": "A text field for collecting a URL.",
-	"parent": [ "coblocks/form" ]
+	"parent": [
+		"coblocks/form"
+	]
 }

--- a/src/blocks/form/fields/website/index.js
+++ b/src/blocks/form/fields/website/index.js
@@ -7,6 +7,7 @@ import { FormWebsiteIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import transforms from './transforms';
 
 /**
@@ -14,24 +15,6 @@ import transforms from './transforms';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-
-/**
- * Block constants
- */
-const metadata = {
-	name: 'coblocks/field-website',
-	category: 'layout',
-	attributes: {
-		label: {
-			type: 'string',
-			default: __( 'Website', 'coblocks' ),
-		},
-		required: {
-			type: 'boolean',
-			default: false,
-		},
-	},
-};
 
 const { name, category, attributes } = metadata;
 

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -20,12 +20,22 @@ import { Icon } from '@wordpress/components';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 const { name, category, attributes } = metadata;
-
 let conditionalBlockAttributes = { ...attributes };
 if ( typeof coblocksBlockData !== 'undefined' ) {
 	conditionalBlockAttributes = {
 		...conditionalBlockAttributes,
-		successText: coblocksBlockData.form.successText,
+		subject: {
+			default: coblocksBlockData.form.emailSubject,
+			type: 'string',
+		},
+		successText: {
+			default: coblocksBlockData.form.successText,
+			type: 'string',
+		},
+		to: {
+			default: coblocksBlockData.form.adminEmail,
+			type: 'string',
+		},
 	};
 }
 

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -9,6 +9,7 @@ import { FormIcon as icon } from '@godaddy-wordpress/coblocks-icons';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import variations from './variations';
 
 /**
@@ -18,35 +19,18 @@ import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-// Note: Check that coblocksBlockData is set. So jest tests will pass.
-const successTextDefault = typeof coblocksBlockData === 'undefined' ? __( 'Your message was sent:', 'coblocks' ) : coblocksBlockData.form.successText;
-
-/**
- * Block constants
- */
-const metadata = {
-	attributes: {
-		subject: {
-			default: null,
-			type: 'string',
-		},
-		successText: {
-			default: successTextDefault,
-			type: 'string',
-		},
-		to: {
-			default: null,
-			type: 'string',
-		},
-	},
-	category: 'layout',
-	name: 'coblocks/form',
-};
-
 const { name, category, attributes } = metadata;
 
+let conditionalBlockAttributes = { ...attributes };
+if ( typeof coblocksBlockData !== 'undefined' ) {
+	conditionalBlockAttributes = {
+		...conditionalBlockAttributes,
+		successText: coblocksBlockData.form.successText,
+	};
+}
+
 const settings = {
-	attributes,
+	attributes: conditionalBlockAttributes,
 	/* translators: block description */
 	description: __( 'Add a contact form to your page.', 'coblocks' ),
 	edit,

--- a/src/blocks/gallery-carousel/block.json
+++ b/src/blocks/gallery-carousel/block.json
@@ -110,5 +110,9 @@
 				}
 			}
 		}
-	}
+	},
+	"title": "Carousel",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-1",
+	"description": "Display multiple images in a beautiful carousel gallery."
 }

--- a/src/blocks/gallery-collage/block.json
+++ b/src/blocks/gallery-collage/block.json
@@ -54,5 +54,9 @@
 			"type": "string",
 			"default": "wide"
 		}
-	}
+	},
+	"title": "Collage",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-3",
+	"description": "Assemble images into a beautiful collage gallery."
 }

--- a/src/blocks/gallery-masonry/block.json
+++ b/src/blocks/gallery-masonry/block.json
@@ -96,5 +96,6 @@
 		"html": false
 	},
 	"editorStyle": "wp-block-coblocks-gallery-masonry-editor",
-	"style": "wp-block-coblocks-gallery-masonry"
+	"style": "wp-block-coblocks-gallery-masonry",
+	"editorScript": "blocks-5"
 }

--- a/src/blocks/gallery-offset/block.json
+++ b/src/blocks/gallery-offset/block.json
@@ -6,5 +6,9 @@
 			"type": "string",
 			"default": "small"
 		}
-	}
+	},
+	"title": "Offset",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-7",
+	"description": "Display images in an offset brick pattern gallery."
 }

--- a/src/blocks/gallery-stacked/block.json
+++ b/src/blocks/gallery-stacked/block.json
@@ -91,5 +91,7 @@
 		}
 	},
 	"textdomain": "coblocks",
-	"title": "Stacked"
+	"title": "Stacked",
+	"editorScript": "blocks-10",
+	"description": "Display multiple images in a single column stacked gallery."
 }

--- a/src/blocks/gif/block.json
+++ b/src/blocks/gif/block.json
@@ -29,5 +29,9 @@
 		"height": {
 			"type": "number"
 		}
-	}
+	},
+	"title": "Gif",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-9",
+	"description": "Pick a gif, any gif."
 }

--- a/src/blocks/gist/block.json
+++ b/src/blocks/gist/block.json
@@ -15,5 +15,9 @@
 		"caption": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Gist",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-9",
+	"description": "Embed a GitHub Gist."
 }

--- a/src/blocks/hero/block.json
+++ b/src/blocks/hero/block.json
@@ -54,5 +54,9 @@
 			"type": "number",
 			"default": 500
 		}
-	}
+	},
+	"title": "Hero",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-9",
+	"description": "An introductory area of a page accompanied by a small amount of text and a call to action."
 }

--- a/src/blocks/highlight/block.json
+++ b/src/blocks/highlight/block.json
@@ -31,5 +31,7 @@
 		}
 	},
 	"textdomain": "coblocks",
-	"title": "Highlight"
+	"title": "Highlight",
+	"editorScript": "blocks-9",
+	"description": "Draw attention and emphasize important narrative."
 }

--- a/src/blocks/icon/block.json
+++ b/src/blocks/icon/block.json
@@ -54,5 +54,9 @@
 		"linkTarget": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Icon",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-8",
+	"description": "Add a stylized graphic symbol to communicate something more."
 }

--- a/src/blocks/logos/block.json
+++ b/src/blocks/logos/block.json
@@ -34,5 +34,9 @@
 				}
 			}
 		}
-	}
+	},
+	"title": "Logos",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-5",
+	"description": "Add logos, badges, or certifications to build credibility."
 }

--- a/src/blocks/map/block.json
+++ b/src/blocks/map/block.json
@@ -58,5 +58,9 @@
 		"hasError": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Map",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-12",
+	"description": "Add an address or location to drop a pin on a Google map."
 }

--- a/src/blocks/media-card/block.json
+++ b/src/blocks/media-card/block.json
@@ -44,5 +44,9 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"title": "Media Card",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-7",
+	"description": "Add an image or video with an offset card side-by-side."
 }

--- a/src/blocks/opentable/block.json
+++ b/src/blocks/opentable/block.json
@@ -10,5 +10,9 @@
 			"type": "string",
 			"default": ""
 		}
-	}
+	},
+	"title": "Opentable",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-7",
+	"description": "Embed an OpenTable Reservations Widget."
 }

--- a/src/blocks/post-carousel/block.json
+++ b/src/blocks/post-carousel/block.json
@@ -70,5 +70,9 @@
 			"type": "string",
 			"default": "or"
 		}
-	}
+	},
+	"title": "Post Carousel (CoBlocks)",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-11",
+	"description": "Display posts or an external blog feed as a carousel."
 }

--- a/src/blocks/posts/block.json
+++ b/src/blocks/posts/block.json
@@ -79,5 +79,9 @@
 		"gutter": {
 			"default": "medium"
 		}
-	}
+	},
+	"title": "Posts",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-11",
+	"description": "Display posts or an RSS feed as stacked or horizontal cards."
 }

--- a/src/blocks/pricing-table/block.json
+++ b/src/blocks/pricing-table/block.json
@@ -10,5 +10,9 @@
 			"type": "string",
 			"default": "center"
 		}
-	}
+	},
+	"title": "Pricing Table",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-6",
+	"description": "Add pricing tables to help visitors compare products and plans."
 }

--- a/src/blocks/pricing-table/pricing-table-item/block.json
+++ b/src/blocks/pricing-table/pricing-table-item/block.json
@@ -40,5 +40,7 @@
 	"textdomain": "coblocks",
 	"editorScript": "blocks-6",
 	"description": "A pricing table to help visitors compare products and plans.",
-	"parent": [	"coblocks/pricing-table" ]
+	"parent": [
+		"coblocks/pricing-table"
+	]
 }

--- a/src/blocks/pricing-table/pricing-table-item/block.json
+++ b/src/blocks/pricing-table/pricing-table-item/block.json
@@ -35,5 +35,10 @@
 		"placeholder": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Pricing Table Item",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-6",
+	"description": "A pricing table to help visitors compare products and plans.",
+	"parent": [	"coblocks/pricing-table" ]
 }

--- a/src/blocks/row/block.json
+++ b/src/blocks/row/block.json
@@ -20,5 +20,9 @@
 		"verticalAlignment": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Row",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-6",
+	"description": "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
 }

--- a/src/blocks/row/column/block.json
+++ b/src/blocks/row/column/block.json
@@ -22,5 +22,7 @@
 	"textdomain": "coblocks",
 	"editorScript": "blocks-2",
 	"description": "An immediate child of a row.",
-	"parent": [	"coblocks/row" ]
+	"parent": [
+		"coblocks/row"
+	]
 }

--- a/src/blocks/row/column/block.json
+++ b/src/blocks/row/column/block.json
@@ -17,5 +17,10 @@
 		"verticalAlignment": {
 			"type": "string"
 		}
-	}
+	},
+	"title": "Column",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-2",
+	"description": "An immediate child of a row.",
+	"parent": [	"coblocks/row" ]
 }

--- a/src/blocks/services/block.json
+++ b/src/blocks/services/block.json
@@ -18,5 +18,9 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"title": "Services",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-6",
+	"description": "Add up to four columns of services to display."
 }

--- a/src/blocks/services/service/block.json
+++ b/src/blocks/services/service/block.json
@@ -69,5 +69,7 @@
 	"textdomain": "coblocks",
 	"editorScript": "blocks-6",
 	"description": "A single service item within a services block.",
-	"parent": [	"coblocks/services" ]
+	"parent": [
+		"coblocks/services"
+	]
 }

--- a/src/blocks/services/service/block.json
+++ b/src/blocks/services/service/block.json
@@ -64,5 +64,10 @@
 	},
 	"supports": {
 		"anchor": true
-	}
+	},
+	"title": "Service",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-6",
+	"description": "A single service item within a services block.",
+	"parent": [	"coblocks/services" ]
 }

--- a/src/blocks/shape-divider/block.json
+++ b/src/blocks/shape-divider/block.json
@@ -39,5 +39,9 @@
 			"type": "boolean",
 			"default": true
 		}
-	}
+	},
+	"title": "Shape Divider",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-10",
+	"description": "Add a shape divider to visually distinquish page sections."
 }

--- a/src/blocks/share/block.json
+++ b/src/blocks/share/block.json
@@ -82,5 +82,9 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"title": "Share",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-10",
+	"description": "Add social sharing links to help you get likes and shares."
 }

--- a/src/blocks/social-profiles/block.json
+++ b/src/blocks/social-profiles/block.json
@@ -90,5 +90,9 @@
 			"type": "string",
 			"default": ""
 		}
-	}
+	},
+	"title": "Social Profiles",
+	"textdomain": "coblocks",
+	"editorScript": "blocks-10",
+	"description": "Grow your audience with links to social media profiles."
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This change has been confirmed to fix the WP.org plugin details page for CoBlocks by listing the proper block titles.
This PR address all blocks registered with CoBlocks so they all use proper block.json definitions. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Mostly new additions to the block.json files.
Also some changes to the form field blocks which did not have existing block.json files.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
This has been tested and confirmed in a previous PR.
https://github.com/godaddy-wordpress/coblocks/pull/2337

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should fix the WP.org details page for CoBlocks.
