### PR TITLE
Change command from go get to go install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -915,7 +915,7 @@ jobs:
       - run:
           name: Install ghr
           command: |
-            go get -u github.com/tcnksm/ghr
+            go install github.com/tcnksm/ghr@latest
       - run:
           name: Build the plugin
           command: |
@@ -972,7 +972,7 @@ jobs:
       - run:
           name: Install ghr
           command: |
-            go get -u github.com/tcnksm/ghr
+            go install github.com/tcnksm/ghr@latest
       - run:
           name: Build the plugin
           command: |


### PR DESCRIPTION
### Description
In Go 1.18, the command changed from `go get` to `go install` to install packages.


