### PR TITLE
fix form button colors and fix color bleed

### DIFF
--- a/src/blocks/form/fields/submit-button/edit.js
+++ b/src/blocks/form/fields/submit-button/edit.js
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-import { isEqual, get } from 'lodash';
 import classnames from 'classnames';
+import { get, isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
-import { compose, usePrevious } from '@wordpress/compose';
 import { withFallbackStyles } from '@wordpress/components';
-import { InspectorControls,
+import { compose, usePrevious } from '@wordpress/compose';
+import { ContrastChecker,
+	InspectorControls,
 	PanelColorSettings,
-	ContrastChecker,
 	RichText,
 	withColors,
 } from '@wordpress/block-editor';
@@ -58,13 +58,11 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 
 const CoBlocksSubmitButton = ( props ) => {
 	const {
-		setAttributes,
+		attributes,
 		customTextButtonColor,
 		customBackgroundButtonColor,
 		className,
-		attributes,
-		fallbackBackgroundColor,
-		fallbackTextColor,
+		setAttributes,
 		setBackgroundButtonColor,
 		setTextButtonColor,
 	} = props;
@@ -72,11 +70,10 @@ const CoBlocksSubmitButton = ( props ) => {
 	const prevCustomTextButtonColor = usePrevious( customTextButtonColor );
 	const prevCustomerBackgroundButtonColor = usePrevious( customBackgroundButtonColor );
 
-	const backgroundColor = attributes.customBackgroundButtonColor || fallbackBackgroundColor;
+	const backgroundColor = attributes.customBackgroundButtonColor;
+	const color = attributes.customTextButtonColor;
 
-	const color = attributes.customTextButtonColor || fallbackTextColor;
-
-	const buttonStyle = { border: 'none', backgroundColor, color };
+	const buttonStyle = { backgroundColor, border: 'none', color };
 
 	useEffect( () => {
 		if (
@@ -91,10 +88,10 @@ const CoBlocksSubmitButton = ( props ) => {
 		const backgroundClass = get( customBackgroundButtonColor, 'class' );
 
 		return classnames( 'wp-block-button__link', {
-			'has-background': customBackgroundButtonColor,
 			[ backgroundClass ]: backgroundClass,
-			'has-text-color': customTextButtonColor,
 			[ className ]: className,
+			'has-background': customBackgroundButtonColor,
+			'has-text-color': customTextButtonColor,
 		} );
 	};
 
@@ -102,38 +99,38 @@ const CoBlocksSubmitButton = ( props ) => {
 		<>
 			<div className="coblocks-form__submit wp-block-button">
 				<RichText
-					placeholder={ __( 'Add text…', 'coblocks' ) }
-					value={ attributes.submitButtonText }
-					onChange={ ( nextValue ) => setAttributes( { submitButtonText: nextValue } ) }
-					className={ getButtonClasses() }
-					style={ buttonStyle }
 					allowedFormats={ [ 'bold', 'italic', 'strikethrough' ] }
+					className={ getButtonClasses() }
+					onChange={ ( nextValue ) => setAttributes( { submitButtonText: nextValue } ) }
+					placeholder={ __( 'Add text…', 'coblocks' ) }
+					style={ buttonStyle }
+					value={ attributes.submitButtonText }
 				/>
 			</div>
 			<InspectorControls>
 				<PanelColorSettings
-					title={ __( 'Color settings', 'coblocks' ) }
-					initialOpen={ false }
 					colorSettings={ [
 						{
-							value: backgroundColor,
+							label: __( 'Button color', 'coblocks' ),
 							onChange: ( nextColor ) => {
 								setBackgroundButtonColor( nextColor );
 								setAttributes( { customBackgroundButtonColor: nextColor } );
 							},
-							label: __( 'Button color', 'coblocks' ),
+							value: backgroundColor,
 						},
 						{
-							value: color,
+							label: __( 'Button text color', 'coblocks' ),
 							onChange: ( nextColor ) => {
 								setTextButtonColor( nextColor );
 								setAttributes( { customTextButtonColor: nextColor } );
 							},
-							label: __( 'Button text color', 'coblocks' ),
+							value: color,
 						},
 					] }
+					initialOpen={ false }
+					title={ __( 'Color settings', 'coblocks' ) }
 				/>
-				<ContrastChecker textColor={ color } backgroundColor={ backgroundColor } />
+				<ContrastChecker backgroundColor={ backgroundColor } textColor={ color } />
 			</InspectorControls>
 		</>
 	);

--- a/src/extensions/button-styles/styles/style.scss
+++ b/src/extensions/button-styles/styles/style.scss
@@ -19,7 +19,3 @@
 		box-shadow: 0 4px 6px rgba(0, 0, 0, 0.11), 0 1px 3px rgba(0, 0, 0, 0.075);
 	}
 }
-
-.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background) {
-	background-color: var(--go-button--color--background, var(--go--color--primary));
-}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Closes #2460

The original approach using styles did not work because there are other situations where the style would bleed. Change here fixes the bleed reported in #2460 and keeps the original bug resolved by ensuring the form block submit button does not apply default colors to its color component but instead inherits from the theme.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Remove style changes. Allow form block submit button to inherit colors from stylesheets.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually with TwentyTwentyThree and with Go theme.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
This should resolve the color bleed reported in the linked issue. It should also continue to resolve the originally attempted fix. Original bug behavior can be seen here: https://github.com/godaddy-wordpress/coblocks/pull/2449

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
