### PR TITLE
Check null getcurrentscreen

### DIFF
--- a/includes/block-migrate/loader.php
+++ b/includes/block-migrate/loader.php
@@ -27,7 +27,7 @@ require_once COBLOCKS_PLUGIN_DIR . 'includes/block-migrate/class-coblocks-author
 add_action(
 	'the_post',
 	function( WP_Post &$post ) {
-		if ( ! function_exists( 'is_admin' ) || ! function_exists( 'get_current_screen' ) || is_null(get_current_screen()) ) {
+		if ( ! function_exists( 'is_admin' ) || ! function_exists( 'get_current_screen' ) || is_null( get_current_screen() ) ) {
 			return;
 		}
 

--- a/includes/block-migrate/loader.php
+++ b/includes/block-migrate/loader.php
@@ -27,7 +27,7 @@ require_once COBLOCKS_PLUGIN_DIR . 'includes/block-migrate/class-coblocks-author
 add_action(
 	'the_post',
 	function( WP_Post &$post ) {
-		if ( ! function_exists( 'is_admin' ) || ! function_exists( 'get_current_screen' ) ) {
+		if ( ! function_exists( 'is_admin' ) || ! function_exists( 'get_current_screen' ) || is_null(get_current_screen()) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description
This should solve this warning message : https://wordpress.org/support/topic/php-error-612/


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->


### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
