### PR TITLE
Add jobs to test against 8.2 php

### DIFF
--- a/.dev/tests/phpunit/includes/admin/test-coblocks-action-links.php
+++ b/.dev/tests/phpunit/includes/admin/test-coblocks-action-links.php
@@ -8,7 +8,7 @@ class CoBlocks_Action_Links_Tests extends WP_UnitTestCase {
 
 	private $coblocks_action_links;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -20,7 +20,7 @@ class CoBlocks_Action_Links_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/admin/test-coblocks-install.php
+++ b/.dev/tests/phpunit/includes/admin/test-coblocks-install.php
@@ -8,7 +8,7 @@ class CoBlocks_Install_Tests extends WP_UnitTestCase {
 
 	private $coblocks_install;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -20,7 +20,7 @@ class CoBlocks_Install_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/block-migrate/test-coblocks-block-migration.php
+++ b/.dev/tests/phpunit/includes/block-migrate/test-coblocks-block-migration.php
@@ -7,11 +7,11 @@
 class CoBlocks_Block_Migration_Test extends WP_UnitTestCase {
 	private $instance;
 
-	public function set_up() {
+	public function set_up(): void {
 		$this->instance = new Block_Migration_Mock();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		$this->instance = null;
 	}
 

--- a/.dev/tests/phpunit/includes/test-class-register-blocks.php
+++ b/.dev/tests/phpunit/includes/test-class-register-blocks.php
@@ -8,7 +8,7 @@ class CoBlocks_Register_Blocks_Tests extends WP_UnitTestCase {
 
 	private $coblocks_register_blocks;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -18,7 +18,7 @@ class CoBlocks_Register_Blocks_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-accordion-ie-support.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-accordion-ie-support.php
@@ -6,7 +6,7 @@
  */
 class CoBlocks_Accordion_IE_Support_Tests extends WP_UnitTestCase {
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -14,7 +14,7 @@ class CoBlocks_Accordion_IE_Support_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-block-assets.php
@@ -8,7 +8,7 @@ class CoBlocks_Block_Assets_Tests extends WP_UnitTestCase {
 
 	private $coblocks_block_assets;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -22,7 +22,7 @@ class CoBlocks_Block_Assets_Tests extends WP_UnitTestCase {
 		$wp_styles = new WP_Styles();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-body-classes.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-body-classes.php
@@ -8,7 +8,7 @@ class CoBlocks_Body_Classes_Tests extends WP_UnitTestCase {
 
 	private $coblocks_body_classes;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -18,7 +18,7 @@ class CoBlocks_Body_Classes_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-font-loader.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-font-loader.php
@@ -8,7 +8,7 @@ class CoBlocks_Font_Loader_Tests extends WP_UnitTestCase {
 
 	private $coblocks_font_loader;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -18,7 +18,7 @@ class CoBlocks_Font_Loader_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-form.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-form.php
@@ -8,7 +8,7 @@ class CoBlocks_Form_Tests extends WP_UnitTestCase {
 
 	private $coblocks_form;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -18,7 +18,7 @@ class CoBlocks_Form_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-generated-styles.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-generated-styles.php
@@ -13,7 +13,7 @@ class CoBlocks_Generated_Styles_Tests extends WP_UnitTestCase {
 
 	private $responsive_height;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -51,7 +51,7 @@ class CoBlocks_Generated_Styles_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-google-map-block.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-google-map-block.php
@@ -8,7 +8,7 @@ class CoBlocks_Google_Map_Block_Tests extends WP_UnitTestCase {
 
 	private $coblocks_google_map_block;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -18,7 +18,7 @@ class CoBlocks_Google_Map_Block_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/includes/test-coblocks-post-meta.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-post-meta.php
@@ -24,7 +24,7 @@ class CoBlocks_Post_Meta_Tests extends WP_Test_REST_TestCase {
 
 	}
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -44,7 +44,7 @@ class CoBlocks_Post_Meta_Tests extends WP_Test_REST_TestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/src/blocks/alert/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/alert/test-index.php
@@ -10,11 +10,11 @@ require_once dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/compare-bl
 class CoBlocks_Block_Alert_Migration_Test extends WP_UnitTestCase {
 	private $instance;
 
-	public function set_up() {
+	public function set_up(): void {
 		$this->instance = new CoBlocks_Alert_Migration();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		$this->instance = null;
 	}
 

--- a/.dev/tests/phpunit/src/blocks/author/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/author/test-index.php
@@ -10,11 +10,11 @@ require_once dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/compare-bl
 class CoBlocks_Block_Author_Migration_Test extends WP_UnitTestCase {
 	private $instance;
 
-	public function set_up() {
+	public function set_up(): void {
 		$this->instance = new CoBlocks_Author_Migration();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		$this->instance = null;
 	}
 

--- a/.dev/tests/phpunit/src/blocks/gist/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/gist/test-index.php
@@ -6,14 +6,14 @@
  */
 class CoBlocks_Gist_Index_Tests extends WP_UnitTestCase {
 
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		include_once COBLOCKS_PLUGIN_DIR . 'src/blocks/gist/index.php';
 		set_current_screen( 'edit-post' );
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		parent::tear_down();
 
 		unset( $GLOBALS['current_screen'] );
@@ -45,7 +45,7 @@ class CoBlocks_Gist_Index_Tests extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			coblocks_block_gist_handler( array( $gist_url, $gist_path ) ),
-			"<span class='coblocks-gist__container' style='pointer-events: none'><script src=\"https://gist.github.com/${gist_path}.js\">\n\n</script>\n<a class=\"gist-block__container\" href=\"${gist_url}\" target=\"_blank\">View this gist on GitHub</a></span>"
+			"<span class='coblocks-gist__container' style='pointer-events: none'><script src=\"https://gist.github.com/{$gist_path}.js\">\n\n</script>\n<a class=\"gist-block__container\" href=\"{$gist_url}\" target=\"_blank\">View this gist on GitHub</a></span>"
 		);
 	}
 

--- a/.dev/tests/phpunit/src/blocks/post-carousel/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/post-carousel/test-index.php
@@ -6,7 +6,7 @@
  */
 class CoBlocks_Post_Carousel_Index_Tests extends WP_UnitTestCase {
 
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		include_once COBLOCKS_PLUGIN_DIR . 'src/blocks/post-carousel/index.php';
@@ -14,7 +14,7 @@ class CoBlocks_Post_Carousel_Index_Tests extends WP_UnitTestCase {
 		set_current_screen( 'edit-post' );
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		parent::tear_down();
 
 		unset( $GLOBALS['current_screen'] );

--- a/.dev/tests/phpunit/src/blocks/posts/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/posts/test-index.php
@@ -6,7 +6,7 @@
  */
 class CoBlocks_Posts_Index_Tests extends WP_UnitTestCase {
 
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		include_once COBLOCKS_PLUGIN_DIR . 'src/blocks/posts/index.php';
@@ -14,7 +14,7 @@ class CoBlocks_Posts_Index_Tests extends WP_UnitTestCase {
 		set_current_screen( 'edit-post' );
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		parent::tear_down();
 
 		unset( $GLOBALS['current_screen'] );

--- a/.dev/tests/phpunit/src/blocks/shape-divider/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/shape-divider/test-index.php
@@ -6,14 +6,14 @@
  */
 class CoBlocks_Shape_Divider_Index_Tests extends WP_UnitTestCase {
 
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		include_once COBLOCKS_PLUGIN_DIR . 'src/blocks/shape-divider/index.php';
 		set_current_screen( 'edit-post' );
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		parent::tear_down();
 
 		unset( $GLOBALS['current_screen'] );

--- a/.dev/tests/phpunit/src/blocks/social/test-index.php
+++ b/.dev/tests/phpunit/src/blocks/social/test-index.php
@@ -8,7 +8,7 @@ class CoBlocks_Social_Index_Tests extends WP_UnitTestCase {
 
 	private $thumbnail_id;
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -18,7 +18,7 @@ class CoBlocks_Social_Index_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 

--- a/.dev/tests/phpunit/src/extensions/layout-selector/test-index.php
+++ b/.dev/tests/phpunit/src/extensions/layout-selector/test-index.php
@@ -10,7 +10,7 @@ class CoBlocks_Layout_Selector_Tests extends WP_UnitTestCase {
 		require_once COBLOCKS_PLUGIN_DIR . 'src/extensions/layout-selector/index.php';
 	}
 
-    public function set_up() {
+    public function set_up(): void {
 		parent::set_up();
 
 		set_current_screen( 'dashboard' );
@@ -21,7 +21,7 @@ class CoBlocks_Layout_Selector_Tests extends WP_UnitTestCase {
 		$wp_styles = new WP_Styles();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		parent::tear_down();
 
 		unset( $GLOBALS['current_screen'] );

--- a/.dev/tests/phpunit/test-class-coblocks.php
+++ b/.dev/tests/phpunit/test-class-coblocks.php
@@ -6,7 +6,7 @@
  */
 class CoBlocks_Tests extends WP_UnitTestCase {
 
-	public function set_up() {
+	public function set_up(): void {
 
 		parent::set_up();
 
@@ -23,7 +23,7 @@ class CoBlocks_Tests extends WP_UnitTestCase {
 
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 
 		parent::tear_down();
 
@@ -210,7 +210,7 @@ class CoBlocks_Tests extends WP_UnitTestCase {
 
 				$this->assertTrue(
 					file_exists( COBLOCKS_PLUGIN_DIR . $path_to_asset ),
-					"${minfied_asset_string} ${asset_type} asset not found: " . COBLOCKS_PLUGIN_DIR . "${path_to_asset}"
+					"{$minfied_asset_string} {$asset_type} asset not found: " . COBLOCKS_PLUGIN_DIR . "{$path_to_asset}"
 				);
 
 			}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -34,3 +34,13 @@ jobs:
     concurrency:
       group: chrome-php74
       cancel-in-progress: true
+
+  chrome_e2e_php82:
+    name: Chrome on PHP 8.2
+    uses: ./.github/workflows/test-e2e-cypress.yml
+    with:
+      wpVersion: "WordPress/WordPress#6.1.1"
+      phpVersion: "8.2"
+    concurrency:
+      group: chrome-php74
+      cancel-in-progress: true

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -23,3 +23,9 @@ jobs:
     uses: ./.github/workflows/test-php-unit.yml
     with:
       phpVersion: '8.1'
+    
+  php_unit_82:
+    name: PHP 8.2
+    uses: ./.github/workflows/test-php-unit.yml
+    with:
+      phpVersion: '8.2'

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -174,7 +174,7 @@ class CoBlocks_Form {
 		foreach ( $form_blocks as $form_block ) {
 
 			register_block_type(
-				"coblocks/field-${form_block}",
+				"coblocks/field-{$form_block}",
 				array(
 					'parent'          => array( 'coblocks/form' ),
 					'render_callback' => array( $this, sprintf( 'render_field_%s', str_replace( '-', '_', $form_block ) ) ),


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Introduce jobs to test both unit testing and e2e while in a PHP 8.2 environment.
Changes only affect CICD testing. A few minimal changes to code for quality reasons.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minimal and simple. Few syntax changes around string interpolation and adding types to test functions. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested through CICD pipelines and manually.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
All tests should pass with 8.2 active both PHPUnit and e2e testing. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
