### PR TITLE
Add logic so that we use core/buttons instead of core/button

### DIFF
--- a/src/blocks/author/index.js
+++ b/src/blocks/author/index.js
@@ -106,15 +106,17 @@ const settings = {
 		};
 
 		const buttonBlock = parentBlock.innerBlocks;
-		const imageBlock = createBlock( 'core/image', { className: 'is-style-rounded', id: props.attributes.imgId, url: props.attributes.imgUrl } );
-
 		// Set buttons to align.
 		buttonBlock.forEach( function( button, index ) {
 			buttonBlock[ index ].attributes.align = isRTL ? 'right' : 'left';
 		} );
+		// Button blocks are no-longer stand-alone and should be within `core/buttons` block.
+		const coreButtons = createBlock( 'core/buttons', { }, [ ...buttonBlock ] );
+
+		const imageBlock = createBlock( 'core/image', { className: 'is-style-rounded', id: props.attributes.imgId, url: props.attributes.imgUrl } );
 
 		const leftColumn = createBlock( 'core/column', { width: '25%' }, [ imageBlock ] );
-		const rightColumn = createBlock( 'core/column', { width: '75%' }, [ authorNameBlock(), authorBioBlock(), ...buttonBlock ] );
+		const rightColumn = createBlock( 'core/column', { width: '75%' }, [ authorNameBlock(), authorBioBlock(), coreButtons ] );
 
 		const columnsBlock = () => {
 			let columnsBlockProps = {

--- a/src/blocks/author/test/author.cypress.js
+++ b/src/blocks/author/test/author.cypress.js
@@ -24,6 +24,8 @@ describe( 'Test CoBlocks Author Block', function() {
 		// Two blocks two images.
 		cy.get( '[data-type="core/image"]' ).should( 'have.length', 2 );
 
+		// Two blocks two core/buttons with two core/button inside.
+		cy.get( '[data-type="core/buttons"]' ).should( 'have.length', 2 );
 		// Two blocks two buttons.
 		cy.get( '[data-type="core/button"]' ).should( 'have.length', 2 );
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
The `core/button` block once was stand-alone but now should be a child of `core/buttons`. Changes here properly wrap the button inside of buttons and applies it to the migration.

Added test logic to check for the presence of `core/buttons`.

### Screenshots
<!-- if applicable -->
**Before**
![Screen Shot 2023-04-19 at 10 35 19 AM](https://user-images.githubusercontent.com/30462574/233156074-60a47ccc-ad04-4989-96a7-3737807cd8ad.png)

**After**
![Screen Shot 2023-04-19 at 10 37 38 AM](https://user-images.githubusercontent.com/30462574/233156071-69825bcf-96f0-407a-9b23-4a42990d0c90.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Simple JS changes to wrap an extra `core/buttons` in the markup.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and also added new logic to e2e test.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should have a test.
Should wrapper core/button with core/buttons block.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
