### PR TITLE
Validate Site Design nonce and capabilities

### DIFF
--- a/.dev/tests/jest/setup-globals.js
+++ b/.dev/tests/jest/setup-globals.js
@@ -269,3 +269,5 @@ global.siteDesign = {
 };
 
 global.coblocksLabs = true;
+
+global.coblocksBlockData = {};

--- a/.dev/tests/jest/setup-globals.js
+++ b/.dev/tests/jest/setup-globals.js
@@ -269,5 +269,3 @@ global.siteDesign = {
 };
 
 global.coblocksLabs = true;
-
-global.coblocksBlockData = {};

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -297,6 +297,7 @@ class CoBlocks_Block_Assets {
 				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
+				'labsSiteDesignNonce'            => wp_create_nonce( 'labsSiteDesignNonce' ),
 				'bundledIconsEnabled'            => $bundled_icons_enabled,
 				'customIcons'                    => $this->get_custom_icons(),
 				'customIconConfigExists'         => file_exists( get_stylesheet_directory() . '/coblocks/icons/config.json' ),

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -298,6 +298,16 @@ class CoBlocks_Site_Design {
 	 * Retrieve the selected design style styles and return them for injection into the DOM
 	 */
 	public function update_design_style() {
+		// Nonce check.
+		if ( ! wp_verify_nonce( filter_input( INPUT_POST, 'nonce' ), 'labsSiteDesignNonce' ) ) {
+			wp_send_json_error( 'invalid_nonce', 403 );
+		}
+
+		// Permission check.
+		if ( ! current_user_can( self::USER_CAP ) ) {
+			wp_send_json_error( 'invalid_permissions', 403 );
+		}
+
 		// short-circuit.
 		if ( self::short_circuit_check() ) {
 			return array();

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -15,7 +15,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class CoBlocks_Site_Design {
 
-	const USER_CAP             = 'edit_theme_options';
 	const EDITOR_WRAPPER_CLASS = 'editor-styles-wrapper';
 	const API_ROUTE            = 'design';
 
@@ -77,11 +76,11 @@ class CoBlocks_Site_Design {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_assets' ) );
 
 		// short-circuit.
-		if ( self::short_circuit_check() ) {
+		if ( $this->short_circuit_check() ) {
 			return array();
 		}
 
-		add_action( 'wp_ajax_site_design_update_design_style', array( $this, 'update_design_style' ) );
+		add_action( 'wp_ajax_site_design_update_design_style', array( $this, 'design_endpoint_ajax' ) );
 		add_action( 'rest_api_init', array( $this, 'design_endpoint' ) );
 
 		add_action(
@@ -98,33 +97,26 @@ class CoBlocks_Site_Design {
 	 *
 	 * @return boolean
 	 */
-	public static function short_circuit_check() {
+	public function short_circuit_check() {
 		return 'go' !== get_stylesheet();
 	}
 
 	/**
 	 * Enqueue the scripts and styles.
 	 */
-	public static function get_coblocks_site_design_data() {
-
-		if ( ! current_user_can( self::USER_CAP ) ) {
-
+	public function get_coblocks_site_design_data() {
+		// Permission check.
+		if ( is_wp_error( $this->design_endpoint_permissions_check() ) ) {
 			return array();
-
 		}
 
-		$default_asset_file = array(
-			'dependencies' => array(),
-			'version'      => COBLOCKS_VERSION,
-		);
-
 		// short-circuit.
-		if ( self::short_circuit_check() ) {
+		if ( $this->short_circuit_check() ) {
 			return array();
 		}
 
 		$current_design_style = \Go\Core\get_design_style();
-		$fonts                = self::get_go_fonts();
+		$fonts                = $this->get_go_fonts();
 
 		$data = array(
 			'apiRoute'               => self::API_ROUTE,
@@ -179,24 +171,53 @@ class CoBlocks_Site_Design {
 			self::API_ROUTE,
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'permission_callback' => function() {
-					// See https://wordpress.org/support/article/roles-and-capabilities/#edit_theme_options.
-					return current_user_can( self::USER_CAP );
-				},
+				'permission_callback' => array( $this, 'design_endpoint_permissions_check' ),
 				'callback'            => array( $this, 'update_design_style' ),
 			)
 		);
 	}
 
+	/**
+	 * Check if the current user can edit theme options.
+	 *
+	 * @return true|WP_Error True if the user can edit theme options, WP_Error otherwise.
+	 */
+	public function design_endpoint_permissions_check() {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to do that.', 'coblocks' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Ajax callback for updating the design style.
+	 */
+	public function design_endpoint_ajax() {
+		// Nonce check.
+		if ( ! wp_verify_nonce( filter_input( INPUT_POST, 'nonce' ), 'labsSiteDesignNonce' ) ) {
+			wp_send_json_error( 'invalid_nonce', 403 );
+		}
+
+		// Permission check.
+		if ( is_wp_error( $this->design_endpoint_permissions_check() ) ) {
+			wp_send_json_error( 'invalid_permissions', 403 );
+		}
+
+		return $this->update_design_style();
+	}
 
 	/**
 	 * Return array of Go fonts.
 	 *
 	 * @return array
 	 */
-	private static function get_go_fonts() {
+	private function get_go_fonts() {
 		// short-circuit.
-		if ( self::short_circuit_check() ) {
+		if ( $this->short_circuit_check() ) {
 			return array();
 		}
 
@@ -298,18 +319,8 @@ class CoBlocks_Site_Design {
 	 * Retrieve the selected design style styles and return them for injection into the DOM
 	 */
 	public function update_design_style() {
-		// Nonce check.
-		if ( ! wp_verify_nonce( filter_input( INPUT_POST, 'nonce' ), 'labsSiteDesignNonce' ) ) {
-			wp_send_json_error( 'invalid_nonce', 403 );
-		}
-
-		// Permission check.
-		if ( ! current_user_can( self::USER_CAP ) ) {
-			wp_send_json_error( 'invalid_permissions', 403 );
-		}
-
 		// short-circuit.
-		if ( self::short_circuit_check() ) {
+		if ( $this->short_circuit_check() ) {
 			return array();
 		}
 

--- a/src/extensions/site-design/data/actions.js
+++ b/src/extensions/site-design/data/actions.js
@@ -66,6 +66,7 @@ export function* updateDesign( {
 
 	const body = new FormData();
 	body.append( 'action', 'site_design_update_design_style' );
+	body.append( 'nonce', coblocksBlockData.labsSiteDesignNonce );
 	body.append( 'design_style', designStyle );
 	body.append( 'color_palette', colorPalette );
 	body.append( 'fonts', fonts );

--- a/src/extensions/site-design/test/design-preview.spec.js
+++ b/src/extensions/site-design/test/design-preview.spec.js
@@ -8,6 +8,7 @@ import DesignPreviews from '../design-preview';
 // Setup API globals.
 global.ajaxurl = '';
 global.window.fetch = () => new Promise( () => {} );
+global.coblocksBlockData = {};
 
 const setup = ( props = {} ) => {
 	const { container } = render( <DesignPreviews { ...props } /> );


### PR DESCRIPTION
We performed sanitization on the request params and had a check for the Go theme but we did not have a nonce in place nor a user capabilities check on the `wp_ajax_site_design_update_design_style` request. This PR adds both a nonce check and user capabilities check.