### PR TITLE
Update CoBlocks_Site_Design:short_circuit_check to prevent fatal error on WooCommerce system status page on PHP8

### DIFF
--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -99,8 +99,8 @@ class CoBlocks_Site_Design {
 	 * @return boolean
 	 */
 	public static function short_circuit_check() {
-		$active_theme = wp_get_theme( 'go' );
-		return 'Go' !== $active_theme->get( 'Name' );
+		$active_theme = get_stylesheet();
+		return 'go' !== $active_theme;
 	}
 
 	/**

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -99,8 +99,7 @@ class CoBlocks_Site_Design {
 	 * @return boolean
 	 */
 	public static function short_circuit_check() {
-		$active_theme = get_stylesheet();
-		return 'go' !== $active_theme;
+		return 'go' !== get_stylesheet();
 	}
 
 	/**

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -99,7 +99,8 @@ class CoBlocks_Site_Design {
 	 * @return boolean
 	 */
 	public static function short_circuit_check() {
-		return 'go' !== get_option( 'stylesheet' );
+		$active_theme = wp_get_theme( 'go' );
+		return 'Go' !== $active_theme->get( 'Name' );
 	}
 
 	/**

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -99,8 +99,7 @@ class CoBlocks_Site_Design {
 	 * @return boolean
 	 */
 	public static function short_circuit_check() {
-		$active_theme = wp_get_theme();
-		return 'Go' !== $active_theme->get( 'Name' );
+		return 'go' !== get_option( 'stylesheet' );
 	}
 
 	/**


### PR DESCRIPTION
### Description
As reported, when on PHP 8, and having the WooCommerce + WooCommerce Subscriptions plugins installed, the WooCommerce system status fatal errors and is inaccessible.

### Screenshots
![image](https://user-images.githubusercontent.com/5321364/227594747-86085032-d4ef-4bfb-85e2-56227d714257.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
This was manually tested against PHP 7.4, and PHP 8. I tested with a few variations of plugins installed/activated and was consistently able to reproduce the issue with only PHP 8, CoBlocks, WooCommerce and WooCommerce Subscriptions.

### Acceptance criteria
Ensure that the WooCommerce system status is accessible and no fatal error exists.


### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
