### PR TITLE
Remove FILTER_SANITIZE_STRING

### DIFF
--- a/includes/admin/class-coblocks-crop-settings.php
+++ b/includes/admin/class-coblocks-crop-settings.php
@@ -86,10 +86,18 @@ class CoBlocks_Crop_Settings {
 	 * Retrieve the original image.
 	 */
 	public function get_original_image() {
-		$nonce = htmlspecialchars( filter_input( INPUT_POST, 'nonce' ) );
+		$nonce = filter_input( INPUT_POST, 'nonce' );
 
-		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'cropSettingsOriginalImageNonce' ) ) {
+		if ( ! $nonce ) {
+
+			wp_send_json_error();
+
+		}
+
+		if ( ! wp_verify_nonce( htmlspecialchars( $nonce ), 'cropSettingsOriginalImageNonce' ) ) {
+
 			wp_send_json_error( 'No nonce value present' );
+
 		}
 
 		$id = filter_input( INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT );
@@ -119,9 +127,15 @@ class CoBlocks_Crop_Settings {
 	 * Cropping.
 	 */
 	public function api_crop() {
-		$nonce = htmlspecialchars( filter_input( INPUT_POST, 'nonce' ) );
+		$nonce = filter_input( INPUT_POST, 'nonce' );
 
-		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'cropSettingsNonce' ) ) {
+		if ( ! $nonce ) {
+
+			wp_send_json_error();
+
+		}
+
+		if ( ! wp_verify_nonce( htmlspecialchars( $nonce ), 'cropSettingsNonce' ) ) {
 			wp_send_json_error( 'No nonce value present' );
 		}
 

--- a/includes/admin/class-coblocks-crop-settings.php
+++ b/includes/admin/class-coblocks-crop-settings.php
@@ -90,13 +90,13 @@ class CoBlocks_Crop_Settings {
 
 		if ( ! $nonce ) {
 
-			wp_send_json_error();
+			wp_send_json_error( 'No nonce value present.' );
 
 		}
 
 		if ( ! wp_verify_nonce( htmlspecialchars( $nonce ), 'cropSettingsOriginalImageNonce' ) ) {
 
-			wp_send_json_error( 'No nonce value present' );
+			wp_send_json_error( 'Invalid nonce value.' );
 
 		}
 
@@ -104,7 +104,7 @@ class CoBlocks_Crop_Settings {
 
 		if ( ! $id ) {
 
-			wp_send_json_error();
+			wp_send_json_error( 'Missing id value.' );
 
 		}
 
@@ -131,12 +131,14 @@ class CoBlocks_Crop_Settings {
 
 		if ( ! $nonce ) {
 
-			wp_send_json_error();
+			wp_send_json_error( 'No nonce value present.' );
 
 		}
 
 		if ( ! wp_verify_nonce( htmlspecialchars( $nonce ), 'cropSettingsNonce' ) ) {
-			wp_send_json_error( 'No nonce value present' );
+
+			wp_send_json_error( 'Invalid nonce value.' );
+
 		}
 
 		if (

--- a/includes/admin/class-coblocks-crop-settings.php
+++ b/includes/admin/class-coblocks-crop-settings.php
@@ -86,7 +86,7 @@ class CoBlocks_Crop_Settings {
 	 * Retrieve the original image.
 	 */
 	public function get_original_image() {
-		$nonce = filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING );
+		$nonce = htmlspecialchars( filter_input( INPUT_POST, 'nonce' ) );
 
 		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'cropSettingsOriginalImageNonce' ) ) {
 			wp_send_json_error( 'No nonce value present' );
@@ -119,7 +119,7 @@ class CoBlocks_Crop_Settings {
 	 * Cropping.
 	 */
 	public function api_crop() {
-		$nonce = filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING );
+		$nonce = htmlspecialchars( filter_input( INPUT_POST, 'nonce' ) );
 
 		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'cropSettingsNonce' ) ) {
 			wp_send_json_error( 'No nonce value present' );

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -649,14 +649,22 @@ class CoBlocks_Block_Assets {
 		}
 
 		if ( false !== strpos( $admin_page, 'post.php' ) && isset( $_GET['post'] ) ) {
-			$wp_post = get_post( htmlspecialchars( filter_input( INPUT_GET, wp_unslash( $_GET['post'] ) ) ) );
+			$post = filter_input( INPUT_GET, wp_unslash( $_GET['post'] ) );
+			if ( ! $post ) {
+				return false;
+			}
+			$wp_post = get_post( htmlspecialchars( $post ) );
 			if ( isset( $wp_post ) && isset( $wp_post->post_type ) && $this->is_post_type_gutenberg( $wp_post->post_type ) ) {
 				return true;
 			}
 		}
 
 		if ( false !== strpos( $admin_page, 'revision.php' ) && isset( $_GET['revision'] ) ) {
-			$wp_post     = get_post( htmlspecialchars( filter_input( INPUT_GET, wp_unslash( $_GET['revision'] ) ) ) );
+			$revision = filter_input( INPUT_GET, wp_unslash( $_GET['revision'] ) );
+			if ( ! $revision ) {
+				return false;
+			}
+			$wp_post     = get_post( htmlspecialchars( $revision ) );
 			$post_parent = get_post( $wp_post->post_parent );
 			if ( isset( $post_parent ) && isset( $post_parent->post_type ) && $this->is_post_type_gutenberg( $post_parent->post_type ) ) {
 				return true;

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -644,19 +644,19 @@ class CoBlocks_Block_Assets {
 			return true;
 		}
 
-		if ( false !== strpos( $admin_page, 'post-new.php' ) && isset( $_GET['post_type'] ) && $this->is_post_type_gutenberg( filter_input( INPUT_GET, wp_unslash( $_GET['post_type'] ), FILTER_SANITIZE_STRING ) ) ) {
+		if ( false !== strpos( $admin_page, 'post-new.php' ) && isset( $_GET['post_type'] ) && $this->is_post_type_gutenberg( htmlspecialchars( filter_input( INPUT_GET, wp_unslash( $_GET['post_type'] ) ) ) ) ) {
 			return true;
 		}
 
 		if ( false !== strpos( $admin_page, 'post.php' ) && isset( $_GET['post'] ) ) {
-			$wp_post = get_post( filter_input( INPUT_GET, wp_unslash( $_GET['post'] ), FILTER_SANITIZE_STRING ) );
+			$wp_post = get_post( htmlspecialchars( filter_input( INPUT_GET, wp_unslash( $_GET['post'] ) ) ) );
 			if ( isset( $wp_post ) && isset( $wp_post->post_type ) && $this->is_post_type_gutenberg( $wp_post->post_type ) ) {
 				return true;
 			}
 		}
 
 		if ( false !== strpos( $admin_page, 'revision.php' ) && isset( $_GET['revision'] ) ) {
-			$wp_post     = get_post( filter_input( INPUT_GET, wp_unslash( $_GET['revision'] ), FILTER_SANITIZE_STRING ) );
+			$wp_post     = get_post( htmlspecialchars( filter_input( INPUT_GET, wp_unslash( $_GET['revision'] ) ) ) );
 			$post_parent = get_post( $wp_post->post_parent );
 			if ( isset( $post_parent ) && isset( $post_parent->post_type ) && $this->is_post_type_gutenberg( $post_parent->post_type ) ) {
 				return true;

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -201,7 +201,7 @@ class CoBlocks_Form {
 	public function render_form( $atts, $content ) {
 
 		$this->form_hash = sha1( $content );
-		$submitted_hash  = filter_input( INPUT_POST, 'form-hash', FILTER_SANITIZE_STRING );
+		$submitted_hash  = htmlspecialchars( filter_input( INPUT_POST, 'form-hash' ) );
 
 		ob_start();
 		?>
@@ -851,7 +851,7 @@ class CoBlocks_Form {
 	 */
 	public function process_form_submission( $atts ) {
 
-		$form_submission = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
+		$form_submission = htmlspecialchars( filter_input( INPUT_POST, 'action' ) );
 
 		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission ) {
 
@@ -859,7 +859,7 @@ class CoBlocks_Form {
 
 		}
 
-		$nonce = filter_input( INPUT_POST, 'form-submit', FILTER_SANITIZE_STRING );
+		$nonce = htmlspecialchars( filter_input( INPUT_POST, 'form-submit' ) );
 
 		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'coblocks-form-submit' ) ) {
 
@@ -870,7 +870,7 @@ class CoBlocks_Form {
 		/**
 		 * Check if the honeypot field was filled out and if so, bail.
 		 */
-		$honeypot_check = filter_input( INPUT_POST, 'coblocks-verify-email', FILTER_SANITIZE_STRING );
+		$honeypot_check = htmlspecialchars( filter_input( INPUT_POST, 'coblocks-verify-email' ) );
 
 		if ( ! empty( $honeypot_check ) ) {
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -209,7 +209,7 @@ class CoBlocks_Form {
 		<div class="coblocks-form" id="<?php echo esc_attr( $this->form_hash ); ?>">
 
 			<?php
-			if ( htmlspecialchars( $submitted_hash ) === $this->form_hash ) {
+			if ( $submitted_hash && htmlspecialchars( $submitted_hash ) === $this->form_hash ) {
 
 				$submit_form = $this->process_form_submission( $atts );
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -201,7 +201,7 @@ class CoBlocks_Form {
 	public function render_form( $atts, $content ) {
 
 		$this->form_hash = sha1( $content );
-		$submitted_hash  = htmlspecialchars( filter_input( INPUT_POST, 'form-hash' ) );
+		$submitted_hash  = filter_input( INPUT_POST, 'form-hash' );
 
 		ob_start();
 		?>
@@ -209,7 +209,7 @@ class CoBlocks_Form {
 		<div class="coblocks-form" id="<?php echo esc_attr( $this->form_hash ); ?>">
 
 			<?php
-			if ( $submitted_hash === $this->form_hash ) {
+			if ( htmlspecialchars( $submitted_hash ) === $this->form_hash ) {
 
 				$submit_form = $this->process_form_submission( $atts );
 
@@ -851,17 +851,29 @@ class CoBlocks_Form {
 	 */
 	public function process_form_submission( $atts ) {
 
-		$form_submission = htmlspecialchars( filter_input( INPUT_POST, 'action' ) );
+		$form_submission = filter_input( INPUT_POST, 'action' );
 
-		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission ) {
+		if ( ! $form_submission ) {
 
 			return;
 
 		}
 
-		$nonce = htmlspecialchars( filter_input( INPUT_POST, 'form-submit' ) );
+		if ( 'coblocks-form-submit' !== htmlspecialchars( $form_submission ) ) {
 
-		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'coblocks-form-submit' ) ) {
+			return;
+
+		}
+
+		$nonce = filter_input( INPUT_POST, 'form-submit' );
+
+		if ( ! $nonce ) {
+
+			return;
+
+		}
+
+		if ( ! wp_verify_nonce( htmlspecialchars( $nonce ), 'coblocks-form-submit' ) ) {
 
 			return;
 
@@ -870,9 +882,9 @@ class CoBlocks_Form {
 		/**
 		 * Check if the honeypot field was filled out and if so, bail.
 		 */
-		$honeypot_check = htmlspecialchars( filter_input( INPUT_POST, 'coblocks-verify-email' ) );
+		$honeypot_check = filter_input( INPUT_POST, 'coblocks-verify-email' );
 
-		if ( ! empty( $honeypot_check ) ) {
+		if ( ! empty( htmlspecialchars( $honeypot_check ) ) ) {
 
 			$this->remove_url_form_hash();
 

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -248,17 +248,17 @@ class CoBlocks_Site_Design {
 	 */
 	protected function sanitize_request_params( $request_params = null ) {
 		$args = array(
-			'design_style'     => FILTER_SANITIZE_STRING,
-			'color_palette'    => FILTER_SANITIZE_STRING,
-			'fonts'            => FILTER_SANITIZE_STRING,
-			'font_size'        => FILTER_SANITIZE_STRING,
+			'design_style'     => FILTER_SANITIZE_SPECIAL_CHARS,
+			'color_palette'    => FILTER_SANITIZE_SPECIAL_CHARS,
+			'fonts'            => FILTER_SANITIZE_SPECIAL_CHARS,
+			'font_size'        => FILTER_SANITIZE_SPECIAL_CHARS,
 			'type_ratio'       => FILTER_VALIDATE_FLOAT,
 			'should_update'    => FILTER_VALIDATE_BOOLEAN,
 			'initial_load'     => FILTER_VALIDATE_BOOLEAN,
-			'primary_color'    => FILTER_SANITIZE_STRING,
-			'secondary_color'  => FILTER_SANITIZE_STRING,
-			'tertiary_color'   => FILTER_SANITIZE_STRING,
-			'background_color' => FILTER_SANITIZE_STRING,
+			'primary_color'    => FILTER_SANITIZE_SPECIAL_CHARS,
+			'secondary_color'  => FILTER_SANITIZE_SPECIAL_CHARS,
+			'tertiary_color'   => FILTER_SANITIZE_SPECIAL_CHARS,
+			'background_color' => FILTER_SANITIZE_SPECIAL_CHARS,
 		);
 
 		return is_array( $request_params )


### PR DESCRIPTION
### Description
PHP 8.1 deprecated `FILTER_SANITIZE_STRING`. As per the PHP docs, this can be replaced with `htmlspecialchars()`.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually testing the plugin to ensure functionality.

### Acceptance criteria
Remove all usage of `FILTER_SANITIZE_STRING`, where used.


### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
