### PR TITLE
Update form button class attribute name

### DIFF
--- a/.dev/tests/phpunit/includes/test-coblocks-form.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-form.php
@@ -590,7 +590,7 @@ class CoBlocks_Form_Tests extends WP_UnitTestCase {
 		$this->expectOutputRegex( '/<button type="submit" class="wp-block-button__link custom-button-class" style="background-color: #B4D455; color: #333333;">Submit<\/button>/' );
 
 		$atts = [
-			'submitButtonClasses'         => 'custom-button-class',
+			'className'                   => 'custom-button-class',
 			'customBackgroundButtonColor' => '#B4D455',
 			'customTextButtonColor'       => '#333333',
 		];

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -797,7 +797,7 @@ class CoBlocks_Form {
 	public function render_field_submit_button( $atts ) {
 
 		$btn_text             = isset( $atts['submitButtonText'] ) ? $atts['submitButtonText'] : __( 'Submit', 'coblocks' );
-		$btn_class            = isset( $atts['submitButtonClasses'] ) ? " {$atts['submitButtonClasses']}" : '';
+		$btn_class            = isset( $atts['className'] ) ? " {$atts['className']}" : '';
 		$styles               = array();
 		$recaptcha_site_key   = get_option( 'coblocks_google_recaptcha_site_key' );
 		$recaptcha_secret_key = get_option( 'coblocks_google_recaptcha_secret_key' );

--- a/src/blocks/form/fields/submit-button/block.json
+++ b/src/blocks/form/fields/submit-button/block.json
@@ -19,9 +19,6 @@
 		},
 		"customTextButtonColor": {
 			"type": "string"
-		},
-		"submitButtonClasses": {
-			"type": "string"
 		}
 	},
 	"title": "Submit",

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -566,6 +566,8 @@ describe( 'Test CoBlocks Form Block', function() {
 		cy.get( '.coblocks-label' ).each( ( $el ) => {
 			cy.wrap( $el ).should( 'have.class', 'has-text-color' );
 		} );
+
+		helpers.editPage();
 	} );
 
 	/**

--- a/src/blocks/form/test/form.cypress.js
+++ b/src/blocks/form/test/form.cypress.js
@@ -567,4 +567,57 @@ describe( 'Test CoBlocks Form Block', function() {
 			cy.wrap( $el ).should( 'have.class', 'has-text-color' );
 		} );
 	} );
+
+	/**
+	 * Test that the form submit button styles are applied on the front of site.
+	 * https://github.com/godaddy-wordpress/coblocks/pull/2449
+	 */
+	it( 'Test that the submit button styles are applied.', function() {
+		helpers.addBlockToPost( 'coblocks/form', true );
+
+		cy.get( '[data-type="coblocks/form"] .components-placeholder' ).then( ( placeholder ) => {
+			if ( placeholder.prop( 'outerHTML' ).includes( 'block-editor-block-variation-picker' ) ) {
+				cy.get( placeholder )
+					.find( '.block-editor-block-variation-picker__variations li:first-child' )
+					.find( 'button' ).click( { force: true } );
+			} else {
+				cy.get( '.block-editor-inner-blocks__template-picker-options li:first-child' )
+					.click();
+
+				cy.get( '.block-editor-inner-blocks__template-picker-options' )
+					.should( 'not.exist' );
+			}
+		} );
+
+		const styles = [
+			'outline',
+			'circular',
+			'3d',
+			'shadow',
+		];
+
+		for ( let i = 0; i < styles.length; i++ ) {
+			const buttonStyleClass = `is-style-${ styles[ i ] }`;
+
+			cy.get( '[data-type="coblocks/form"] .coblocks-form__submit' ).click( { force: true } );
+
+			// Switch styles.
+			// Note: We use i+2 to avoid 'Fill'.
+			cy.get( `.block-editor-block-styles__variants button:nth-child(${ i + 2 })` ).click( { force: true } );
+
+			// Check button has proper style class.
+			cy.get( '[data-type="coblocks/form"] .coblocks-form__submit div' ).should( 'have.class', buttonStyleClass );
+
+			helpers.savePage();
+			helpers.checkForBlockErrors( 'coblocks/form' );
+			helpers.viewPage();
+
+			cy.get( '.coblocks-form' )
+				.should( 'exist' );
+
+			cy.get( '.coblocks-form__submit button[type="submit"]' ).should( 'have.class', buttonStyleClass );
+
+			helpers.editPage();
+		}
+	} );
 } );

--- a/src/extensions/button-styles/styles/style.scss
+++ b/src/extensions/button-styles/styles/style.scss
@@ -19,3 +19,7 @@
 		box-shadow: 0 4px 6px rgba(0, 0, 0, 0.11), 0 1px 3px rgba(0, 0, 0, 0.075);
 	}
 }
+
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background) {
+	background-color: var(--go-button--color--background, var(--go--color--primary));
+}


### PR DESCRIPTION
Resolves #2218 

### Description
The form block submit button class attribute name changed from `` to ``, but was not updated in the .php file that renders the button, so the form button styles did not reflect selected style on the front of site. The button would always show as the default 'filled' style, and not have the proper classes assigned to it.

### Screenshots
Master:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/5321364/202727256-aaa92add-1cf1-416f-b6ec-2576125b9dea.png">

PR:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/5321364/202727299-8534b3b3-d1fa-4aae-ab15-4e40c910ae4f.png">

### Types of changes
Bug fix (non-breaking change which fixes an issue)

Updated `$atts['submitButtonClasses']` to `$atts['className']` when the submit button is rendered.

### How has this been tested?
Manually tested.

### Acceptance criteria
Originally reported in #2218 


### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
