### PR TITLE
Introduce a blueprint for WordPress preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,5 +1,5 @@
 {
-    "landingPage": "\/wp-admin\/edit.php",
+    "landingPage": "/wp-admin/post.php?post=5&action=edit",
     "phpExtensionBundles": [
         "kitchen-sink"
     ],
@@ -8,6 +8,17 @@
             "step": "login",
             "username": "admin",
             "password": "password"
+        },
+        {
+            "step": "installTheme",
+            "themeZipFile": {
+                "resource": "wordpress.org\/themes",
+                "slug": "go"
+            }
+        },
+        {
+            "step": "runPHP",
+            "code": "<?php\ninclude 'wordpress/wp-load.php';\nwp_insert_post(array(\n'import_id' => 5,\n'post_title' => 'CoBlocks Demo',\n'post_content' => '<!-- wp:paragraph -->\n<p>You can test out CoBlocks by adding any CoBlocks block to the page.</p>\n<!-- \/wp:paragraph -->',\n'post_status' => 'publish',\n'post_author' => 1\n));"
         }
     ]
 }

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,13 @@
+{
+    "landingPage": "\/wp-admin\/edit.php",
+    "phpExtensionBundles": [
+        "kitchen-sink"
+    ],
+    "steps": [
+        {
+            "step": "login",
+            "username": "admin",
+            "password": "password"
+        }
+    ]
+}


### PR DESCRIPTION
### Description
Introduce a `blueprint.json` file that is a template for a live preview on WordPress.org.
- Same file as the one currently on WordPress.org, so when this PR is merged it won't overwrite the existing one.
   - https://plugins.svn.wordpress.org/coblocks/assets/blueprints/
- The live preview is currently only visible to logged in plugin committers. It can be enabled publicly from the WordPress.org plugin page advanced tab.

#### Thoughts
We can import a `.wxz` file. Maybe we setup a number of CoBlocks blocks so that when the page loads there are a number of blocks on the page already?

### Screenshots
<img width="1020" alt="image" src="https://github.com/godaddy-wordpress/coblocks/assets/5321364/fa643faa-2382-46fc-bfa8-af4fc467f02e">
<img width="1440" alt="image" src="https://github.com/godaddy-wordpress/coblocks/assets/5321364/aa071503-c9dd-46d3-9f48-f8f7181d0ca8">

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
`Test Preview` link on the [WordPress.org plugin page](https://wordpress.org/plugins/coblocks/).

### Acceptance criteria
- Add a `blueprint.json` file so users can test out CoBlocks before installing it.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
