### PR TITLE
Update Go from 1.16 to 1.19 for deploy and canary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   go_browsers:
     docker:
-      - image: cimg/go:1.16-browsers
+      - image: cimg/go:1.19-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
### Description
Needed for deploy and canary
