### PR TITLE
Hotfix Site Design controls selector

### DIFF
--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -83,6 +83,29 @@ class CoBlocks_Site_Design {
 
 		add_action( 'wp_ajax_site_design_update_design_style', array( $this, 'update_design_style' ) );
 		add_action( 'rest_api_init', array( $this, 'design_endpoint' ) );
+
+		/**
+		 * Add the shared styles to the editor
+		 */
+		add_action(
+			'admin_init',
+			function() {
+				$suffix = SCRIPT_DEBUG ? '' : '.min';
+				$rtl    = ! is_rtl() ? '' : '-rtl';
+				// Enqueue  shared editor styles.
+				add_editor_style(
+					"dist/css/style-editor{$rtl}{$suffix}.css"
+				);
+			}
+		);
+
+		add_action(
+			'admin_head',
+			function() {
+				printf( '<style id="site-design-styles">%s</style>', esc_html( $this->get_editor_styles() ) );
+			}
+		);
+
 	}
 
 	/**

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -84,21 +84,6 @@ class CoBlocks_Site_Design {
 		add_action( 'wp_ajax_site_design_update_design_style', array( $this, 'update_design_style' ) );
 		add_action( 'rest_api_init', array( $this, 'design_endpoint' ) );
 
-		/**
-		 * Add the shared styles to the editor
-		 */
-		add_action(
-			'admin_init',
-			function() {
-				$suffix = SCRIPT_DEBUG ? '' : '.min';
-				$rtl    = ! is_rtl() ? '' : '-rtl';
-				// Enqueue  shared editor styles.
-				add_editor_style(
-					"dist/css/style-editor{$rtl}{$suffix}.css"
-				);
-			}
-		);
-
 		add_action(
 			'admin_head',
 			function() {

--- a/src/extensions/site-design/component.js
+++ b/src/extensions/site-design/component.js
@@ -65,10 +65,17 @@ export function SiteDesignStyles() {
 
 		fontStylesCache = !! fontStylesCache ? fontStylesCache : designResp.fontStyles;
 
+		// Set the style element innerHTML to remove the old design style.
 		stylesElement.innerHTML = [
 			designResp.stylesheet,
 			fontStylesCache,
 		].join( ' ' );
+
+		// Here we move the style element so that we can continue to target and change on user action.
+		// Only move element if it is not yet under the desktop preview div.
+		if ( ! stylesElement.closest( 'div.is-desktop-preview' ) ) {
+			document.querySelectorAll( '.is-desktop-preview style:last-of-type' )?.[ 0 ].after( stylesElement );
+		}
 	}, [ isUpdating, designResp ] );
 
 	useEffect( () => {

--- a/src/extensions/site-design/component.js
+++ b/src/extensions/site-design/component.js
@@ -1,4 +1,3 @@
-/* global siteDesign */
 /**
  * External dependencies
  */
@@ -62,27 +61,14 @@ export function SiteDesignStyles() {
 			return;
 		}
 
-		// The style elements living in the body are those initialized by `add_editor_style` call.
-		// These style elements are non-mutable and need to be manipulated on the fly for the purpose of this component.
-		const taggedStyle = Array.from( document.querySelectorAll( 'style.is-design-style' ) );
-		const originalStyle = () => Array.from( document.querySelectorAll( '.is-desktop-preview style' ) )
-			.filter( ( elem ) => elem.innerHTML?.includes( `style-${ siteDesign.currentDesignStyle }` ) );
-
-		// Reference to the present style tag if class is defined or by original query if not yet modified.
-		const currentDesignStyleTag = ( taggedStyle.length ? taggedStyle : originalStyle() )[ 0 ];
+		const stylesElement = document.getElementById( 'site-design-styles' );
 
 		fontStylesCache = !! fontStylesCache ? fontStylesCache : designResp.fontStyles;
 
-		// Set the style element innerHTML to remove the old design style.
-		currentDesignStyleTag.innerHTML = [
+		stylesElement.innerHTML = [
 			designResp.stylesheet,
 			fontStylesCache,
 		].join( ' ' );
-
-		// Here we tag the style element so that we can continue to target and change on user action.
-		if ( currentDesignStyleTag.className !== 'is-design-style' ) {
-			currentDesignStyleTag.className = 'is-design-style';
-		}
 	}, [ isUpdating, designResp ] );
 
 	useEffect( () => {


### PR DESCRIPTION
Reverts godaddy-wordpress/coblocks#2442
This caused an issue in prod where the chosen selector may not be present. Reverting as a temp fix.