### PR TITLE
Bump 'Tested up to' to WP 6.1

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -7,7 +7,7 @@
  * Version: 2.24.4
  * Text Domain: coblocks
  * Domain Path: /languages
- * Tested up to: 6.0
+ * Tested up to: 6.1
  *
  * CoBlocks is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "CoBlocks",
 	"description": "CoBlocks is a suite of professional page building blocks for the WordPress Gutenberg block editor.",
 	"version": "2.24.4",
-	"tested_up_to": "6.0",
+	"tested_up_to": "6.1",
 	"author": "GoDaddy",
 	"license": "GPL-2.0",
 	"repository": "godaddy-wordpress/coblocks",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Author URI: https://www.godaddy.com
 Contributors: godaddy, richtabor, eherman24, jonathanbardo, jrtashjian, paranoia1906, fjarrett, olivierlafleur, jasonlemay, snovosel
 Tags: page builder, Gutenberg blocks, WordPress blocks, gutenberg, blocks
 Requires at least: 5.5
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 7.4
 Stable tag: 2.24.4
 License: GPL-2.0


### PR DESCRIPTION
### Description
We're nearing the end of our modifications and tests for WP 6.1, so our next release will be tagged as supporting WP 6.1