### PR TITLE
Fix Layout Selector styles in WP 6.2.

### DIFF
--- a/src/extensions/layout-selector/editor.scss
+++ b/src/extensions/layout-selector/editor.scss
@@ -291,7 +291,7 @@
 	&__layouts {
 		column-count: 1;
 		column-gap: 1em;
-		padding-top: 4px;
+		padding-top: 1em;
 
 		@include break-small() {
 			column-count: 2;
@@ -303,6 +303,11 @@
 		@include break-large() {
 			column-count: 2;
 		}
+	}
+
+	&__layout-preview-container {
+		margin: 2em;
+		width: 100%;
 	}
 
 	&__layout {
@@ -323,7 +328,6 @@
 
 		.block-editor-block-preview__container {
 			background-color: var(--go--color--background, $white);
-			margin: 2em;
 			position: relative;
 			z-index: 10;
 

--- a/src/extensions/layout-selector/layout-selector-results.js
+++ b/src/extensions/layout-selector/layout-selector-results.js
@@ -74,10 +74,11 @@ export const LayoutPreview = ( { layout, onClick } ) => {
 			data-testid="coblocks-layout-selector__layout-button"
 			onClick={ () => onClick( layout ) }
 		>
-
 			<Spinner />
+			<div className="coblocks-layout-selector__layout-preview-container">
+				<BlockPreview blocks={ sanitizedBlocks } viewportWidth={ 700 } />
+			</div>
 
-			<BlockPreview blocks={ sanitizedBlocks } viewportWidth={ 700 } />
 		</Button>
 	);
 };


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
The block preview component has had major changes between 6.1.1 and 6.2 release of WP. One of the changes is related to the mechanism where the iframe is produced. We now need an extra wrapper for the preview container so we can apply margins and spacing.


### Screenshots
<!-- if applicable -->
**Bugged**
![LayoutSelectorBugged](https://user-images.githubusercontent.com/30462574/229166110-85798f81-42f7-4d92-8b4b-66ab5ff7c551.gif)

**Fixed**
![LayoutSelectorFixed](https://user-images.githubusercontent.com/30462574/229159611-e6128174-ab0a-4c75-8046-98a3c651a3eb.gif)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->


### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
