### PR TITLE
Fix more Cypress tests for WP 6.0 RC1

### DIFF
--- a/src/blocks/click-to-tweet/test/click-to-tweet.cypress.js
+++ b/src/blocks/click-to-tweet/test/click-to-tweet.cypress.js
@@ -58,7 +58,7 @@ describe( 'Test CoBlocks Click to Tweet Block', function() {
 		cy.get( '.wp-block-coblocks-click-to-tweet' ).click( { force: true } );
 		cy.get( '.wp-block-coblocks-click-to-tweet__text' ).focus().type( 'Some custom data here.' );
 
-		cy.get( '.components-toggle-group-control-option' ).then( ( elems ) => {
+		cy.get( '.components-toggle-group-control-option, .components-toggle-group-control-option-base' ).then( ( elems ) => {
 			let dataValue;
 			Array.from( elems ).forEach( ( elem ) => {
 				dataValue = Cypress.$( elem ).css( 'font-size' );

--- a/src/blocks/dynamic-separator/test/dynamic-separator.cypress.js
+++ b/src/blocks/dynamic-separator/test/dynamic-separator.cypress.js
@@ -30,21 +30,21 @@ describe( 'Test CoBlocks Dynamic Seperator Block', function() {
 
 		helpers.openSettingsPanel( 'Styles' );
 
-		cy.get( '.block-editor-block-styles__item-label' )
+		cy.get( '.block-editor-block-styles__item-label, .block-editor-block-styles__item-text' )
 			.contains( 'Line' )
 			.click();
 
 		cy.get( '.wp-block-coblocks-dynamic-separator' )
 			.should( 'have.class', 'is-style-line' );
 
-		cy.get( '.block-editor-block-styles__item-label' )
+		cy.get( '.block-editor-block-styles__item-label, .block-editor-block-styles__item-text' )
 			.contains( 'Dot' )
 			.click();
 
 		cy.get( '.wp-block-coblocks-dynamic-separator' )
 			.should( 'have.class', 'is-style-dots' );
 
-		cy.get( '.block-editor-block-styles__item-label' )
+		cy.get( '.block-editor-block-styles__item-label, .block-editor-block-styles__item-text' )
 			.contains( 'Fullwidth' )
 			.click();
 

--- a/src/blocks/logos/test/logos.cypress.js
+++ b/src/blocks/logos/test/logos.cypress.js
@@ -93,7 +93,9 @@ describe( 'Test CoBlocks Logos Block', function() {
 			}
 		} );
 
-		helpers.setBlockStyle( /black & white/i );
+		// 'whit' instead of 'white' is intentional. Sometimes when rendering with smaller screens,
+		// it shows Black & Whit... instead of Black & White
+		helpers.setBlockStyle( /black & whit/i );
 
 		cy.get( '.wp-block-coblocks-logos' ).should( 'have.class', 'is-style-black-and-white' );
 

--- a/src/extensions/colors/test/settings-modal-control.cypress.js
+++ b/src/extensions/colors/test/settings-modal-control.cypress.js
@@ -43,7 +43,8 @@ describe( 'Settings Modal: Colors feature', () => {
 		helpers.openSettingsPanel( /Overlay/i );
 
 		// Open settings modal.
-		cy.get( '.interface-interface-skeleton__header .edit-post-more-menu .components-button' ).click();
+		cy.get( '.interface-interface-skeleton__header .edit-post-more-menu .components-button' +
+			', .interface-interface-skeleton__header .interface-more-menu-dropdown .components-button' ).click();
 		cy.get( '.components-menu-item__button,.components-button' ).contains( 'Editor settings' ).click();
 	} );
 


### PR DESCRIPTION
### Description
This time, I am fixing tests for these blocks/extensions : 
- Click to Tweet
- Dynamic Separator
- Logos
- Colors extension (settings modal)