### PR TITLE
Tweak carousel bottom padding and fix captions

### DIFF
--- a/src/blocks/gallery-carousel/styles/style.scss
+++ b/src/blocks/gallery-carousel/styles/style.scss
@@ -1,6 +1,7 @@
 .wp-block-coblocks-gallery-carousel {
 	.coblocks-gallery--item {
 		height: 100%;
+		position: relative;
 		width: 100% !important;
 	}
 
@@ -121,7 +122,6 @@
 
 .has-responsive-height.has-carousel {
 	height: auto !important;
-	padding-bottom: 56.25%;
 	position: relative;
 
 	.flickity-viewport {


### PR DESCRIPTION
### Description
Originally reported in https://wordpress.org/support/topic/carousel-image-caption-not-loading/ the carousel captions were not displaying properly. This PR fixes the placement of the captions so they show up at the bottom of each image in the carousel.

During my testing I noticed that the carousel also had a 50% padding beneath it, which was throwing off the navigation buttons. Removing this padding go the carousel displaying properly again with the captions.


### Screenshots
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/5321364/160876798-cc7a7fee-638f-461b-8286-ebe1de88aa81.png">

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested with a few different carousel settings.

### Acceptance criteria
Captions display properly beneath each image in the carousel.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
