### PR TITLE
Issue-2115: Reintroduce transformation unit tests for CoBlocks Galleries to Core 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,3 +52,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @ehamwey          |                        |
 | @amenk            |                        |
 | @frozzare         |                        |
+| @adamf59          | @afrankgodaddy         |

--- a/src/blocks/gallery-carousel/test/transforms.spec.js
+++ b/src/blocks/gallery-carousel/test/transforms.spec.js
@@ -22,8 +22,8 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		] };
 
 	const innerBlocks = [
-		createBlock( 'core/image', attributes.images[0], [] ),
-		createBlock( 'core/image', attributes.images[1], [] )
+		createBlock( 'core/image', attributes.images[ 0 ], [ ] ),
+		createBlock( 'core/image', attributes.images[ 1 ], [ ] ),
 	];
 
 	beforeAll( () => {
@@ -98,7 +98,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 	} );
 
 	it( 'should transform from core/image block only if match', () => {
-		expect( transforms.from[ 2 ].isMatch( [ { id: 1234, url: 'someUrl' }, { id: "1234", url: 'someUrl' } ] ) ).toHaveLength( 1 );
+		expect( transforms.from[ 2 ].isMatch( [ { id: 1234, url: 'someUrl' }, { id: '1234', url: 'someUrl' } ] ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should transform to coblocks/gallery-stacked block', () => {
@@ -149,13 +149,9 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		attributes.images.forEach( (image, index) => {
-
-			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+		attributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
-
-		});
-
+		} );
 	} );
 
 	it( 'should transform when ":carousel" prefix is seen', () => {
@@ -170,7 +166,7 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 			createBlock( 'core/image', { id: 0, url: 'http://local.domain/image.jpg' } ),
 			createBlock( 'core/image', { id: 1, url: 'http://local.domain/image.jpg' } ),
 		];
-		const transformed = switchToBlockType( coreImageBlocks, name )[0];
+		const transformed = switchToBlockType( coreImageBlocks, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		expect( transformed.attributes.images.length ).toBeGreaterThan( 0 );

--- a/src/blocks/gallery-carousel/test/transforms.spec.js
+++ b/src/blocks/gallery-carousel/test/transforms.spec.js
@@ -144,15 +144,18 @@ describe( 'coblocks/gallery-carousel transforms', () => {
 		}
 	} );
 
-	it.skip( 'should transform to core/gallery block', () => {
+	it( 'should transform to core/gallery block', () => {
 		const block = createBlock( name, attributes );
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i = 0; i < attributes.images.length; i++ ) {
-			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
-			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
-		}
+		attributes.images.forEach( (image, index) => {
+
+			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
+
+		});
+
 	} );
 
 	it( 'should transform when ":carousel" prefix is seen', () => {

--- a/src/blocks/gallery-collage/test/transforms.spec.js
+++ b/src/blocks/gallery-collage/test/transforms.spec.js
@@ -22,8 +22,8 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		] };
 
 	const innerBlocks = [
-		createBlock( 'core/image', attributes.images[0], [] ),
-		createBlock( 'core/image', attributes.images[1], [] )
+		createBlock( 'core/image', attributes.images[ 0 ], [ ] ),
+		createBlock( 'core/image', attributes.images[ 1 ], [ ] ),
 	];
 
 	beforeAll( () => {
@@ -98,7 +98,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 	} );
 
 	it( 'should transform from core/image block only if match', () => {
-		expect( transforms.from[ 2 ].isMatch( [ { id: 1234, url: 'someUrl' }, { id: "1234", url: 'someUrl' } ] ) ).toHaveLength( 1 );
+		expect( transforms.from[ 2 ].isMatch( [ { id: 1234, url: 'someUrl' }, { id: '1234', url: 'someUrl' } ] ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should transform to coblocks/gallery-stacked block', () => {
@@ -114,7 +114,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 
 	it( 'should transform to coblocks/gallery-masonry block', () => {
 		const block = createBlock( name, attributes );
-		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' )[0];
+		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -149,13 +149,9 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		attributes.images.forEach( (image, index) => {
-
-			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+		attributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
-
-		});
-
+		} );
 	} );
 
 	it( 'should transform when ":collage" prefix is seen', () => {
@@ -170,7 +166,7 @@ describe( 'coblocks/gallery-collage transforms', () => {
 			createBlock( 'core/image', { id: 0, url: 'http://local.domain/image.jpg' } ),
 			createBlock( 'core/image', { id: 1, url: 'http://local.domain/image.jpg' } ),
 		];
-		const transformed = switchToBlockType( coreImageBlocks, name )[0];
+		const transformed = switchToBlockType( coreImageBlocks, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		expect( transformed.attributes.images.length ).toBeGreaterThan( 0 );

--- a/src/blocks/gallery-collage/test/transforms.spec.js
+++ b/src/blocks/gallery-collage/test/transforms.spec.js
@@ -144,15 +144,18 @@ describe( 'coblocks/gallery-collage transforms', () => {
 		}
 	} );
 
-	it.skip( 'should transform to core/gallery block', () => {
+	it( 'should transform to core/gallery block', () => {
 		const block = createBlock( name, attributes );
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i = 0; i < attributes.images.length; i++ ) {
-			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
-			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
-		}
+		attributes.images.forEach( (image, index) => {
+
+			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
+
+		});
+
 	} );
 
 	it( 'should transform when ":collage" prefix is seen', () => {

--- a/src/blocks/gallery-masonry/test/transforms.spec.js
+++ b/src/blocks/gallery-masonry/test/transforms.spec.js
@@ -157,15 +157,18 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		} )
 	} );
 
-	it.skip( 'should transform to core/gallery block', () => {
+	it( 'should transform to core/gallery block', () => {
 		const block = createBlock( name, masonryAttributes, innerBlocks );
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		sharedAttributes.images.forEach( ( image, index ) => {
-			expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
-			expect( transformed[ 0 ].attributes.images[ index ].url ).toBe( image.url );
+
+			// expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
+			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
+
 		} );
+
 	} );
 
 	it( 'should transform when ":masonry" prefix is seen', () => {

--- a/src/blocks/gallery-masonry/test/transforms.spec.js
+++ b/src/blocks/gallery-masonry/test/transforms.spec.js
@@ -22,8 +22,8 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	const masonryAttributes = {};
 	const innerBlocks = [
-		createBlock( 'core/image', sharedAttributes.images[0], [] ),
-		createBlock( 'core/image', sharedAttributes.images[1], [] )
+		createBlock( 'core/image', sharedAttributes.images[ 0 ], [ ] ),
+		createBlock( 'core/image', sharedAttributes.images[ 1 ], [ ] ),
 	];
 
 	beforeAll( () => {
@@ -33,7 +33,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	it( 'should transform from coblocks/gallery-stacked block', () => {
 		const galleryStacked = createBlock( 'coblocks/gallery-stacked',	sharedAttributes );
-		const transformed = switchToBlockType( galleryStacked, name )[0];
+		const transformed = switchToBlockType( galleryStacked, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -44,7 +44,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	it( 'should transform from coblocks/gallery-collage block', () => {
 		const galleryCollage = createBlock( 'coblocks/gallery-collage', sharedAttributes );
-		const transformed = switchToBlockType( galleryCollage, name )[0];
+		const transformed = switchToBlockType( galleryCollage, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -55,7 +55,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	it( 'should transform from coblocks/gallery-offset block', () => {
 		const galleryOffset = createBlock( 'coblocks/gallery-offset', sharedAttributes );
-		const transformed = switchToBlockType( galleryOffset, name )[0];
+		const transformed = switchToBlockType( galleryOffset, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -66,7 +66,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	it( 'should transform from coblocks/gallery-carousel block', () => {
 		const galleryCarousel = createBlock( 'coblocks/gallery-carousel', sharedAttributes );
-		const transformed = switchToBlockType( galleryCarousel, name )[0];
+		const transformed = switchToBlockType( galleryCarousel, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -77,7 +77,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 	it( 'should transform from core/gallery block', () => {
 		const coreGallery = createBlock( 'core/gallery', { images: sharedAttributes.images } );
-		const transformed = switchToBlockType( coreGallery, name )[0];
+		const transformed = switchToBlockType( coreGallery, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -87,14 +87,14 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 	} );
 
 	it( 'should transform from core/image block', () => {
-		const coreImage = createBlock( 'core/image', { id:sharedAttributes.images[ 0 ].index, url:sharedAttributes.images[ 0 ].url } );
-		const transformed = switchToBlockType( coreImage, name )[0];
+		const coreImage = createBlock( 'core/image', { id: sharedAttributes.images[ 0 ].index, url: sharedAttributes.images[ 0 ].url } );
+		const transformed = switchToBlockType( coreImage, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		expect( transformed.innerBlocks.length ).toBeGreaterThan( 0 );
 
-		expect( transformed.innerBlocks[0].attributes.id ).toBe( coreImage.attributes.id );
-		expect( transformed.innerBlocks[0].attributes.url ).toBe( coreImage.attributes.url );
+		expect( transformed.innerBlocks[ 0 ].attributes.id ).toBe( coreImage.attributes.id );
+		expect( transformed.innerBlocks[ 0 ].attributes.url ).toBe( coreImage.attributes.url );
 	} );
 
 	it( 'should transform from multiple core/image blocks', () => {
@@ -102,7 +102,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 			createBlock( 'core/image', { id: 0, url: 'http://local.domain/image.jpg' } ),
 			createBlock( 'core/image', { id: 1, url: 'http://local.domain/image.jpg' } ),
 		];
-		const transformed = switchToBlockType( coreImageBlocks, name )[0];
+		const transformed = switchToBlockType( coreImageBlocks, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		expect( transformed.innerBlocks.length ).toBeGreaterThan( 0 );
@@ -121,7 +121,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		sharedAttributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
 			expect( transformed[ 0 ].attributes.images[ index ].url ).toBe( image.url );
-		} )
+		} );
 	} );
 
 	it( 'should transform to coblocks/gallery-collage block', () => {
@@ -132,7 +132,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		sharedAttributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
 			expect( transformed[ 0 ].attributes.images[ index ].url ).toBe( image.url );
-		} )
+		} );
 	} );
 
 	it( 'should transform to coblocks/gallery-offset block', () => {
@@ -143,7 +143,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		sharedAttributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
 			expect( transformed[ 0 ].attributes.images[ index ].url ).toBe( image.url );
-		} )
+		} );
 	} );
 
 	it( 'should transform to coblocks/gallery-carousel block', () => {
@@ -154,7 +154,7 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 		sharedAttributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
 			expect( transformed[ 0 ].attributes.images[ index ].url ).toBe( image.url );
-		} )
+		} );
 	} );
 
 	it( 'should transform to core/gallery block', () => {
@@ -163,12 +163,8 @@ describe( 'coblocks/gallery-masonry transforms', () => {
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
 		sharedAttributes.images.forEach( ( image, index ) => {
-
-			// expect( transformed[ 0 ].attributes.images[ index ].index ).toBe( index );
 			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
-
 		} );
-
 	} );
 
 	it( 'should transform when ":masonry" prefix is seen', () => {

--- a/src/blocks/gallery-offset/test/transforms.spec.js
+++ b/src/blocks/gallery-offset/test/transforms.spec.js
@@ -144,15 +144,18 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		}
 	} );
 
-	it.skip( 'should transform to core/gallery block', () => {
+	it( 'should transform to core/gallery block', () => {
 		const block = createBlock( name, attributes );
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i = 0; i < attributes.images.length; i++ ) {
-			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
-			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
-		}
+		attributes.images.forEach( (image, index) => {
+
+			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
+
+		});
+
 	} );
 
 	it( 'should transform when ":offset" prefix is seen', () => {

--- a/src/blocks/gallery-offset/test/transforms.spec.js
+++ b/src/blocks/gallery-offset/test/transforms.spec.js
@@ -19,12 +19,13 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		images: [
 			{ index: 0, url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg' },
 			{ index: 1, url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
-		] };
+		],
+	};
 
-		const innerBlocks = [
-			createBlock( 'core/image', attributes.images[0], [] ),
-			createBlock( 'core/image', attributes.images[1], [] )
-		];
+	const innerBlocks = [
+		createBlock( 'core/image', attributes.images[ 0 ], [ ] ),
+		createBlock( 'core/image', attributes.images[ 1 ], [ ] ),
+	];
 
 	beforeAll( () => {
 		// Register all gallery blocks.
@@ -98,7 +99,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 	} );
 
 	it( 'should transform from core/image block only if match', () => {
-		expect( transforms.from[ 2 ].isMatch( [ { id: 1234, url: 'someUrl' }, { id: "1234", url: 'someUrl' } ] ) ).toHaveLength( 1 );
+		expect( transforms.from[ 2 ].isMatch( [ { id: 1234, url: 'someUrl' }, { id: '1234', url: 'someUrl' } ] ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should transform to coblocks/gallery-stacked block', () => {
@@ -149,13 +150,9 @@ describe( 'coblocks/gallery-offset transforms', () => {
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		attributes.images.forEach( (image, index) => {
-
-			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+		attributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
-
-		});
-
+		} );
 	} );
 
 	it( 'should transform when ":offset" prefix is seen', () => {
@@ -170,7 +167,7 @@ describe( 'coblocks/gallery-offset transforms', () => {
 			createBlock( 'core/image', { id: 0, url: 'http://local.domain/image.jpg' } ),
 			createBlock( 'core/image', { id: 1, url: 'http://local.domain/image.jpg' } ),
 		];
-		const transformed = switchToBlockType( coreImageBlocks, name )[0];
+		const transformed = switchToBlockType( coreImageBlocks, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		expect( transformed.attributes.images.length ).toBeGreaterThan( 0 );

--- a/src/blocks/gallery-stacked/test/transforms.spec.js
+++ b/src/blocks/gallery-stacked/test/transforms.spec.js
@@ -21,8 +21,8 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		] };
 
 	const innerBlocks = [
-		createBlock( 'core/image', attributes.images[0], [] ),
-		createBlock( 'core/image', attributes.images[1], [] )
+		createBlock( 'core/image', attributes.images[ 0 ], [] ),
+		createBlock( 'core/image', attributes.images[ 1 ], [] ),
 	];
 
 	beforeAll( () => {
@@ -117,7 +117,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 
 	it( 'should transform to coblocks/gallery-masonry block', () => {
 		const block = createBlock( name, attributes );
-		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' )[0];
+		const transformed = switchToBlockType( block, 'coblocks/gallery-masonry' )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		transformed.innerBlocks.forEach( ( image, index ) => {
@@ -152,13 +152,9 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		attributes.images.forEach( (image, index) => {
-
-			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+		attributes.images.forEach( ( image, index ) => {
 			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
-
-		});
-
+		} );
 	} );
 
 	it( 'should transform when ":stacked" prefix is seen', () => {
@@ -173,7 +169,7 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 			createBlock( 'core/image', { id: 0, url: 'http://local.domain/image.jpg' } ),
 			createBlock( 'core/image', { id: 1, url: 'http://local.domain/image.jpg' } ),
 		];
-		const transformed = switchToBlockType( coreImageBlocks, name )[0];
+		const transformed = switchToBlockType( coreImageBlocks, name )[ 0 ];
 
 		expect( transformed.isValid ).toBe( true );
 		expect( transformed.attributes.images.length ).toBeGreaterThan( 0 );

--- a/src/blocks/gallery-stacked/test/transforms.spec.js
+++ b/src/blocks/gallery-stacked/test/transforms.spec.js
@@ -147,15 +147,18 @@ describe( 'coblocks/gallery-stacked transforms', () => {
 		}
 	} );
 
-	it.skip( 'should transform to core/gallery block', () => {
+	it( 'should transform to core/gallery block', () => {
 		const block = createBlock( name, attributes );
 		const transformed = switchToBlockType( block, 'core/gallery' );
 
 		expect( transformed[ 0 ].isValid ).toBe( true );
-		for ( let i = 0; i < attributes.images.length; i++ ) {
-			expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
-			expect( transformed[ 0 ].attributes.images[ i ].url ).toBe( attributes.images[ i ].url );
-		}
+		attributes.images.forEach( (image, index) => {
+
+			// expect( transformed[ 0 ].attributes.images[ i ].index ).toBe( attributes.images[ i ].index );
+			expect( transformed[ 0 ].innerBlocks[ index ].attributes.url ).toBe( image.url );
+
+		});
+
 	} );
 
 	it( 'should transform when ":stacked" prefix is seen', () => {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This change reintroduces tests that were skipped due to breaking-changes in data structuring caused by dependency updates in #2379. Tests are no longer skipped and the proper fields are validated in the transformed block. Additionally, gallery transform test files now fully pass the linter `yarn lint:js`.

### Types of changes
- Reformatting to pass linter (non-breaking).
- Refactoring of skipped unit tests.


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run `npm test:js`: Passes all tests, including the tests that this PR revises.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
- Reintroduced tests pass linter.
- Reintroduced tests properly validate transformations from CoBlocks gallery blocks to Core blocks.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
