### PR TITLE
Add a null check in class-coblocks-generated-styles.php

### DIFF
--- a/includes/class-coblocks-generated-styles.php
+++ b/includes/class-coblocks-generated-styles.php
@@ -52,7 +52,11 @@ class CoBlocks_Generated_Styles {
 	 * @access public
 	 */
 	public function enqueue_styles() {
-		wp_add_inline_style( 'coblocks-frontend', $this->styles() );
+		$styles = $this->styles();
+		if ( is_null( $styles ) ) {
+			return;
+		}
+		wp_add_inline_style( 'coblocks-frontend', $styles );
 	}
 
 	/**


### PR DESCRIPTION
### Description
Originally reported in https://wordpress.org/support/topic/small-mistake-in-class-coblocks-generated-styles-php/

In WordPress 6.1 and PHP 8.1, there is a PHP warning when a null value is passed to `wp_add_inline_style`.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
