### PR TITLE
[WPEX-1977] Experiment with a carousel block

### DIFF
--- a/src/blocks-1.js
+++ b/src/blocks-1.js
@@ -16,7 +16,8 @@ import * as accordionItem from './blocks/accordion/accordion-item';
 import * as alert from './blocks/alert';
 import * as author from './blocks/author';
 import * as buttons from './blocks/buttons';
-import * as carousel from './blocks/gallery-carousel';
+import * as carousel from './blocks/carousel';
+import * as galleryCarousel from './blocks/gallery-carousel';
 
 /**
  * Function to register blocks provided by CoBlocks.
@@ -27,5 +28,6 @@ import * as carousel from './blocks/gallery-carousel';
 	alert,
 	author,
 	buttons,
+	galleryCarousel,
 	carousel,
 ].forEach( registerBlock );

--- a/src/blocks/carousel/block-edit.js
+++ b/src/blocks/carousel/block-edit.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+// import SwiperPluginPagination from 'tiny-swiper/lib/modules/pagination.min.js';
+import TinySwiper from 'tiny-swiper';
+// import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+
+import './styles/editor.scss';
+
+export default function BlockEdit( { clientId, isSelected } ) {
+	const tinyswiperRef = useRef();
+	const carouselRef = useRef();
+	const blockProps = useBlockProps( { ref: carouselRef } );
+	const innerBlocksProps = useInnerBlocksProps( {}, {
+		__experimentalCaptureToolbars: true,
+		allowedBlocks: [ 'core/image', 'core/paragraph', 'core/query' ],
+		orientation: 'horizontal',
+		renderAppender: false,
+	} );
+
+	const {
+		hasInnerBlocks,
+		innerBlocks,
+		isInserterOpened,
+		isListViewOpened,
+		selectedBlock,
+		sidebarIsOpened,
+	} = useSelect( ( select ) => {
+		const { getSelectedBlock, getBlock } = select( 'core/block-editor' );
+		const block = getBlock( clientId );
+
+		return {
+			hasInnerBlocks: !! ( block && block.innerBlocks.length ),
+			innerBlocks: block.innerBlocks,
+			isInserterOpened: select( 'core/edit-post' ).isInserterOpened(),
+			isListViewOpened: select( 'core/edit-post' ).isListViewOpened(),
+			selectedBlock: getSelectedBlock(),
+			sidebarIsOpened: !! (
+				select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' ) ||
+				select( 'core/edit-post' ).isPublishSidebarOpened()
+			),
+		};
+	}, [ clientId ],
+	);
+
+	// console.debug( { hasInnerBlocks, innerBlocks, selectedBlock } );
+
+	useEffect( () => {
+		try {
+			tinyswiperRef.current = new TinySwiper( carouselRef.current, {
+				// * classnames for making any child block a slide.
+				// slideClass: 'block-editor-block-list__block',
+				// wrapperClass: 'block-editor-block-list__layout',
+
+				// * classnames for making a core/query block into slides.
+				slideClass: 'wp-block-post',
+				wrapperClass: 'wp-block-post-template',
+				touchStartPreventDefault: false,
+
+				// pagination: {
+				// 	el: '.swiper-plugin-pagination',
+				// 	clickable: true,
+				// 	bulletClass: 'swiper-plugin-pagination__item',
+				// 	bulletActiveClass: 'is-active',
+				// },
+				// plugins: [ SwiperPluginPagination ],
+			} );
+		} catch ( error ) {
+			console.debug( 'swiper init error', error );
+		}
+
+		return () => tinyswiperRef.current.destroy();
+	}, [] );
+
+	// Update tinyswiper when the innerBlocks change and slide to the selected block.
+	useEffect( () => {
+		const innerBlockSelected = innerBlocks.findIndex( ( block ) => block === selectedBlock );
+		if ( innerBlockSelected !== null && innerBlockSelected !== -1 ) {
+			tinyswiperRef.current.slideTo( innerBlockSelected );
+		}
+		tinyswiperRef.current.update();
+	}, [ innerBlocks, selectedBlock, isSelected ] );
+
+	// Update the size when the various sidebars are toggled.
+	useEffect( () => {
+		tinyswiperRef.current.updateSize();
+	}, [
+		isInserterOpened,
+		isListViewOpened,
+		sidebarIsOpened,
+	] );
+
+	return (
+		<div { ...blockProps }>
+			<div { ...innerBlocksProps } />
+			<ul>
+				<li><Button className="swiper-slide-prev" variant="secondary">Prev</Button></li>
+				<li><Button className="swiper-slide-next" variant="secondary">Next</Button></li>
+			</ul>
+		</div>
+	);
+}

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "coblocks/carousel",
+	"attributes": {
+		"align": {
+			"type": "string"
+		}
+	},
+	"textdomain": "coblocks",
+	"title": "Carousel",
+	"supports": {
+		"align": [ "wide", "full" ],
+		"alignWide": true
+	}
+}

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import BlockEdit from './block-edit';
+import metadata from './block.json';
+
+const settings = {
+	edit: BlockEdit,
+	save: () => (
+		<div { ...useBlockProps.save() }>
+			<InnerBlocks.Content />
+		</div>
+	),
+};
+
+const name = metadata.name;
+export { name, metadata, settings };

--- a/src/blocks/carousel/styles/editor.scss
+++ b/src/blocks/carousel/styles/editor.scss
@@ -1,0 +1,110 @@
+// Container
+.wp-block-coblocks-carousel {
+	// border: 1px solid #f00;
+	box-shadow: inset 0 0 1px #f00;
+	height: 450px;
+	overflow: hidden;
+}
+
+// Wrapper
+.wp-block-coblocks-carousel > .block-editor-block-list__layout,
+.wp-block-coblocks-carousel .wp-block-post-template {
+	// border: 1px solid #0f0;
+	box-shadow: inset 0 0 1px #0f0;
+	display: flex;
+	height: 100%;
+	width: 100%;
+}
+
+// Slide
+.wp-block-coblocks-carousel > .block-editor-block-list__layout > .block-editor-block-list__block,
+.wp-block-coblocks-carousel .wp-block-post-template > .wp-block-post {
+	// border: 1px solid #00f;
+	box-shadow: inset 0 0 1px #00f;
+	cursor: grab;
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+	height: auto;
+	margin: 0;
+	padding: 0;
+	position: relative;
+	width: 100%;
+}
+
+// .wp-block-coblocks-carousel > .block-editor-block-list__block > .block-list-appender {
+// 	align-items: center;
+// 	display: flex;
+// 	justify-content: center;
+
+// }
+
+// .wp-block-coblocks-carousel > .block-editor-block-list__block > .block-list-appender .block-editor-default-block-appender {
+// 	height: auto !important;
+// }
+
+// .wp-block-coblocks-carousel > .block-editor-block-list__block > .block-list-appender .block-editor-inserter {
+// 	position: relative;
+// }
+
+// .block-editor-block-list__block .block-list-appender .block-editor-default-block-appender
+
+// .wp-block-coblocks-carousel .block-editor-block-list__block .block-list-appender {
+// 	align-items: center;
+// 	display: flex;
+// 	height: 100%;
+// 	justify-content: center;
+// 	width: 100%;
+
+// 	.block-editor-inserter button.block-editor-inserter__toggle {
+// 		height: 100%;
+// 		width: 100%;
+// 	}
+// }
+
+.swiper-plugin-pagination {
+	display: block;
+	position: absolute;
+	right: 2.2rem;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 0.5rem;
+}
+
+.swiper-plugin-pagination__item {
+	background: #aaa;
+	border: none;
+	border-radius: 50% !important;
+	cursor: pointer;
+	display: block;
+	height: 24px;
+	// margin: 100% 0;
+	// padding-top: 100%;
+	transition: background ease 0.2s;
+	width: 24px;
+}
+
+.swiper-plugin-pagination__item.is-active {
+	background: #333;
+}
+
+// Image Block
+.wp-block-coblocks-carousel > .block-editor-block-list__layout > .wp-block-image {
+	overflow: hidden;
+
+	.components-resizable-box__container {
+		height: 100% !important;
+		width: 100% !important;
+	}
+
+	// Disable resizable box handles
+	.components-resizable-box__handle {
+		display: none;
+	}
+
+	img {
+		height: 100%;
+		object-fit: cover;
+		width: 100%;
+	}
+}


### PR DESCRIPTION
This experimental branch adds a dedicated carousel block which can be wrapped around any blocks, making each innerBlock a "slide" within the carousel.

The concept is possible though we are running into problems that prevent a good experience for users interacting with the block in the block editor. The idea is to replace each block within CoBlocks that includes carousel functionality to utilize this new block instead. This will consolidate logic for ease of maintainability and unify the features provided by the carousel.

This is a work-in-progress PR. It's put on pause for now with the intent to come back at a later date once/if we resolve the interaction issues.

https://user-images.githubusercontent.com/375788/176958317-95f75b34-ae4b-4dc2-b79b-85bdfaa9670d.mp4