### PR TITLE
Add short-circuit to loader around screen logic

### DIFF
--- a/includes/block-migrate/class-coblocks-block-migration.php
+++ b/includes/block-migrate/class-coblocks-block-migration.php
@@ -110,7 +110,11 @@ abstract class CoBlocks_Block_Migration {
 	 *
 	 * @return string attribute value.
 	 */
-	protected function get_attribute_from_classname( $classname_prefix, DOMElement $element ) {
+	protected function get_attribute_from_classname( $classname_prefix, $element ) {
+		if ( is_null( $element ) ) {
+			return '';
+		}
+
 		$class_attribute = $element->attributes->getNamedItem( 'class' );
 		if ( empty( $class_attribute ) ) {
 			return '';

--- a/includes/block-migrate/loader.php
+++ b/includes/block-migrate/loader.php
@@ -27,11 +27,11 @@ require_once COBLOCKS_PLUGIN_DIR . 'includes/block-migrate/class-coblocks-author
 add_action(
 	'the_post',
 	function( WP_Post &$post ) {
-		if ( function_exists( 'is_admin' ) && ! is_admin() ) {
+		if ( ! function_exists( 'is_admin' ) || ! function_exists( 'get_current_screen' ) ) {
 			return;
 		}
 
-		if ( function_exists( 'get_current_screen' ) && ! get_current_screen()->is_block_editor ) {
+		if ( ! is_admin() || ! get_current_screen()->is_block_editor ) {
 			return;
 		}
 

--- a/includes/block-migrate/loader.php
+++ b/includes/block-migrate/loader.php
@@ -27,6 +27,10 @@ require_once COBLOCKS_PLUGIN_DIR . 'includes/block-migrate/class-coblocks-author
 add_action(
 	'the_post',
 	function( WP_Post &$post ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
 		if ( ! is_admin() || ! get_current_screen()->is_block_editor ) {
 			return;
 		}

--- a/includes/block-migrate/loader.php
+++ b/includes/block-migrate/loader.php
@@ -27,10 +27,10 @@ require_once COBLOCKS_PLUGIN_DIR . 'includes/block-migrate/class-coblocks-author
 add_action(
 	'the_post',
 	function( WP_Post &$post ) {
-		if ( function_exists('is_admin') && ! is_admin() ) {
+		if ( function_exists( 'is_admin' ) && ! is_admin() ) {
 			return;
 		}
-		
+
 		if ( function_exists( 'get_current_screen' ) && ! get_current_screen()->is_block_editor ) {
 			return;
 		}

--- a/includes/block-migrate/loader.php
+++ b/includes/block-migrate/loader.php
@@ -27,11 +27,11 @@ require_once COBLOCKS_PLUGIN_DIR . 'includes/block-migrate/class-coblocks-author
 add_action(
 	'the_post',
 	function( WP_Post &$post ) {
-		if ( ! function_exists( 'get_current_screen' ) ) {
+		if ( function_exists('is_admin') && ! is_admin() ) {
 			return;
 		}
-
-		if ( ! is_admin() || ! get_current_screen()->is_block_editor ) {
+		
+		if ( function_exists( 'get_current_screen' ) && ! get_current_screen()->is_block_editor ) {
 			return;
 		}
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -679,9 +679,20 @@ class CoBlocks_Block_Assets {
 	 * @return boolean True when an element on the page has .coblocks-animate class, else false.
 	 */
 	public function has_coblocks_animation() {
+		global $post;
+
 		ob_start();
 		the_content();
-		return false !== strpos( ob_get_clean(), 'coblocks-animate' );
+		$the_content = ob_get_clean();
+
+		/**
+		 * Resolves a fatal error bug on PHP 8+ with Timber.
+		 *
+		 * @see https://wordpress.org/support/topic/the-method-has_masonry_v1_block-produces-a-fatal-error-on-php-8-0-22-and-above/
+		 */
+		$post_content = ! empty( $post ) ? $post->post_content : $the_content;
+
+		return false !== strpos( $post_content, 'coblocks-animate' );
 	}
 }
 

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -681,16 +681,12 @@ class CoBlocks_Block_Assets {
 	public function has_coblocks_animation() {
 		global $post;
 
-		ob_start();
-		the_content();
-		$the_content = ob_get_clean();
-
 		/**
 		 * Resolves a fatal error bug on PHP 8+ with Timber.
 		 *
 		 * @see https://wordpress.org/support/topic/the-method-has_masonry_v1_block-produces-a-fatal-error-on-php-8-0-22-and-above/
 		 */
-		$post_content = ! empty( $post ) ? $post->post_content : $the_content;
+		$post_content = ! empty( $post ) ? $post->post_content : get_the_content();
 
 		return false !== strpos( $post_content, 'coblocks-animate' );
 	}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Add short-circuit for cases where the `get_current_screen` is undefined.


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Minor logic changes to introduce short-circuit.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should short-circuit if the function `get_current_screen` is not defined.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
