### PR TITLE
Add e2e tests with PHP 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,20 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+  php_81_browsers_mysql_mailhog:
+    docker:
+      - image: cimg/php:8.1-browsers
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: cimg/mysql:5.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: mailhog/mailhog:v1.0.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
   php_74_node:
     docker:
       - image: cimg/php:7.4-node
@@ -176,12 +190,12 @@ workflows:
           requires:
             - build
 
-      # - e2e_chrome_wp_previous_major:
-      #    filters:
-      #      tags:
-      #        only: /^(?!canary).*$/
-      #    requires:
-      #      - build
+      - e2e_chrome_wp_php81:
+          filters:
+            tags:
+              only: /^(?!canary).*$/
+          requires:
+            - build
 
       # PERF TESTING
       - perf_tests_master:
@@ -773,6 +787,13 @@ jobs:
       - run_e2e_tests:
           browser: chrome
           theme: twentytwentytwo
+
+  e2e_chrome_wp_php81:
+    executor: php_81_browsers_mysql_mailhog
+    parallelism: 11
+    steps:
+      - run_e2e_tests:
+          browser: chrome
 
   perf_tests_master:
     executor: php_74_browsers_mysql


### PR DESCRIPTION
### Description
Adding e2e tests for PHP 8.1 in CircleCI, as WP now supports PHP 8.1.

### Types of changes
Developer Experience