### PR TITLE
Fix how/when the Template Selector shows

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -561,3 +561,14 @@ export function isWP61AtLeast() {
 
 	return Cypress.$( "[class*='branch-6-']" ).length > 0;
 }
+
+function getIframeDocument( containerClass ) {
+	return cy.get( containerClass + ' iframe' ).its( '0.contentDocument' ).should( 'exist' );
+}
+
+export function getIframeBody( containerClass ) {
+	return getIframeDocument( containerClass ).its( 'body' ).should( 'not.be.undefined' )
+		// wraps "body" DOM element to allow
+		// chaining more Cypress commands, like ".find(...)"
+		.then( cy.wrap );
+}

--- a/.dev/tests/cypress/support/commands.js
+++ b/.dev/tests/cypress/support/commands.js
@@ -1,10 +1,13 @@
-import { disableGutenbergFeatures, loginToSite } from '../helpers';
+import { disableGutenbergFeatures, isNotWPLocalEnv, loginToSite } from '../helpers';
 
 before( function() {
 	loginToSite().then( () => {
-		// Waiting to see if the Welcome Guide will show up. Could probably be improved, but
-		// for the moment, it seems hard to tie the wait to something else
-		cy.wait( 10000 );
+		if ( isNotWPLocalEnv() ) {
+			// Waiting to see if the Welcome Guide will show up. Could probably be improved, but
+			// for the moment, it seems hard to tie the wait to something else
+			cy.wait( 10000 );
+		}
+
 		disableGutenbergFeatures();
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"commander": "^8.3.0",
 		"copy-webpack-plugin": "^10.2.0",
 		"counterup2": "^2.0.2",
-		"cypress": "^10.7.0",
+		"cypress": "^11.1.0",
 		"cypress-log-to-output": "1.1.2",
 		"email-validator": "^2.0.4",
 		"enzyme": "^3.11.0",

--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -8,8 +8,8 @@ import { kebabCase } from 'lodash';
  * WordPress dependencies
  */
 import memoize from 'memize';
-import { registerStore } from '@wordpress/data';
-import { controls, select } from '@wordpress/data-controls';
+import { registerStore, select } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
 
 const DEFAULT_STATE = {
 	templateSelector: false,
@@ -132,8 +132,11 @@ const store = registerStore( 'coblocks/template-selector', {
 
 	resolvers: {
 		* isTemplateSelectorActive() {
-			const isCleanNewPost = yield select( 'core/editor', 'isCleanNewPost' );
-			return isCleanNewPost && actions.openTemplateSelector();
+			const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
+			const isEditedPostEmpty = select( 'core/editor' ).isEditedPostEmpty();
+			const shouldShowTemplateSelector = isCleanNewPost || isEditedPostEmpty;
+
+			return shouldShowTemplateSelector && actions.openTemplateSelector();
 		},
 	},
 

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -8,95 +8,97 @@ import {
 } from '../constants';
 
 describe( 'Extension: Layout Selector', () => {
-	beforeEach( () => {
-		helpers.goTo( '/wp-admin/post-new.php?post_type=page' );
-		helpers.disableGutenbergFeatures();
+	if ( Cypress.browser.name !== 'firefox' ) {
+		beforeEach( () => {
+			helpers.goTo( '/wp-admin/post-new.php?post_type=page' );
+			helpers.disableGutenbergFeatures();
 
-		// Reset settings.
-		helpers.getWindowObject().then( ( win ) => {
-			win.wp.data.dispatch( 'core' ).saveEntityRecord( 'root', 'site', {
-				[ LAYOUT_SELECTOR_FEATURE_ENABLED_KEY ]: true,
+			// Reset settings.
+			helpers.getWindowObject().then( ( win ) => {
+				win.wp.data.dispatch( 'core' ).saveEntityRecord( 'root', 'site', {
+					[ LAYOUT_SELECTOR_FEATURE_ENABLED_KEY ]: true,
+				} );
+
+				win.wp.data.dispatch( 'coblocks/template-selector' ).updateCategories(
+					[
+						{ slug: 'test-one', title: 'Test One' },
+						{ slug: 'test-two', title: 'Test Two' },
+					]
+				);
+
+				win.wp.data.dispatch( 'coblocks/template-selector' ).updateLayouts(
+					[
+						{
+							blocks: [ [ 'core/paragraph', { content: 'Test One paragraph.' }, [] ] ],
+							category: 'test-one',
+							label: 'Test One',
+						},
+						{
+							blocks: [ [ 'core/paragraph', { content: 'Test Two paragraph.' }, [] ] ],
+							category: 'test-two',
+							label: 'Test Two',
+						},
+					]
+				);
 			} );
 
-			win.wp.data.dispatch( 'coblocks/template-selector' ).updateCategories(
-				[
-					{ slug: 'test-one', title: 'Test One' },
-					{ slug: 'test-two', title: 'Test Two' },
-				]
-			);
-
-			win.wp.data.dispatch( 'coblocks/template-selector' ).updateLayouts(
-				[
-					{
-						blocks: [ [ 'core/paragraph', { content: 'Test One paragraph.' }, [] ] ],
-						category: 'test-one',
-						label: 'Test One',
-					},
-					{
-						blocks: [ [ 'core/paragraph', { content: 'Test Two paragraph.' }, [] ] ],
-						category: 'test-two',
-						label: 'Test Two',
-					},
-				]
-			);
+			// The new page post_type admin page is already loaded before tests run.
+			cy.get( '.coblocks-layout-selector-modal' ).should( 'exist' );
 		} );
 
-		// The new page post_type admin page is already loaded before tests run.
-		cy.get( '.coblocks-layout-selector-modal' ).should( 'exist' );
-	} );
+		it( 'loads layouts of each category', () => {
+			// Click "Test One" category.
+			cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
+			cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
 
-	it( 'loads layouts of each category', () => {
-		// Click "Test One" category.
-		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
-		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
+			// Click "Test Two" category.
+			cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(2)' ).find( 'a' ).click();
+			cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
+		} );
 
-		// Click "Test Two" category.
-		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(2)' ).find( 'a' ).click();
-		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
-	} );
+		it( 'inserts layout into page', () => {
+			cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
 
-	it( 'inserts layout into page', () => {
-		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
+			// Ensure layout is loaded
+			helpers.getIframeBody( '.block-editor-block-preview__content' ).should( 'exist' );
 
-		// Ensure layout is loaded
-		helpers.getIframeBody( '.block-editor-block-preview__content' ).should( 'exist' );
+			cy.get( '.coblocks-layout-selector__layout' ).first().click();
 
-		cy.get( '.coblocks-layout-selector__layout' ).first().click();
+			cy.get( '.editor-post-title__block, .editor-post-title' ).contains( 'Test One' );
+			cy.get( '.edit-post-visual-editor' ).contains( 'Test One paragraph.' );
+		} );
 
-		cy.get( '.editor-post-title__block, .editor-post-title' ).contains( 'Test One' );
-		cy.get( '.edit-post-visual-editor' ).contains( 'Test One paragraph.' );
-	} );
+		it( 'inserts blank layout into page', () => {
+			// Click "Add Blank Page" button.
+			cy.get( '.coblocks-layout-selector__add-button' ).first().click();
 
-	it( 'inserts blank layout into page', () => {
-		// Click "Add Blank Page" button.
-		cy.get( '.coblocks-layout-selector__add-button' ).first().click();
+			// Post title block should be empty.
+			cy.get( '.editor-post-title__block, .editor-post-title' ).find( 'textarea, span' ).should( 'be.empty' );
 
-		// Post title block should be empty.
-		cy.get( '.editor-post-title__block, .editor-post-title' ).find( 'textarea, span' ).should( 'be.empty' );
+			// The first block should be the default prompt.
+			cy.get( '.edit-post-visual-editor .block-editor-block-list__layout .wp-block' );
+			cy.contains( RegExp( 'type / to choose a block', 'i' ) );
+		} );
 
-		// The first block should be the default prompt.
-		cy.get( '.edit-post-visual-editor .block-editor-block-list__layout .wp-block' );
-		cy.contains( RegExp( 'type / to choose a block', 'i' ) );
-	} );
+		it( 'does not show modal on add new "post" post_type', () => {
+			helpers.goTo( '/wp-admin/post-new.php?post_type=post' );
+			helpers.disableGutenbergFeatures();
 
-	it( 'does not show modal on add new "post" post_type', () => {
-		helpers.goTo( '/wp-admin/post-new.php?post_type=post' );
-		helpers.disableGutenbergFeatures();
+			cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+		} );
 
-		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
-	} );
+		it( 'does not open modal when editing a draft post', () => {
+			// Ensure the preview has rendered before clicking it.
+			cy.get( '.block-editor-block-preview__container' ).should( 'exist' );
+			cy.get( '.coblocks-layout-selector__layout' ).first().click();
+			cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
 
-	it( 'does not open modal when editing a draft post', () => {
-		// Ensure the preview has rendered before clicking it.
-		cy.get( '.block-editor-block-preview__container' ).should( 'exist' );
-		cy.get( '.coblocks-layout-selector__layout' ).first().click();
-		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+			cy.get( '.editor-post-save-draft' ).click();
+			cy.reload();
+			cy.get( '.edit-post-visual-editor' );
 
-		cy.get( '.editor-post-save-draft' ).click();
-		cy.reload();
-		cy.get( '.edit-post-visual-editor' );
-
-		helpers.disableGutenbergFeatures();
-		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
-	} );
+			helpers.disableGutenbergFeatures();
+			cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+		} );
+	}
 } );

--- a/src/extensions/layout-selector/test/layout-selector.cypress.js
+++ b/src/extensions/layout-selector/test/layout-selector.cypress.js
@@ -1,0 +1,102 @@
+/**
+ * Include our constants
+ */
+import * as helpers from '../../../../.dev/tests/cypress/helpers';
+
+import {
+	LAYOUT_SELECTOR_FEATURE_ENABLED_KEY,
+} from '../constants';
+
+describe( 'Extension: Layout Selector', () => {
+	beforeEach( () => {
+		helpers.goTo( '/wp-admin/post-new.php?post_type=page' );
+		helpers.disableGutenbergFeatures();
+
+		// Reset settings.
+		helpers.getWindowObject().then( ( win ) => {
+			win.wp.data.dispatch( 'core' ).saveEntityRecord( 'root', 'site', {
+				[ LAYOUT_SELECTOR_FEATURE_ENABLED_KEY ]: true,
+			} );
+
+			win.wp.data.dispatch( 'coblocks/template-selector' ).updateCategories(
+				[
+					{ slug: 'test-one', title: 'Test One' },
+					{ slug: 'test-two', title: 'Test Two' },
+				]
+			);
+
+			win.wp.data.dispatch( 'coblocks/template-selector' ).updateLayouts(
+				[
+					{
+						blocks: [ [ 'core/paragraph', { content: 'Test One paragraph.' }, [] ] ],
+						category: 'test-one',
+						label: 'Test One',
+					},
+					{
+						blocks: [ [ 'core/paragraph', { content: 'Test Two paragraph.' }, [] ] ],
+						category: 'test-two',
+						label: 'Test Two',
+					},
+				]
+			);
+		} );
+
+		// The new page post_type admin page is already loaded before tests run.
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'exist' );
+	} );
+
+	it( 'loads layouts of each category', () => {
+		// Click "Test One" category.
+		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
+		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
+
+		// Click "Test Two" category.
+		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(2)' ).find( 'a' ).click();
+		cy.get( '.coblocks-layout-selector__layouts .coblocks-layout-selector__layout' ).should( 'not.have.length', 0 );
+	} );
+
+	it( 'inserts layout into page', () => {
+		cy.get( '.coblocks-layout-selector__sidebar__item:nth-child(1)' ).find( 'a' ).click();
+
+		// Ensure layout is loaded
+		helpers.getIframeBody( '.block-editor-block-preview__content' ).should( 'exist' );
+
+		cy.get( '.coblocks-layout-selector__layout' ).first().click();
+
+		cy.get( '.editor-post-title__block, .editor-post-title' ).contains( 'Test One' );
+		cy.get( '.edit-post-visual-editor' ).contains( 'Test One paragraph.' );
+	} );
+
+	it( 'inserts blank layout into page', () => {
+		// Click "Add Blank Page" button.
+		cy.get( '.coblocks-layout-selector__add-button' ).first().click();
+
+		// Post title block should be empty.
+		cy.get( '.editor-post-title__block, .editor-post-title' ).find( 'textarea, span' ).should( 'be.empty' );
+
+		// The first block should be the default prompt.
+		cy.get( '.edit-post-visual-editor .block-editor-block-list__layout .wp-block' );
+		cy.contains( RegExp( 'type / to choose a block', 'i' ) );
+	} );
+
+	it( 'does not show modal on add new "post" post_type', () => {
+		helpers.goTo( '/wp-admin/post-new.php?post_type=post' );
+		helpers.disableGutenbergFeatures();
+
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+	} );
+
+	it( 'does not open modal when editing a draft post', () => {
+		// Ensure the preview has rendered before clicking it.
+		cy.get( '.block-editor-block-preview__container' ).should( 'exist' );
+		cy.get( '.coblocks-layout-selector__layout' ).first().click();
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+
+		cy.get( '.editor-post-save-draft' ).click();
+		cy.reload();
+		cy.get( '.edit-post-visual-editor' );
+
+		helpers.disableGutenbergFeatures();
+		cy.get( '.coblocks-layout-selector-modal' ).should( 'not.exist' );
+	} );
+} );

--- a/src/extensions/site-content/post-type-panel.js
+++ b/src/extensions/site-content/post-type-panel.js
@@ -143,11 +143,6 @@ export class PostTypePanel extends Component {
 					),
 					{ type: 'snackbar' }
 				);
-
-				if ( postType.slug === 'page' ) {
-					// Open up the layout selector.
-					props.openTemplateSelector();
-				}
 			} )
 			.catch( () => {
 				props.createErrorNotice(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5381,10 +5381,10 @@ cypress-log-to-output@1.1.2:
     chalk "^2.4.2"
     chrome-remote-interface "^0.27.1"
 
-cypress@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.npmjs.org/cypress/-/cypress-10.7.0.tgz"
-  integrity sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==
+cypress@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.1.0.tgz#b8f16495a8a5d8f9a7dd3374ae7b2cef45e9c779"
+  integrity sha512-kzizbG9s3p3ahWqxUwG/21NqLWEGtScMevMyUPeYlcmMX9RzVxWM18MkA3B4Cb3jKx72hSyIE2mHgHymfCM1bg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -5405,7 +5405,7 @@ cypress@^10.7.0:
     dayjs "^1.10.4"
     debug "^4.3.2"
     enquirer "^2.3.6"
-    eventemitter2 "^6.4.3"
+    eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
@@ -6305,10 +6305,10 @@ ev-emitter@^1.0.0:
   resolved "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz"
   integrity sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q==
 
-eventemitter2@^6.4.3:
-  version "6.4.5"
-  resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz"
-  integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
+eventemitter2@6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter2@~0.4.13:
   version "0.4.14"


### PR DESCRIPTION
### Description
The Template Selector should show only when it is a new page or when the current page is empty.

### Screenshots
https://user-images.githubusercontent.com/85255688/202632436-18117d78-a78f-477f-b675-d824d9f0ccd7.mp4


### Types of changes
Bug fix

### How has this been tested?
Cypress test and manually

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
