### PR TITLE
WPEX-1927 remove WP error showing within the Widget editor 

### DIFF
--- a/includes/class-block-patterns.php
+++ b/includes/class-block-patterns.php
@@ -119,7 +119,7 @@ class CoBlocks_Block_Patterns {
 			'coblocks-editor',
 			'coblocksBlockPatterns',
 			array(
-				'patternsEnabled' => is_wp_version_compatible( '5.5' ),
+				'patternsEnabled' => (bool) apply_filters( 'coblocks_patterns_show_settings_panel', is_wp_version_compatible( '5.5' ) ),
 			)
 		);
 	}

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -163,6 +163,20 @@ class CoBlocks_Block_Assets {
 		$filepath   = 'dist/' . $name;
 		$asset_file = $this->get_asset_file( $filepath );
 
+		global $pagenow;
+
+		// Prevent wp-edit-post and coblocks settings/patterns plugins from loading on the widgets.php page.
+		if ( 'widgets.php' === $pagenow ) {
+			$script_key = array_search( 'wp-edit-post', $asset_file['dependencies'], true );
+
+			if ( false !== $script_key ) {
+				unset( $asset_file['dependencies'][ $script_key ] );
+			}
+
+			add_filter( 'coblocks_show_settings_panel', '__return_false' );
+			add_filter( 'coblocks_patterns_show_settings_panel', '__return_false' );
+		}
+
 		wp_enqueue_script(
 			'coblocks-editor',
 			COBLOCKS_PLUGIN_URL . $filepath . '.js',
@@ -180,6 +194,15 @@ class CoBlocks_Block_Assets {
 
 			$filepath   = 'dist/' . $name;
 			$asset_file = $this->get_asset_file( $filepath );
+
+			// Prevent wp-editor from loading on the widgets.php page.
+			if ( 'widgets.php' === $pagenow ) {
+				$script_key = array_search( 'wp-editor', $asset_file['dependencies'], true );
+
+				if ( false !== $script_key ) {
+					unset( $asset_file['dependencies'][ $script_key ] );
+				}
+			}
 
 			wp_enqueue_script(
 				$name,


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This PR resolves an issue within the WP admin Widget editor which displays an error message in the admin header. The issue was caused by wp-editor scripts being loaded and conflicting with the widget editor scripts.

Fixes #2291 


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
manually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Error message should not be shown on the widget editor screen


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
