### PR TITLE
Run Cypress tests headed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,8 @@ commands:
           command: |
             touch cypress.env.json
             echo '{"wpUsername":"admin","wpPassword":"password","testURL":"http://coblocks.test"}' | jq . > cypress.env.json
-            ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >>-wp-<< parameters.wpversion >>
+            ./node_modules/.bin/cypress verify
+            ./node_modules/.bin/cypress run --config integrationFolder=./ --browser << parameters.browser >> --record --parallel --group e2e-<< parameters.browser >>-wp-<< parameters.wpversion >> --headed
 
   setup_perf_tests:
     steps:


### PR DESCRIPTION
### Description
There seems to be a bug that sometimes make the Firefox tests fail when it is headless. So, adding the `--headed` flag to make these pass. There does not seem to be a noticeable time difference.

Also making the verification before the run, which is a little bit quicker than doing it at the `cypress run` call.