### PR TITLE
Disable color controls for WordPress 6.1+

### DIFF
--- a/includes/class-coblocks-settings.php
+++ b/includes/class-coblocks-settings.php
@@ -59,16 +59,33 @@ class CoBlocks_Settings {
 			'coblocksSettings',
 			array(
 				'coblocksSettingsEnabled' => (bool) apply_filters( 'coblocks_show_settings_panel', true ),
+				'deprecateWith61'         => (bool) $this->deprecate_with_61(),
 			)
 		);
 	}
 
 	/**
+	 * Compare current version with 6.1 WordPress.
+	 *
+	 * @access public
+	 */
+	public function deprecate_with_61() {
+		return (bool) is_wp_version_compatible( '6.1' );
+	}
+
+	/**
 	 * Propagate CoBlocks settings to editor.
+	 * Starting with WordPress 6.1 Color settings are disabled.
+	 * We no longer propagate settings for 6.1 color settings.
 	 *
 	 * @access public
 	 */
 	public function coblocks_feature_propagation() {
+		// Short-circuit feature propagation to prevent missing color controls in 6.1.
+		if ( $this->deprecate_with_61() ) {
+			return;
+		}
+
 		if ( ! get_option( 'coblocks_custom_colors_controls_enabled' ) ) {
 			add_theme_support( 'disable-custom-colors' );
 		}

--- a/src/extensions/colors/settings-modal-control.js
+++ b/src/extensions/colors/settings-modal-control.js
@@ -1,20 +1,21 @@
+/* global coblocksSettings */
 /**
  * WordPress Dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
-import { useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
+import { useEffect } from '@wordpress/element';
+import { useEntityProp } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
 import CoBlocksSettingsModalControl from '../coblocks-settings/coblocks-settings-slot';
 import {
-	COLORS_FEATURE_ENABLED_KEY,
 	COLORS_CUSTOM_FEATURE_ENABLED_KEY,
+	COLORS_FEATURE_ENABLED_KEY,
 	COLORS_GRADIENT_FEATURE_ENABLED_KEY,
 } from './constants';
 
@@ -89,6 +90,10 @@ function CoBlocksEditorSettingsControls() {
 	const disableEditorSetting = ( key ) => setEditorSetting( key, false );
 
 	useEffect( () => {
+		if ( coblocksSettings.deprecateWith61 ) {
+			return;
+		}
+
 		// Skip if the settings have not loaded yet.
 		const hasSettings = [ colorPanelEnabled, customColorsEnabled, gradientPresetsEnabled ].every( ( value ) => value !== undefined );
 		if ( ! hasSettings ) {
@@ -102,6 +107,7 @@ function CoBlocksEditorSettingsControls() {
 			gradients: gradientPresetsEnabled ? enableEditorSetting( 'gradients' ) : disableEditorSetting( 'gradients' ),
 
 			// Handle experimental features for WP 5.8
+			/* eslint-disable sort-keys */
 			__experimentalFeatures: {
 				...settings?.__experimentalFeatures,
 				color: {
@@ -114,15 +120,21 @@ function CoBlocksEditorSettingsControls() {
 						: disableEditorSetting( '__experimentalFeatures.color.gradients' ),
 				},
 			},
+			/* eslint-enable sort-keys */
 		} );
 	}, [ colorPanelEnabled, customColorsEnabled, gradientPresetsEnabled ] );
+
+	const settingsEnabled = ! coblocksSettings?.deprecateWith61;
+	if ( ! settingsEnabled ) {
+		return null;
+	}
 
 	return (
 		<CoBlocksSettingsModalControl>
 			<CheckboxControl
-				label={ __( 'Color settings', 'coblocks' ) }
-				help={ __( 'Allow color settings throughout the editor.', 'coblocks' ) }
 				checked={ !! colorPanelEnabled }
+				help={ __( 'Allow color settings throughout the editor.', 'coblocks' ) }
+				label={ __( 'Color settings', 'coblocks' ) }
 				onChange={ ( isEnabled ) => {
 					setColorPanelEnabled( isEnabled );
 					setCustomColorsEnabled( isEnabled );
@@ -132,9 +144,9 @@ function CoBlocksEditorSettingsControls() {
 
 			{ colorPanelEnabled && (
 				<CheckboxControl
-					label={ __( 'Custom color pickers', 'coblocks' ) }
-					help={ __( 'Allow styling with custom colors.', 'coblocks' ) }
 					checked={ !! customColorsEnabled }
+					help={ __( 'Allow styling with custom colors.', 'coblocks' ) }
+					label={ __( 'Custom color pickers', 'coblocks' ) }
 					onChange={ ( isEnabled ) => {
 						setCustomColorsEnabled( isEnabled );
 						setGradientPresetsEnabled( isEnabled );
@@ -144,9 +156,9 @@ function CoBlocksEditorSettingsControls() {
 
 			{ customColorsEnabled && (
 				<CheckboxControl
-					label={ __( 'Gradient styles', 'coblocks' ) }
-					help={ __( 'Allow styling with gradient fills.', 'coblocks' ) }
 					checked={ !! gradientPresetsEnabled }
+					help={ __( 'Allow styling with gradient fills.', 'coblocks' ) }
+					label={ __( 'Gradient styles', 'coblocks' ) }
 					onChange={ ( isEnabled ) => {
 						setGradientPresetsEnabled( isEnabled );
 					} }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->

Changes to the global color controls now prevent our previous method of removing the colors from the global colors array.  We have removed this feature for 6.1 instead so when running 6.1+ the site will no longer propagate previous color settings or show color controls.

### Screenshots
<!-- if applicable -->
![Screen Shot 2022-10-28 at 1 21 17 PM](https://user-images.githubusercontent.com/30462574/198725846-721f9da2-dc73-475d-bef3-3df875eb6c4c.png)

![Screen Shot 2022-10-28 at 1 24 14 PM](https://user-images.githubusercontent.com/30462574/198726031-6a8e90bd-011d-416c-8eb7-3889c03d79e5.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Add logic to PHP site to short-circuit feature propagation and prevent controls from showing on the editor settings modal.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in 6.1 and 6.0.3.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should not generate errors in 6.1 or in 6.0.3.


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
