### PR TITLE
Update the Form block test selector

### DIFF
--- a/.dev/tests/cypress/helpers.js
+++ b/.dev/tests/cypress/helpers.js
@@ -13,7 +13,7 @@ export function selectStylesTabIfExists() {
 export function addFormChild( name ) {
 	cy.get( '[data-type="coblocks/form"] [data-type^="coblocks/field"]' ).first().click( { force: true } );
 	cy.get( '.block-editor-block-settings-menu' ).click();
-	cy.get( '.components-popover__content button' ).contains( /insert after/i ).click( { force: true } );
+	cy.get( '.components-popover__content button' ).contains( /insert after|add after/i ).click( { force: true } );
 	cy.get( '[data-type="coblocks/form"] [data-type="core/paragraph"]' ).click( { force: true } );
 
 	cy.get( '.edit-post-header-toolbar' ).find( '.edit-post-header-toolbar__inserter-toggle' ).click( { force: true } );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Update the Form block selector so that tests pass as expected.

### Screenshots
<!-- if applicable -->
![Screenshot 2023-08-07 at 12 12 48 PM](https://github.com/godaddy-wordpress/coblocks/assets/30462574/e5a40f8c-8968-43b6-ba52-bd07f7f22af6)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Simple selector fix here for backward compatibility with old selectors.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in E2E.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
The tests for Form block should pass with 6.2.2 and with 6.3

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
