### PR TITLE
Fix conditional to determine if we are using a WP version >= WP 6.1 in the tests

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -554,5 +554,6 @@ export function isNotWPLocalEnv() {
 export function isWP61AtLeast() {
 	// WP 6.0 uses the branch-6 class, and version 6.1+ uses branch-6-x (ex : branch-6-1 for WP 6.1)
 	// So we are looking for a class that starts with branch-6-
-	return Cypress.$( "[class^='branch-6-']" ).length > 0;
+
+	return Cypress.$( "[class*='branch-6-']" ).length > 0;
 }


### PR DESCRIPTION
### Description
The old version was looking for the first class only, the correct looks for the presence of the class in the list of classes. It is better, because we cannot guarantee that the `branch-6-1` (for example) is the first class named.