### PR TITLE
WPEX-1926 - handle multi day events in the events block

### DIFF
--- a/src/blocks/events/event-item/styles/style.scss
+++ b/src/blocks/events/event-item/styles/style.scss
@@ -18,7 +18,7 @@
 	margin-bottom: var(--coblocks-spacing--3, map-get($spacing, 3));
 
 	@include break-medium() {
-		flex-basis: 15%;
+		flex-basis: 25%;
 		margin-bottom: 0;
 	}
 }

--- a/src/blocks/events/event-item/styles/style.scss
+++ b/src/blocks/events/event-item/styles/style.scss
@@ -55,9 +55,12 @@
 
 
 .wp-block-coblocks-events__day {
-	display: block;
+	align-items: center;
+	display: flex;
+	flex-direction: row;
 	font-size: 1.75em;
 	font-weight: 700;
+	justify-content: space-between;
 	margin-bottom: 5px;
 }
 

--- a/src/blocks/events/event-item/styles/style.scss
+++ b/src/blocks/events/event-item/styles/style.scss
@@ -61,7 +61,10 @@
 	font-size: 1.75em;
 	font-weight: 700;
 	justify-content: space-between;
-	margin-bottom: 5px;
+
+	& > p {
+		margin-bottom: 0;
+	}
 }
 
 .wp-block-coblocks-events__month {

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -251,13 +251,9 @@ function coblocks_render_event_item(
  * @param mixed  ...$event_data list of event data arguments.
  */
 function coblocks_render_multi_day_event_item( $start_date, $end_date, ...$event_data ) {
-	$date_range  = '<p>';
-	$date_range .= $start_date;
-	$date_range .= '</p>';
+	$date_range  = $start_date;
 	$date_range .= ' - ';
-	$date_range .= '<p>';
 	$date_range .= $end_date;
-	$date_range .= '</p>';
 
 	return coblocks_render_event_item( $date_range, ...$event_data );
 }

--- a/src/blocks/events/styles/editor.scss
+++ b/src/blocks/events/styles/editor.scss
@@ -32,6 +32,10 @@
 	}
 }
 
+.wp-block-coblocks-events__day > p {
+	margin: 0;
+}
+
 .wp-block-coblocks-events {
 
 	.wp-block:first-child [data-block] {

--- a/src/js/coblocks-events.js
+++ b/src/js/coblocks-events.js
@@ -1,48 +1,69 @@
 import TinySwiper from 'tiny-swiper';
 import TinySwiperPluginNavigation from 'tiny-swiper/lib/modules/navigation.min.js';
 
+const loadEventCarousel = () => {
+	const frontEndContainers = document.querySelectorAll( '.page .wp-block-coblocks-front-events-swiper-container' );
+
+	// there may be multiple event blocks
+	for ( let j = 0; j < frontEndContainers.length; j++ ) {
+		const frontEndContainer = frontEndContainers[ j ];
+
+		if ( ! frontEndContainer ) {
+			return;
+		}
+
+		const swiperWrapper = frontEndContainer.querySelector( '.swiper-wrapper-loading' );
+
+		const totalSlides = frontEndContainer.querySelectorAll( '.swiper-slide' );
+
+		const swiperBackButton = frontEndContainer.parentNode.querySelector( `#wp-coblocks-event-swiper-prev` );
+		const swiperNextButton = frontEndContainer.parentNode.querySelector( `#wp-coblocks-event-swiper-next` );
+
+		if ( totalSlides.length > 1 && swiperWrapper ) {
+			swiperWrapper.classList.remove( 'swiper-wrapper-loading' );
+			swiperWrapper.classList.add( 'swiper-wrapper' );
+
+			swiperBackButton.style.visibility = 'visible';
+			swiperNextButton.style.visibility = 'visible';
+
+			new TinySwiper( frontEndContainer, {
+				navigation: {
+					nextEl: swiperNextButton,
+					prevEl: swiperBackButton,
+				},
+				plugins: [
+					TinySwiperPluginNavigation,
+				],
+				spaceBetween: 10,
+				touchable: false,
+			} );
+		}
+	}
+};
+
+const formatEventTimes = () => {
+	const allEventItems = document.querySelectorAll( '.wp-block-coblocks-events__time-formatted' );
+	for ( let x = 0; x < allEventItems.length; x++ ) {
+		const eventItem = allEventItems[ x ];
+
+		const startTime = eventItem.getAttribute( 'data-start-time' );
+		const endTime = eventItem.getAttribute( 'data-end-time' );
+
+		eventItem.innerHTML = ( `
+			${ new Date( startTime ).toLocaleTimeString() }
+			-
+			${ new Date( endTime ).toLocaleTimeString() }
+	` );
+	}
+};
+
 ( function() {
 	'use strict';
 
 	document.addEventListener( 'DOMContentLoaded', function() {
 		setTimeout( () => {
-			const frontEndContainers = document.querySelectorAll( '.page .wp-block-coblocks-front-events-swiper-container' );
-
-			// there may be multiple event blocks
-			for ( let j = 0; j < frontEndContainers.length; j++ ) {
-				const frontEndContainer = frontEndContainers[ j ];
-
-				if ( ! frontEndContainer ) {
-					return;
-				}
-
-				const swiperWrapper = frontEndContainer.querySelector( '.swiper-wrapper-loading' );
-
-				const totalSlides = frontEndContainer.querySelectorAll( '.swiper-slide' );
-
-				const swiperBackButton = frontEndContainer.parentNode.querySelector( `#wp-coblocks-event-swiper-prev` );
-				const swiperNextButton = frontEndContainer.parentNode.querySelector( `#wp-coblocks-event-swiper-next` );
-
-				if ( totalSlides.length > 1 && swiperWrapper ) {
-					swiperWrapper.classList.remove( 'swiper-wrapper-loading' );
-					swiperWrapper.classList.add( 'swiper-wrapper' );
-
-					swiperBackButton.style.visibility = 'visible';
-					swiperNextButton.style.visibility = 'visible';
-
-					new TinySwiper( frontEndContainer, {
-						navigation: {
-							nextEl: swiperNextButton,
-							prevEl: swiperBackButton,
-						},
-						plugins: [
-							TinySwiperPluginNavigation,
-						],
-						spaceBetween: 10,
-						touchable: false,
-					} );
-				}
-			}
+			loadEventCarousel();
+			formatEventTimes();
 		}, 500 );
 	}, false );
 }() );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Previously the events block did not support multi day events. Additionally, timed events which were not "all day" would show incorrect times for the events. 

Fixes #2302 
Fixes #2301 


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
manually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Multi day events should be supported, correct times should be shown


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
