### PR TITLE
 Make Labs and Settings modals compatible with Gutenberg >=14.3.0

### DIFF
--- a/src/extensions/coblocks-labs/coblocks-labs-slot.js
+++ b/src/extensions/coblocks-labs/coblocks-labs-slot.js
@@ -6,6 +6,8 @@ import {
 	// Disable reason: We choose to use unsafe APIs in our codebase.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUseSlot as useSlot,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 
 const slotName = 'CoBlocksLabsModalControl';
@@ -13,8 +15,25 @@ const slotName = 'CoBlocksLabsModalControl';
 const { Fill, Slot: CoBlocksLabsModalControlsSlot } = createSlotFill( slotName );
 
 const Slot = ( { children } ) => {
-	const slot = useSlot( slotName );
-	const hasFills = Boolean( slot.fills && slot.fills.length );
+	let fills;
+
+	// The checking order matters here, because for Gutenberg >=14.3.0 both
+	// useSlot and useSlotFills are available while only the useSlotFill should
+	// be used. The breaking change has been introduced in this PR:
+	// https://github.com/WordPress/gutenberg/pull/44642
+	if ( typeof useSlotFills === 'function' ) {
+		// Use the useSlotFills for Gutenberg >=14.3.0 compatibility
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		fills = useSlotFills( slotName );
+	} else if ( typeof useSlot === 'function' ) {
+		// Use the useSlot for Gutenberg <14.3.0 compatibility
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		fills = useSlot( slotName ).fills;
+	} else {
+		return;
+	}
+
+	const hasFills = Boolean( fills && fills.length );
 
 	if ( ! hasFills ) {
 		return children;

--- a/src/extensions/coblocks-settings/coblocks-settings-slot.js
+++ b/src/extensions/coblocks-settings/coblocks-settings-slot.js
@@ -6,15 +6,35 @@ import {
 	// Disable reason: We choose to use unsafe APIs in our codebase.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUseSlot as useSlot,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 
 const slotName = 'CoBlocksSettingsModalControl';
 
-const { Fill, Slot: CoBlocksSettingsModalControlSlot } = createSlotFill( slotName );
+const { Fill, Slot: CoBlocksSettingsModalControlSlot } =
+	createSlotFill( slotName );
 
 function Slot( { children } ) {
-	const slot = useSlot( slotName );
-	const hasFills = Boolean( slot.fills && slot.fills.length );
+	let fills;
+
+	// The checking order matters here, because for Gutenberg >=14.3.0 both
+	// useSlot and useSlotFills are available while only the useSlotFill should
+	// be used. The breaking change has been introduced in this PR:
+	// https://github.com/WordPress/gutenberg/pull/44642
+	if ( typeof useSlotFills === 'function' ) {
+		// Use the useSlotFills for Gutenberg >=14.3.0 compatibility
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		fills = useSlotFills( slotName );
+	} else if ( typeof useSlot === 'function' ) {
+		// Use the useSlot for Gutenberg <14.3.0 compatibility
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		fills = useSlot( slotName ).fills;
+	} else {
+		return;
+	}
+
+	const hasFills = Boolean( fills && fills.length );
 
 	if ( ! hasFills ) {
 		return children;


### PR DESCRIPTION
Fixes https://github.com/godaddy-wordpress/coblocks/issues/2474

### Description

Fix a regression where the `Editor settings` and `CoBlocks Labs` modals render empty for Gutenberg versions >=14.3.0. The breaking change was introduced in https://github.com/WordPress/gutenberg/pull/44642). 


### Types of changes

Bug fix (non-breaking change which fixes an issue)


### How has this been tested?

1. Checkout this branch,
2. `wp-env start && yarn start`,
3. Make sure the Gutenberg plugin is not installed (the trunk version is active),
4. Go to a new post page,
5. Click the three dots menu in the top right corner,
6. Click `Editor settings` and `CoBlocks Labs` and make sure they render correctly,

   | Editor settings modal | CoBlocks Labs modal |
   | ------------- | ------------- |
   | <img width="376" alt="Screenshot 2023-01-25 at 12 45 50" src="https://user-images.githubusercontent.com/1451471/214555421-56dc86b8-7155-4386-9a90-4ca89188fc52.png"> | <img width="560" alt="Screenshot 2023-01-25 at 12 45 59" src="https://user-images.githubusercontent.com/1451471/214555427-aac8ee4b-6efa-4a23-8f8a-86653f1747ac.png"> |


8. Install and activate the latest Gutenberg plugin (v15.0.1 at the time of writing),
9. Repeat steps 4-6,
10. Checkout `master` branch,
11. Repeat steps 4-6, but now both modals should render broken:
     
    | Editor settings modal | CoBlocks Labs modal |
    | ------------- | ------------- |
    | <img width="465" alt="Screenshot 2023-01-25 at 12 45 25" src="https://user-images.githubusercontent.com/1451471/214555792-b8656c85-29fc-4919-9bc8-6599481050c3.png"> | <img width="435" alt="Screenshot 2023-01-25 at 12 45 34" src="https://user-images.githubusercontent.com/1451471/214555798-4148ad03-f81a-4856-9fd9-540cadb1676c.png"> |



### Acceptance criteria

Both modals should be compatible with the latest and trunk version of Gutenberg.