### PR TITLE
Fix button order in editor header

### DIFF
--- a/src/components/common/styles/edit-post.scss
+++ b/src/components/common/styles/edit-post.scss
@@ -1,4 +1,5 @@
 .edit-post-header__settings .edit-post-more-menu {
+	margin-left: 0.25em;
 	order: 4;
 }
 

--- a/src/components/common/styles/edit-post.scss
+++ b/src/components/common/styles/edit-post.scss
@@ -2,11 +2,6 @@
 	order: 4;
 }
 
-.edit-post-header__settings .editor-post-publish-button__button {
-	margin-left: 25px;
-	order: 3;
-}
-
 .interface-pinned-items {
 	display: flex;
 


### PR DESCRIPTION
Resolves #2421 

### Description
Fix the incorrect button order in the editor.

### Screenshots
<img width="369" alt="image" src="https://user-images.githubusercontent.com/5321364/188680190-46a0d258-a55d-44c0-b9a4-31d734082874.png">

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Tested this with and without Gutenberg active.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->


### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
