### PR TITLE
Fix the name field display/email order

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -903,7 +903,7 @@ class CoBlocks_Form {
 
 			if ( is_array( $data['value'] ) ) {
 
-				$data['value'] = implode( ', ', $data['value'] );
+				$data['value'] = ( array_key_exists( 'first-name', $data['value'] ) && array_key_exists( 'first-name', $data['value'] ) ) ? $data['value']['last-name'] . ', ' . $data['value']['first-name'] : implode( ', ', $data['value'] );
 
 			}
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -903,7 +903,7 @@ class CoBlocks_Form {
 
 			if ( is_array( $data['value'] ) ) {
 
-				$data['value'] = ( array_key_exists( 'first-name', $data['value'] ) && array_key_exists( 'first-name', $data['value'] ) ) ? $data['value']['last-name'] . ', ' . $data['value']['first-name'] : implode( ', ', $data['value'] );
+				$data['value'] = ( array_key_exists( 'first-name', $data['value'] ) && array_key_exists( 'last-name', $data['value'] ) ) ? $data['value']['last-name'] . ', ' . $data['value']['first-name'] : implode( ', ', $data['value'] );
 
 			}
 


### PR DESCRIPTION
### Description
Ensure that the first and last name field display properly. (`lastname, firstname`).

<img width="271" alt="image" src="https://github.com/godaddy-wordpress/coblocks/assets/5321364/46396114-6cec-48a8-af18-c2ddd6c65182">

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested with the first/last name fields.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
