### PR TITLE
Fix OpenTable typo

### DIFF
--- a/src/blocks/opentable/block.json
+++ b/src/blocks/opentable/block.json
@@ -11,7 +11,7 @@
 			"default": ""
 		}
 	},
-	"title": "Opentable",
+	"title": "OpenTable",
 	"textdomain": "coblocks",
 	"editorScript": "blocks-7",
 	"description": "Embed an OpenTable Reservations Widget."


### PR DESCRIPTION
The correct capitalization for this restaurant reservation service is OpenTable.