### PR TITLE
Update form block save for WordPress 6.3

### DIFF
--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -16,7 +16,7 @@ import variations from './variations';
  * WordPress dependencies
  */
 import { Icon } from '@wordpress/components';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const { name, category, attributes } = metadata;
 let conditionalBlockAttributes = { ...attributes };
@@ -42,7 +42,15 @@ const settings = {
 	attributes: conditionalBlockAttributes,
 	edit,
 	icon: <Icon icon={ icon } />,
-	save: InnerBlocks.Content,
+	save: () => {
+		const blockProps = useBlockProps.save();
+
+		return (
+			<div { ...blockProps }>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
 	variations,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4678,9 +4678,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
-  version "1.0.30001442"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+  version "1.0.30001517"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Description
Update the form block `save` for WordPress 6.3 compatibility.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Manually tested a migration from 6.2 with an existing form to 6.3 with the same form.
- Manually tested setting up a new form in both 6.2 and 6.3.

### Acceptance criteria
- Form should load in the editor without any validation errors, and show up on the front of site.
- No visible changes between WordPress 6.2 and 6.3.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request
