### PR TITLE
Fix issues with deploying to wp.org from another workflow.

### DIFF
--- a/.github/workflows/deploy-create-artifact.yml
+++ b/.github/workflows/deploy-create-artifact.yml
@@ -3,6 +3,9 @@ name: 'Deploy / Create Artifact'
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
       retention-days:
         required: false
         type: number
@@ -13,7 +16,6 @@ env:
   ARTIFACT_PATH: 'coblocks'
   ARTIFACT_ZIP: 'coblocks.zip'
 
-# First build our plugin, then create and store the artifact.
 jobs:
   build:
     name: Build
@@ -22,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ inputs.checkout-ref }} || ${{ github.event.repository.default_branch }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-create-release.yml
+++ b/.github/workflows/deploy-create-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -120,3 +122,47 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload $RELEASE_VERSION ${{ env.ARTIFACT_ZIP }}
+
+  deploy:
+    name: Deploy to WordPress.org
+    needs: [ build, tag ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set version
+        run: |
+          echo "NEW_TAG_VERSION=${{ github.event.milestone.title }}" >> $GITHUB_ENV
+
+      - name: Download plugin
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: build/coblocks
+
+      - name: Checkout from WordPress.org
+        run: |
+          svn co http://svn.wp-plugins.org/coblocks wp/coblocks
+          rm -rf wp/coblocks/trunk/*
+
+      - name: Sync code changes
+        run: |
+          cp -a build/coblocks/* wp/coblocks/trunk/
+
+      - name: Create new tag
+        run: |
+          svn cp wp/coblocks/trunk wp/coblocks/tags/$NEW_TAG_VERSION
+          svn commit -m "Tagging version $NEW_TAG_VERSION"
+
+      - name: Sync asset changes
+        run: |
+          rm -rf wp/coblocks/assets/*
+          cp -a .wordpress-org/* wp/coblocks/assets/
+
+      - name: Deploy to WordPress.org
+        run: |
+          cd wp/coblocks
+          svn add * --force
+          svn status | grep '^!' | awk '{print $2}' | xargs svn delete
+          svn ci --no-auth-cache --username ${{ secrets.GODADDY_WPORG_USERNAME }} --password ${{ secrets.GODADDY_WPORG_PASSWORD }} -m "Deploy $NEW_TAG_VERSION version of CoBlocks"

--- a/.github/workflows/deploy-create-release.yml
+++ b/.github/workflows/deploy-create-release.yml
@@ -130,6 +130,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+           ref: ${{ github.event.repository.default_branch }}
 
       - name: Set version
         run: |

--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -2,9 +2,11 @@ name: 'Deploy / WordPress'
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+    inputs:
+      version:
+        description: 'Semantic version to deploy to WordPress.org'
+        type: string
+        required: true
 
 env:
   ARTIFACT_NAME: 'coblocks-plugin'
@@ -14,24 +16,24 @@ jobs:
   build:
     name: Create artifact
     uses: ./.github/workflows/deploy-create-artifact.yml
+    with:
+      checkout-ref: ${{ inputs.version }}
 
   deploy:
-    name: SVN
+    name: Manual
     needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.version }}
 
       - name: Download plugin
         uses: actions/download-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: build
-
-      - name: Unzip
-        run: |
-          unzip build/${{ env.ARTIFACT_ZIP }}
+          path: build/coblocks
 
       - name: Checkout from WordPress.org
         run: |
@@ -44,8 +46,8 @@ jobs:
 
       - name: Create new tag
         run: |
-          svn cp wp/coblocks/trunk wp/coblocks/tags/${{ github.ref_name }}
-          svn commit -m "Tagging version ${{ github.ref_name }}"
+          svn cp wp/coblocks/trunk wp/coblocks/tags/${{ inputs.version }}
+          svn commit -m "Tagging version ${{ inputs.version }}"
 
       - name: Sync asset changes
         run: |
@@ -57,4 +59,4 @@ jobs:
           cd wp/coblocks
           svn add * --force
           svn status | grep '^!' | awk '{print $2}' | xargs svn delete
-          svn ci --no-auth-cache --username ${{ secrets.GODADDY_WPORG_USERNAME }} --password ${{ secrets.GODADDY_WPORG_PASSWORD }} -m "Deploy ${{ github.ref_name }} version of CoBlocks"
+          svn ci --no-auth-cache --username ${{ secrets.GODADDY_WPORG_USERNAME }} --password ${{ secrets.GODADDY_WPORG_PASSWORD }} -m "Deploy ${{ inputs.version }} version of CoBlocks"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,17 +6,20 @@ on:
       - master
 
 jobs:
-  # chrome_e2e:
-  #   name: Chrome with defaults
-  #   uses: ./.github/workflows/test-e2e-cypress.yml
-  #   concurrency:
-  #     group: chrome-defaults
-  #     cancel-in-progress: true
+  chrome_e2e:
+    name: Chrome with defaults
+    uses: ./.github/workflows/test-e2e-cypress.yml
+    with:
+      wpVersion: "WordPress/WordPress#6.0.2"
+    concurrency:
+      group: chrome-defaults
+      cancel-in-progress: true
 
   chrome_e2e_go:
     name: Chrome and Go theme
     uses: ./.github/workflows/test-e2e-cypress.yml
     with:
+      wpVersion: "WordPress/WordPress#6.0.2"
       theme: "https://downloads.wordpress.org/theme/go.zip"
     concurrency:
       group: chrome-go-theme
@@ -26,6 +29,7 @@ jobs:
     name: Chrome on PHP 7.4
     uses: ./.github/workflows/test-e2e-cypress.yml
     with:
+      wpVersion: "WordPress/WordPress#6.0.2"
       phpVersion: "7.4"
     concurrency:
       group: chrome-php74

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,7 +10,7 @@ jobs:
     name: Chrome with defaults
     uses: ./.github/workflows/test-e2e-cypress.yml
     with:
-      wpVersion: "WordPress/WordPress#6.0.2"
+      wpVersion: "WordPress/WordPress#6.1.1"
     concurrency:
       group: chrome-defaults
       cancel-in-progress: true
@@ -19,7 +19,7 @@ jobs:
     name: Chrome and Go theme
     uses: ./.github/workflows/test-e2e-cypress.yml
     with:
-      wpVersion: "WordPress/WordPress#6.0.2"
+      wpVersion: "WordPress/WordPress#6.1.1"
       theme: "https://downloads.wordpress.org/theme/go.zip"
     concurrency:
       group: chrome-go-theme
@@ -29,7 +29,7 @@ jobs:
     name: Chrome on PHP 7.4
     uses: ./.github/workflows/test-e2e-cypress.yml
     with:
-      wpVersion: "WordPress/WordPress#6.0.2"
+      wpVersion: "WordPress/WordPress#6.1.1"
       phpVersion: "7.4"
     concurrency:
       group: chrome-php74

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # CoBlocks: Page Builder Blocks for Gutenberg
 
-[![CircleCI](https://circleci.com/gh/godaddy-wordpress/coblocks/tree/master.svg?style=svg)](https://circleci.com/gh/godaddy-wordpress/coblocks/tree/master) [![WordPress plugin](https://img.shields.io/wordpress/plugin/dt/coblocks.svg?style=flat)](https://wordpress.org/plugins/coblocks/) [![WordPress plugin](https://img.shields.io/wordpress/plugin/v/coblocks.svg?style=flat)](https://wordpress.org/plugins/coblocks/) [![WordPress](https://img.shields.io/wordpress/v/coblocks.svg?style=flat)]() [![License](https://img.shields.io/badge/license-GPL--2.0%2B-red.svg)](https://github.com/godaddy-wordpress/coblocks/blob/master/LICENSE) <img src="https://www.w3.org/WAI/wcag2AA.png" width="55" />
+
+[![Test Accessibility](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-accessibility.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-accessibility.yml)
+[![Test PHP](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-php.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-php.yml)
+[![Test JS](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-javascript.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-javascript.yml)
+[![Test E2E](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-e2e.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-e2e.yml)
+
+[![WordPress plugin](https://img.shields.io/wordpress/plugin/dt/coblocks.svg?style=flat)](https://wordpress.org/plugins/coblocks/) [![WordPress plugin](https://img.shields.io/wordpress/plugin/v/coblocks.svg?style=flat)](https://wordpress.org/plugins/coblocks/) [![WordPress](https://img.shields.io/wordpress/v/coblocks.svg?style=flat)]() [![License](https://img.shields.io/badge/license-GPL--2.0%2B-red.svg)](https://github.com/godaddy-wordpress/coblocks/blob/master/LICENSE) <img src="https://www.w3.org/WAI/wcag2AA.png" width="55" />
 
 [CoBlocks](https://wordpress.org/plugins/coblocks/) is a suite of professional page building content blocks for the WordPress Gutenberg block editor. This is the most innovative collection of page building WordPress blocks for the new Gutenberg block editor. We will make you rethink what WordPress is capable of.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # CoBlocks: Page Builder Blocks for Gutenberg
 
-
 [![Test Accessibility](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-accessibility.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-accessibility.yml)
 [![Test PHP](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-php.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-php.yml)
 [![Test JS](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-javascript.yml/badge.svg)](https://github.com/godaddy-wordpress/coblocks/actions/workflows/test-javascript.yml)


### PR DESCRIPTION
Due to [restrictions in Actions](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), we moved the job of the action to the release workflow, while also adding a manual trigger for deploying a new version to wp.org as well. 