### PR TITLE
Add a check to see if a coblocks-animate is added to an element on the page

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -143,7 +143,7 @@ class CoBlocks_Block_Assets {
 			}
 		}
 
-		if ( ! $has_coblock && ! $this->is_page_gutenberg() ) {
+		if ( ! $has_coblock && ! $this->is_page_gutenberg() && ! $this->has_coblocks_animation() ) {
 			return;
 		}
 
@@ -654,6 +654,15 @@ class CoBlocks_Block_Assets {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Determine if the page content contains an element with a coblocks-animate class.
+	 *
+	 * @return boolean True when an element on the page has .coblocks-animate class, else false.
+	 */
+	public function has_coblocks_animation() {
+		return false !== strpos( get_the_content(), 'coblocks-animate' );
 	}
 }
 


### PR DESCRIPTION
### Description
Determine if an element on the page has the `.coblocks-animate` class, and if so load the styles where the animations are defined.

Background: Adding an animation to a core element, when it is the only element on a page, causes the animation styles to not load.

To reproduce, you can just add a single element to the page (I tested and confirmed when using the `preformatted` block.) and then add an animation to the block. This works fine in the editor, but publish/update the page and look at it on the front of site and you will see the animation does not work.

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
Manually tested these changes.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
