### PR TITLE
Relocate styles used for Site Design controls.

### DIFF
--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -83,29 +83,6 @@ class CoBlocks_Site_Design {
 
 		add_action( 'wp_ajax_site_design_update_design_style', array( $this, 'update_design_style' ) );
 		add_action( 'rest_api_init', array( $this, 'design_endpoint' ) );
-
-		/**
-		 * Add the shared styles to the editor
-		 */
-		add_action(
-			'admin_init',
-			function() {
-				$suffix = SCRIPT_DEBUG ? '' : '.min';
-				$rtl    = ! is_rtl() ? '' : '-rtl';
-				// Enqueue  shared editor styles.
-				add_editor_style(
-					"dist/css/style-editor{$rtl}{$suffix}.css"
-				);
-			}
-		);
-
-		add_action(
-			'admin_head',
-			function() {
-				printf( '<style id="site-design-styles">%s</style>', esc_html( $this->get_editor_styles() ) );
-			}
-		);
-
 	}
 
 	/**

--- a/src/extensions/site-design/component.js
+++ b/src/extensions/site-design/component.js
@@ -69,6 +69,15 @@ export function SiteDesignStyles() {
 			designResp.stylesheet,
 			fontStylesCache,
 		].join( ' ' );
+
+		/**
+		 * The is-desktop-preview element is where other styles are located - within the body.
+		 * We need higher specificity for the selected Site Design for cascading style.
+		 */
+		const parentTargetClass = 'is-desktop-preview';
+		if ( stylesElement.parentElement.className !== parentTargetClass ) {
+			document.querySelector( `.${ parentTargetClass }` ).appendChild( stylesElement );
+		}
 	}, [ isUpdating, designResp ] );
 
 	useEffect( () => {

--- a/src/extensions/site-design/component.js
+++ b/src/extensions/site-design/component.js
@@ -1,3 +1,4 @@
+/* global siteDesign */
 /**
  * External dependencies
  */
@@ -61,22 +62,26 @@ export function SiteDesignStyles() {
 			return;
 		}
 
-		const stylesElement = document.getElementById( 'site-design-styles' );
+		// The style elements living in the body are those initialized by `add_editor_style` call.
+		// These style elements are non-mutable and need to be manipulated on the fly for the purpose of this component.
+		const taggedStyle = Array.from( document.querySelectorAll( 'style.is-design-style' ) );
+		const originalStyle = () => Array.from( document.querySelectorAll( '.is-desktop-preview style' ) )
+			.filter( ( elem ) => elem.innerHTML?.includes( `style-${ siteDesign.currentDesignStyle }` ) );
+
+		// Reference to the present style tag if class is defined or by original query if not yet modified.
+		const currentDesignStyleTag = ( taggedStyle.length ? taggedStyle : originalStyle() )[ 0 ];
 
 		fontStylesCache = !! fontStylesCache ? fontStylesCache : designResp.fontStyles;
 
-		stylesElement.innerHTML = [
+		// Set the style element innerHTML to remove the old design style.
+		currentDesignStyleTag.innerHTML = [
 			designResp.stylesheet,
 			fontStylesCache,
 		].join( ' ' );
 
-		/**
-		 * The is-desktop-preview element is where other styles are located - within the body.
-		 * We need higher specificity for the selected Site Design for cascading style.
-		 */
-		const parentTargetClass = 'is-desktop-preview';
-		if ( stylesElement.parentElement.className !== parentTargetClass ) {
-			document.querySelector( `.${ parentTargetClass }` ).appendChild( stylesElement );
+		// Here we tag the style element so that we can continue to target and change on user action.
+		if ( currentDesignStyleTag.className !== 'is-design-style' ) {
+			currentDesignStyleTag.className = 'is-design-style';
 		}
 	}, [ isUpdating, designResp ] );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
This PR is a measure to resolve issues with cascading styles. 
Companion PR on Go theme for style consistency.
https://github.com/godaddy-wordpress/go/pull/814

The summary of the overall issue is this: 
Styles on-load are persisted by PHP into the header element where we generate a custom style tag. After a user interacts with the Site Design component we previously modified this custom style element which resides in the header. An issue with this approach is that other styles used for the Site Design component live in the body and thus have higher specificity.

To fix this issue we use the same `useEffect` call that modified our custom style element to relocate the element into the proper hierarchal order thus allowing styles to cascade as expected. 


### Screenshots
<!-- if applicable -->
![designStylesMoved](https://user-images.githubusercontent.com/30462574/199351580-e7d5605b-28c3-4fc8-aa82-e86ab6c8cc44.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
JavaScript. Also included with this story are some simple modifications to Go theme for style consistency.
Go PR: https://github.com/godaddy-wordpress/go/pull/814

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should allow font labels to change transform style as expected.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
