### PR TITLE
Make sure that the Welcome Guide does not show in the Cypress tests

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -93,10 +93,8 @@ export function disableGutenbergFeatures() {
 		}
 
 		if ( safeWin.wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
-			cy.log( 'Was activated - toggle it' );
 			safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		} else {
-			cy.log( 'Is not activated' );
 		}
 
 		safeWin.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();

--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -35,7 +35,7 @@ export function addFormChild( name ) {
  * Login to our test WordPress site
  */
 export function loginToSite() {
-	goTo( '/wp-admin/post-new.php?post_type=post' )
+	return goTo( '/wp-admin/post-new.php?post_type=post' )
 		.then( ( window ) => {
 			if ( window.location.pathname === '/wp-login.php' ) {
 			// WordPress has a wp_attempt_focus() function that fires 200ms after the wp-login.php page loads.
@@ -46,9 +46,8 @@ export function loginToSite() {
 				cy.get( '#user_pass' ).type( Cypress.env( 'wpPassword' ) );
 				cy.get( '#wp-submit' ).click();
 			}
-		} );
-
-	cy.get( '.block-editor-page' ).should( 'exist' );
+		} )
+		.get( '.wp-block-post-title' ).should( 'exist' );
 }
 
 /**
@@ -57,9 +56,9 @@ export function loginToSite() {
  * @param {string} path The URI path to go to.
  */
 export function goTo( path = '/wp-admin' ) {
-	cy.visit( Cypress.env( 'testURL' ) + path );
-
-	return getWindowObject();
+	return cy.visit( Cypress.env( 'testURL' ) + path ).then( () => {
+		return getWindowObject();
+	} );
 }
 
 /**
@@ -87,17 +86,19 @@ export function getWindowObject() {
  * Disable Gutenberg Tips
  */
 export function disableGutenbergFeatures() {
-	getWindowObject().then( ( safeWin ) => {
+	return getWindowObject().then( ( safeWin ) => {
 		// Enable "Top Toolbar"
 		if ( ! safeWin.wp.data.select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ) ) {
 			safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
 		}
 
-		if ( ! safeWin.wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
-			return;
+		if ( safeWin.wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
+			cy.log( 'Was activated - toggle it' );
+			safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+		} else {
+			cy.log( 'Is not activated' );
 		}
 
-		safeWin.wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		safeWin.wp.data.dispatch( 'core/editor' ).disablePublishSidebar();
 	} );
 }

--- a/.dev/tests/cypress/support/commands.js
+++ b/.dev/tests/cypress/support/commands.js
@@ -1,8 +1,10 @@
 import { disableGutenbergFeatures, loginToSite } from '../helpers';
 
 before( function() {
-	loginToSite();
-	disableGutenbergFeatures();
+	loginToSite().then( () => {
+		cy.wait( 10000 );
+		disableGutenbergFeatures();
+	} );
 } );
 
 // Maintain WordPress logged in state

--- a/.dev/tests/cypress/support/commands.js
+++ b/.dev/tests/cypress/support/commands.js
@@ -2,6 +2,8 @@ import { disableGutenbergFeatures, loginToSite } from '../helpers';
 
 before( function() {
 	loginToSite().then( () => {
+		// Waiting to see if the Welcome Guide will show up. Could probably be improved, but
+		// for the moment, it seems hard to tie the wait to something else
 		cy.wait( 10000 );
 		disableGutenbergFeatures();
 	} );


### PR DESCRIPTION
### Description
A few tweaks (with a lot of trial and error ;) ) to make the Cypress tests pass with WP 6.1 by fixing the last problem we have for the moment : the welcome guide showing up unexpected and making our tests fail :) 