### PR TITLE
Fix issue preventing the widgets page from showing

### DIFF
--- a/src/extensions/coblocks-labs/index.js
+++ b/src/extensions/coblocks-labs/index.js
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PluginMoreMenuItem } from '@wordpress/edit-post';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import { MenuItem, Modal } from '@wordpress/components';
+
+// In the context of `widgets.php`, `editPostImport` is not available.
+import * as editPostImport from '@wordpress/edit-post';
+const PluginMoreMenuItem = () => !! editPostImport ? editPostImport.PluginMoreMenuItem : null;
 
 /**
  * Internal dependencies

--- a/src/extensions/site-content/index.js
+++ b/src/extensions/site-content/index.js
@@ -13,7 +13,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { useEffect } from '@wordpress/element';
 import { useEntityProp } from '@wordpress/core-data';
 import { compose, ifCondition } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { select as selectWithoutHooks, withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Local dependencies
@@ -74,7 +74,9 @@ registerPlugin( PLUGIN_NAME, {
 	render: compose( [
 		ifCondition( () => {
 			const [ siteContentEnabled ] = useEntityProp( 'root', 'site', SITE_CONTENT_FEATURE_ENABLED_KEY );
-			return siteContentEnabled;
+			// In the context of `widgets.php` site content is incompatible due to missing dependencies.
+			const isCompatible = !! selectWithoutHooks( 'core/editor' );
+			return siteContentEnabled && isCompatible;
 		} ),
 		withSelect( ( select ) => {
 			const {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Close #2377
A few minor changes here to conditionally load some of the dependencies that are being called. For whatever reason, in the `widgets.php` context some of the imports/dispatches we use are unexpectedly undefined. 

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/168379631-fecf0a40-229d-450a-a83c-a989f3f8cbc5.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor JS changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually on twentyseventeen

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should be able to use the widgets page on non-block themes.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
