### PR TITLE
Resolve WordPress Warnings on Widgets.php

### DIFF
--- a/includes/class-block-patterns.php
+++ b/includes/class-block-patterns.php
@@ -119,7 +119,7 @@ class CoBlocks_Block_Patterns {
 			'coblocks-editor',
 			'coblocksBlockPatterns',
 			array(
-				'patternsEnabled' => is_wp_version_compatible( '5.5' ),
+				'patternsEnabled' => (bool) apply_filters( 'coblocks_patterns_show_settings_panel', is_wp_version_compatible( '5.5' ) ),
 			)
 		);
 	}

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -163,6 +163,20 @@ class CoBlocks_Block_Assets {
 		$filepath   = 'dist/' . $name;
 		$asset_file = $this->get_asset_file( $filepath );
 
+		global $pagenow;
+
+		// Prevent wp-edit-post and coblocks settings/patterns plugins from loading on the widgets.php page.
+		if ( 'widgets.php' === $pagenow ) {
+			$script_key = array_search( 'wp-edit-post', $asset_file['dependencies'], true );
+
+			if ( false !== $script_key ) {
+				unset( $asset_file['dependencies'][ $script_key ] );
+			}
+
+			add_filter( 'coblocks_show_settings_panel', '__return_false' );
+			add_filter( 'coblocks_patterns_show_settings_panel', '__return_false' );
+		}
+
 		wp_enqueue_script(
 			'coblocks-editor',
 			COBLOCKS_PLUGIN_URL . $filepath . '.js',
@@ -180,6 +194,15 @@ class CoBlocks_Block_Assets {
 
 			$filepath   = 'dist/' . $name;
 			$asset_file = $this->get_asset_file( $filepath );
+
+			// Prevent wp-editor from loading on the widgets.php page.
+			if ( 'widgets.php' === $pagenow ) {
+				$script_key = array_search( 'wp-editor', $asset_file['dependencies'], true );
+
+				if ( false !== $script_key ) {
+					unset( $asset_file['dependencies'][ $script_key ] );
+				}
+			}
 
 			wp_enqueue_script(
 				$name,


### PR DESCRIPTION
Resolves #2291 

### Description
- Prevent `wp-editor`/`wp-edit-post` scripts and coblocks settings/patterns plugins from loading on widgets.php.
- Introduced a new filter `coblocks_patterns_show_settings_panel` to allow the patterns plugin to be disabled. 

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Manually tested.

### Acceptance criteria
- I should be able to view the `widgets.php` page without any PHP warnings/errors.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
