### PR TITLE
WPEX-1922 - disable links in editor, enable gist links in front end

### DIFF
--- a/.dev/tests/phpunit/src/blocks/gist/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/gist/test-index.php
@@ -45,7 +45,7 @@ class CoBlocks_Gist_Index_Tests extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			coblocks_block_gist_handler( array( $gist_url, $gist_path ) ),
-			"<span class='coblocks-gist__container' style='pointer-events: none'><script src=\"https://gist.github.com/${gist_path}.js\">\n\n</script>\n<noscript><a class=\"gist-block__container\" href=\"${gist_url}\">View this gist on GitHub</a></noscript></span>"
+			"<span class='coblocks-gist__container' style='pointer-events: none'><script src=\"https://gist.github.com/${gist_path}.js\">\n\n</script>\n<a class=\"gist-block__container\" href=\"${gist_url}\" target=\"_blank\">View this gist on GitHub</a></span>"
 		);
 	}
 

--- a/.dev/tests/phpunit/src/blocks/gist/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/gist/test-index.php
@@ -45,7 +45,7 @@ class CoBlocks_Gist_Index_Tests extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			coblocks_block_gist_handler( array( $gist_url, $gist_path ) ),
-			"<script src=\"https://gist.github.com/${gist_path}.js\">\n\n</script>\n<noscript><a href=\"${gist_url}\">View this gist on GitHub</a></noscript>"
+			"<span class='coblocks-gist__container' style='pointer-events: none'><script src=\"https://gist.github.com/${gist_path}.js\">\n\n</script>\n<noscript><a class=\"gist-block__container\" href=\"${gist_url}\">View this gist on GitHub</a></noscript></span>"
 		);
 	}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -80,7 +80,7 @@ class CoBlocks_Block_Assets {
 		$vendors_dir = CoBlocks()->asset_source( 'js/vendors' );
 
 		// Gist block.
-		// only want this loading in front end
+		// only want this loading in front end.
 		if ( has_block( 'coblocks/gist' ) || has_block( 'core/embed' ) ) {
 			wp_enqueue_script(
 				'coblocks-gist',

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -47,6 +47,7 @@ class CoBlocks_Block_Assets {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'frontend_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 		add_action( 'save_post_wp_template_part', array( $this, 'clear_template_transients' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_only_scripts' ) );
 	}
 
 	/**
@@ -66,6 +67,29 @@ class CoBlocks_Block_Assets {
 				'dependencies' => array(),
 				'version'      => COBLOCKS_VERSION,
 			);
+	}
+
+	/**
+	 * Enqueue scripts that should only be available on the front end
+	 */
+	public function frontend_only_scripts() {
+		// Define where the asset is loaded from.
+		$dir = CoBlocks()->asset_source( 'js' );
+
+		// Define where the vendor asset is loaded from.
+		$vendors_dir = CoBlocks()->asset_source( 'js/vendors' );
+
+		// Gist block.
+		// only want this loading in front end
+		if ( has_block( 'coblocks/gist' ) || has_block( 'core/embed' ) ) {
+			wp_enqueue_script(
+				'coblocks-gist',
+				$dir . 'coblocks-gist.js',
+				array(),
+				COBLOCKS_VERSION,
+				true
+			);
+		}
 	}
 
 	/**

--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -80,7 +80,7 @@ function coblocks_block_gist_handler( $matches ) {
 	$gist_html .= wp_get_inline_script_tag( null, array( 'src' => esc_url( 'https://gist.github.com/' . $script_src ) ) );
 
 	$gist_html .= sprintf(
-		'<noscript><a class="gist-block__container" href="%1$s">%2$s</a></noscript>',
+		'<a class="gist-block__container" href="%1$s" target="_blank">%2$s</a>',
 		esc_url( $gist_url ),
 		esc_html( __( 'View this gist on GitHub', 'coblocks' ) )
 	);

--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -9,7 +9,7 @@
  * Registers the Gist oembed handler.
  */
 function coblocks_register_gist_oembed() {
-	wp_embed_register_handler( 'gist', '/https?:\/\/gist\.github\.com\/([a-zA-Z0-9\/]+)(?:\#file\-([a-zA-Z0-9\_\-]+))?/', 'coblocks_block_gist_handler' );
+	wp_embed_register_handler( 'gist', '/https?:\/\/gist\.github\.com\/([a-zA-Z0-9\/\_\-]+)(?:\#file\-([a-zA-Z0-9\_\-]+))?/', 'coblocks_block_gist_handler' );
 }
 add_action( 'init', 'coblocks_register_gist_oembed' );
 
@@ -75,10 +75,16 @@ function coblocks_block_gist_handler( $matches ) {
 
 	}
 
-	return sprintf(
-		'%1$s<noscript><a href="%2$s">%3$s</a></noscript>',
+	$gist_html = '<span className="coblocks-gist__container" style="pointer-events: none" class="coblocks-gist__container">';
+
+	$gist_html .= sprintf(
+		'%1$s<noscript><a class="gist-block__container" href="%2$s">%3$s</a></noscript>',
 		wp_get_inline_script_tag( null, array( 'src' => esc_url( 'https://gist.github.com/' . $script_src ) ) ),
 		esc_url( $gist_url ),
 		esc_html( __( 'View this gist on GitHub', 'coblocks' ) )
 	);
+
+	$gist_html .= '</span>';
+
+	return $gist_html;
 }

--- a/src/blocks/gist/index.php
+++ b/src/blocks/gist/index.php
@@ -75,11 +75,12 @@ function coblocks_block_gist_handler( $matches ) {
 
 	}
 
-	$gist_html = '<span className="coblocks-gist__container" style="pointer-events: none" class="coblocks-gist__container">';
+	$gist_html = "<span class='coblocks-gist__container' style='pointer-events: none'>";
+
+	$gist_html .= wp_get_inline_script_tag( null, array( 'src' => esc_url( 'https://gist.github.com/' . $script_src ) ) );
 
 	$gist_html .= sprintf(
-		'%1$s<noscript><a class="gist-block__container" href="%2$s">%3$s</a></noscript>',
-		wp_get_inline_script_tag( null, array( 'src' => esc_url( 'https://gist.github.com/' . $script_src ) ) ),
+		'<noscript><a class="gist-block__container" href="%1$s">%2$s</a></noscript>',
 		esc_url( $gist_url ),
 		esc_html( __( 'View this gist on GitHub', 'coblocks' ) )
 	);

--- a/src/js/coblocks-gist.js
+++ b/src/js/coblocks-gist.js
@@ -1,0 +1,17 @@
+( function() {
+	'use strict';
+
+	/*
+		Gist block links are disabled by default
+		on front end only, we remove the block to allow for clicking
+	*/
+	document.addEventListener( 'DOMContentLoaded', function() {
+		const gistBlockContainers = document.querySelectorAll( '.coblocks-gist__container' );
+
+		for ( let i = 0; i < gistBlockContainers.length; i++ ) {
+			const currentGistBlock = gistBlockContainers[ i ];
+
+			currentGistBlock.style.pointerEvents = 'all';
+		}
+	} );
+}() );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ const scripts = [
 	'coblocks-masonry',
 	'coblocks-post-carousel',
 	'coblocks-tinyswiper-initializer',
+	'coblocks-gist',
 ];
 
 const coblocksEntries = fs.readdirSync( path.resolve( process.cwd(), 'src' ) ).filter( ( file ) => file.startsWith( 'blocks-' ) );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This PR fixes an issue with the Gist block which (within the editor) any links within the Gist iframe will open within the iframe itself rather than the window. These changes disable the links within the editor and include a script on the front end to re-enable the links. 

Fixes #2326 


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
manually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Links should not be clickable/openable within the editor.


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
