### PR TITLE
Try to resolve php unit test issues - WP-ENV 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"@wordpress/edit-post": "^6.5.0",
 		"@wordpress/editor": "^12.7.0",
 		"@wordpress/element": "^4.6.0",
-		"@wordpress/env": "^7.0.0",
+		"@wordpress/env": "^8.1.1",
 		"@wordpress/eslint-plugin": "^10.0.1",
 		"@wordpress/hooks": "^3.8.0",
 		"@wordpress/i18n": "^4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,10 +3239,10 @@
     react "^18.2.0"
     react-dom "^18.2.0"
 
-"@wordpress/env@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/env/-/env-7.0.0.tgz#2e9b562e53b5ca6df090f22c763d153e630cf721"
-  integrity sha512-C0Z/smvyEeMFPjoDo149dv/w83W9hVOIkBQSGpRzeWSwDEJVYPKeZ1sUSC4y01zdXVyIxeyWIRLSm611pYIlAQ==
+"@wordpress/env@^8.1.1":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/env/-/env-8.4.0.tgz#5e8af0d1904e1a49f1d71bba7a71e50818c00bc4"
+  integrity sha512-3DnTW/WanvQpWqagCIMQYtSBYj9wXLQQqGgmKl8gVJ4MfxV3K5A9zE25Rv6iogdr7ydLcPSbmNJx6mYgQRaSog==
   dependencies:
     chalk "^4.0.0"
     copy-dir "^1.3.0"


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
The only change here is to update wp-env to ^8.1.1

Confirmed that PHP Unit tests 8.1 + 8.1 are passing.


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Package updates for test failures.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Pipelines.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should allow PHP Unit tests to pass for 8.1 + 8.2

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
