### PR TITLE
Swap get_the_content() for $post->post_content in has_masonry_v1_block()

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -604,7 +604,9 @@ class CoBlocks_Block_Assets {
 	public function has_masonry_v1_block() {
 		$v1_regex = '/<!-- wp:coblocks\/gallery-masonry.*|\n*(coblocks-gallery--item).*|\n*<!-- \/wp:coblocks\/gallery-masonry -->/m';
 
-		preg_match_all( $v1_regex, get_the_content(), $matches );
+		global $post;
+
+		preg_match_all( $v1_regex, $post->post_content, $matches );
 		return isset( $matches[0] ) && isset( $matches[0][2] ) && ! empty( $matches[0][2] );
 	}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -606,6 +606,10 @@ class CoBlocks_Block_Assets {
 
 		global $post;
 
+		/**
+		 * Resolves a fatal error bug on PHP 8+ with Timber.
+		 * @see https://wordpress.org/support/topic/the-method-has_masonry_v1_block-produces-a-fatal-error-on-php-8-0-22-and-above/
+		 */
 		$post_content = ! empty( $post ) ? $post->post_content : get_the_content();
 
 		preg_match_all( $v1_regex, $post_content, $matches );

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -606,7 +606,9 @@ class CoBlocks_Block_Assets {
 
 		global $post;
 
-		preg_match_all( $v1_regex, $post->post_content, $matches );
+		$post_content = ! empty( $post ) ? $post->post_content : get_the_content();
+
+		preg_match_all( $v1_regex, $post_content, $matches );
 		return isset( $matches[0] ) && isset( $matches[0][2] ) && ! empty( $matches[0][2] );
 	}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -608,6 +608,7 @@ class CoBlocks_Block_Assets {
 
 		/**
 		 * Resolves a fatal error bug on PHP 8+ with Timber.
+		 *
 		 * @see https://wordpress.org/support/topic/the-method-has_masonry_v1_block-produces-a-fatal-error-on-php-8-0-22-and-above/
 		 */
 		$post_content = ! empty( $post ) ? $post->post_content : get_the_content();


### PR DESCRIPTION
### Description
Originally reported [here](https://wordpress.org/support/topic/the-method-has_masonry_v1_block-produces-a-fatal-error-on-php-8-0-22-and-above/).

Swapping out `get_the_content()` for `$post->post_content`.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tested with PHP 7.4 and PHP 8.2.

### Acceptance criteria
Resolve erroneous fatal error when a v1 masonry block is on the page.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
