### PR TITLE
Enqueue the registered scripts from block.json

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -449,7 +449,7 @@ class CoBlocks_Block_Assets {
 		// Post Carousel block script.
 		wp_register_script(
 			'coblocks-post-carousel',
-			$this->assets_dir . 'coblocks-post-carousel.js',
+			$this->assets_dir . 'coblocks-post-carousel-script.js',
 			array(),
 			COBLOCKS_VERSION,
 			true
@@ -467,7 +467,7 @@ class CoBlocks_Block_Assets {
 		// Events block.
 		wp_register_script(
 			'coblocks-events',
-			$this->assets_dir . 'coblocks-events.js',
+			$this->assets_dir . 'coblocks-events-script.js',
 			array(),
 			COBLOCKS_VERSION,
 			true

--- a/src/blocks/counter/block.json
+++ b/src/blocks/counter/block.json
@@ -44,5 +44,6 @@
 			}
 		}
 	},
-	"editorScript": ["coblocks-13"]
+	"editorScript": ["coblocks-13"],
+	"viewScript": ["coblocks-counter-script"]
 }

--- a/src/blocks/counter/test/counter.cypress.js
+++ b/src/blocks/counter/test/counter.cypress.js
@@ -102,4 +102,25 @@ describe( 'Test CoBlocks Counter Block', function() {
 
 		helpers.checkForBlockErrors( 'coblocks/counter' );
 	} );
+
+	/**
+	 * Test that we can add counter block and use locale formatting controls
+	 * and save block without errors.
+	 */
+	it( 'Test counter block properly enqueues its scripts.', function() {
+		helpers.addBlockToPost( 'coblocks/counter', true );
+
+		cy.get( '.wp-block-coblocks-counter.rich-text' ).first().focus().type( counterData.counterText );
+		cy.get( '.wp-block-coblocks-counter.rich-text' ).last().focus().type( counterData.counterDescription );
+		cy.get( '.wp-block-coblocks-counter.rich-text' ).first().contains( '10000 hours' );
+
+		helpers.savePage();
+		helpers.checkForBlockErrors( 'coblocks/counter' );
+
+		helpers.viewPage();
+
+		cy.get( "script[src*='coblocks-counter-script']" );
+
+		helpers.editPage();
+	} );
 } );

--- a/src/blocks/events/block.json
+++ b/src/blocks/events/block.json
@@ -32,5 +32,6 @@
 	"textdomain": "coblocks",
 	"description": "Add a list of events or display events from a public calendar.",
 	"editorScript": ["coblocks-2"],
+	"viewScript": ["coblocks-tiny-swiper","coblocks-events"],
 	"render": "index.php"
 }

--- a/src/blocks/events/test/events.cypress.js
+++ b/src/blocks/events/test/events.cypress.js
@@ -75,4 +75,22 @@ describe( 'Block: Events', function() {
 
 		helpers.checkForBlockErrors( 'coblocks/events' );
 	} );
+
+	/**
+	 * Test the events block saves with custom classes
+	 */
+	it( 'properly enqueues scripts', function() {
+		// Workaround for the advanced panel not loading consistently.
+		cy.get( '.editor-post-title' ).click();
+
+		helpers.checkForBlockErrors( 'coblocks/events' );
+
+		helpers.savePage();
+		helpers.viewPage();
+
+		cy.get( "script[src*='coblocks-events-script']" );
+		cy.get( "script[src*='coblocks-tiny-swiper']" );
+
+		helpers.editPage();
+	} );
 } );

--- a/src/blocks/events/test/events.cypress.js
+++ b/src/blocks/events/test/events.cypress.js
@@ -89,7 +89,7 @@ describe( 'Block: Events', function() {
 		helpers.viewPage();
 
 		cy.get( "script[src*='coblocks-events-script']" );
-		cy.get( "script[src*='coblocks-tiny-swiper']" );
+		cy.get( "script[src*='tiny-swiper']" );
 
 		helpers.editPage();
 	} );

--- a/src/blocks/gist/block.json
+++ b/src/blocks/gist/block.json
@@ -19,5 +19,6 @@
 	"title": "Gist",
 	"textdomain": "coblocks",
 	"editorScript": ["coblocks-9"],
+	"viewScript": ["coblocks-gist-script"],
 	"description": "Embed a GitHub Gist."
 }

--- a/src/blocks/gist/test/gist.cypress.js
+++ b/src/blocks/gist/test/gist.cypress.js
@@ -22,4 +22,26 @@ describe( 'Test CoBlocks Gist Block', function() {
 
 		helpers.checkForBlockErrors( 'core/embed' );
 	} );
+
+	/**
+	 * Test that we can add counter block and use locale formatting controls
+	 * and save block without errors.
+	 */
+	it( 'Test embedded gist properly enqueues its scripts.', function() {
+		helpers.addBlockToPost( 'core/embed', true );
+
+		cy.get( '.wp-block-embed .components-placeholder__input' ).type( 'https://gist.github.com/jrtashjian/98c1fcfd0e9f9ed59d710ccf7ef4291c#file-block-variation-js' );
+		cy.get( '.wp-block-embed .components-button.is-primary' ).click();
+
+		cy.get( '.components-sandbox' ).should( 'exist' );
+
+		helpers.savePage();
+		helpers.checkForBlockErrors( 'core/embed' );
+
+		helpers.viewPage();
+
+		cy.get( "script[src*='coblocks-gist-script']" );
+
+		helpers.editPage();
+	} );
 } );

--- a/src/blocks/post-carousel/block.json
+++ b/src/blocks/post-carousel/block.json
@@ -75,5 +75,6 @@
 	"textdomain": "coblocks",
 	"description": "Display posts or an external blog feed as a carousel.",
 	"editorScript": ["coblocks-11"],
+	"viewScript": ["coblocks-tiny-swiper","coblocks-post-carousel"],
 	"render": "index.php"
 }

--- a/src/blocks/post-carousel/test/post-carousel.cypress.js
+++ b/src/blocks/post-carousel/test/post-carousel.cypress.js
@@ -75,4 +75,21 @@ describe( 'Test CoBlocks Post Carousel Block', function() {
 
 		helpers.editPage();
 	} );
+
+	/**
+	 * Test the post-carousel block saves with custom classes
+	 */
+	it( 'Test the post-carousel properly enqueues its scripts.', function() {
+		helpers.addBlockToPost( 'coblocks/post-carousel', true );
+
+		helpers.savePage();
+		helpers.checkForBlockErrors( 'coblocks/post-carousel' );
+
+		helpers.viewPage();
+
+		cy.get( "script[src*='coblocks-post-carousel-script']" );
+		cy.get( "script[src*='coblocks-tiny-swiper']" );
+
+		helpers.editPage();
+	} );
 } );

--- a/src/blocks/post-carousel/test/post-carousel.cypress.js
+++ b/src/blocks/post-carousel/test/post-carousel.cypress.js
@@ -88,7 +88,7 @@ describe( 'Test CoBlocks Post Carousel Block', function() {
 		helpers.viewPage();
 
 		cy.get( "script[src*='coblocks-post-carousel-script']" );
-		cy.get( "script[src*='coblocks-tiny-swiper']" );
+		cy.get( "script[src*='tiny-swiper']" );
 
 		helpers.editPage();
 	} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Some files scripts were missed or not properly registered. Those have been resolved here. Added e2e tests that will catch if this case ever happens in the future. 


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Enqueued scripts. 
E2E tests added.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually and with Cypress.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should always enqueue the registered scripts from block.json.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
