### PR TITLE
fix #2431: lightbox key bindings re-registering on subsequent opens.

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -142,15 +142,23 @@
 								( images[ imgIndex ] && images[ imgIndex ].nextElementSibling )
 									? getImageCaption( images[ imgIndex ] ) : '';
 					} );
-					setKeyboardListener();
 				}
 			},
 		};
 
+		function openLightbox() {
+			const isClosed = wrapper.style.display === 'none';
+			
+			if ( isClosed ) {
+				wrapper.style.display = 'flex';
+				setKeyboardListener()	
+			}
+		}
+
 		function changeImage( imageIndex ) {
 			imagePreloader.setPreloadImages();
 			index = imageIndex;
-			wrapper.style.display = 'flex';
+			openLightbox();
 			wrapperBackground.style.backgroundImage = `url(${ imagePreloader[ `img-${ index }` ].src })`;
 			image.src = imagePreloader[ `img-${ index }` ].src;
 			caption.innerHTML = imagePreloader[ `img-${ index }` ][ 'data-caption' ];
@@ -165,8 +173,7 @@
 				return;
 			}
 
-			const lightboxDisplayValue = wrapper;
-			const lightboxIsOpen = ( typeof lightboxDisplayValue !== 'undefined' && lightboxDisplayValue?.style?.display === 'flex' );
+			const lightboxIsOpen = wrapper.style.display === 'flex';
 
 			if ( lightboxIsOpen ) {
 				const code = event.code;


### PR DESCRIPTION
### Description
Corrects a bug introduced by #2258 which unregistered the keyboard event listeners on close, but does not correctly re-register the event listeners on subsequent lightbox opens.

### Issue
[#2431](https://github.com/godaddy-wordpress/coblocks/issues/2431)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
This is a suggestion and has _NOT_ been run let alone tested.
Please feel free to discard this PR and implement a real fix with tests.

### Acceptance criteria
- The lightbox keyboard shortcuts work as expected regardless of the number of times the lightbox has been opened and closed.

### Checklist:
- [ ] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
