### PR TITLE
WPEX-1925 - adjust focus color on accordion block

### DIFF
--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -36,7 +36,7 @@
 		}
 
 		&:focus {
-			outline: 1px dotted #a2aab2;
+			outline: 1px dotted;
 			outline-offset: -4px;
 		}
 	}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
adjusts the outline color of the summary tag within the Accordion block for better visibility to keyboard users.

fixes #2303 


### Screenshots
<!-- if applicable -->

Before:
<img width="706" alt="Screen Shot 2022-05-03 at 11 58 39 AM" src="https://user-images.githubusercontent.com/85255746/166490236-0a697799-6649-4466-a614-519e03172fb2.png">


After:
<img width="706" alt="Screen Shot 2022-05-03 at 11 57 41 AM" src="https://user-images.githubusercontent.com/85255746/166490066-0c84df51-a343-47b4-b6ed-4de062ff5a1d.png">


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
bug fix / css change

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
visually


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
