### PR TITLE
[Urgent] Performance: don't subscribe all blocks to selected block

### DIFF
--- a/src/extensions/apply-extensions.js
+++ b/src/extensions/apply-extensions.js
@@ -84,7 +84,6 @@ const enhance = compose(
 		return {
 			getBlocks: select( 'core/block-editor' ).getBlocks,
 			select,
-			selected: select( 'core/block-editor' ).getSelectedBlock(),
 		};
 	} ),
 );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->

Coblocks extends all blocks (through the `editor.BlockListBlock` filter) with a `withSelect` HoC, subscribing _all_ blocks to the currently selected block. This means that on typing, the selected block updates, and _all_ blocks on the page re-render because they are all subscribed to changes to the selected block.

I went through all functions in `addAllEditorProps` to which `props` is being passed to, but none of them seem to be using `props.selected`, so it looks like this subscription can be removed without further changes. 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

Use the React Dev Tools and enable highlight on re-render. Type in a block and watch all blocks re-render.

<img width="1352" alt="image" src="https://github.com/godaddy-wordpress/coblocks/assets/4710635/ed620024-7eff-4fa9-964d-332a58898f0e">


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->


### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
