### PR TITLE
Add CircleCI context for Canary and Deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,7 @@ workflows:
            - perf_tests_master
 
       - canary-release:
+          context: GoDaddy-Github-Enterprise
           filters:
             branches:
               only: master
@@ -226,6 +227,7 @@ workflows:
             - js
 
       - deploy:
+          context: GoDaddy-Github-Enterprise
           requires:
             - unit_testing_php_74
             - unit_testing_php_80

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ workflows:
               only: /^(?!canary).*$/
 
       - pr_artifact_comment:
+          context: GoDaddy-Github-Enterprise
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,7 @@ workflows:
              only: /^(?!canary).*$/
 
       - aggregate_perf_test_results:
+         context: GoDaddy-Github-Enterprise
          filters:
            tags:
              only: /^(?!canary).*$/


### PR DESCRIPTION
### Description
This is needed to use the GH_AUTH_TOKEN var in the CircleCI context.
