### PR TITLE
Enable Lightbox compatibility with Lazy Loading

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -140,7 +140,15 @@
 					imagePreloader.preloaded = true;
 					Array.from( images ).forEach( function( img, imgIndex ) {
 						imagePreloader[ `img-${ imgIndex }` ] = new window.Image();
-						imagePreloader[ `img-${ imgIndex }` ].src = img.attributes.src.value;
+
+						// If the src is lazy loaded, use the data-src attribute.
+						// Compatibility with A3 Lazy Load plugin and maybe others.
+						if ( img.attributes.src.value?.includes( 'lazy-load' ) ) {
+							imagePreloader[ `img-${ imgIndex }` ].src = img.attributes[ 'data-src' ].value;
+						} else {
+							imagePreloader[ `img-${ imgIndex }` ].src = img.attributes.src.value;
+						}
+
 						imagePreloader[ `img-${ imgIndex }` ][ 'data-caption' ] =
 								( images[ imgIndex ] && images[ imgIndex ].nextElementSibling )
 									? getImageCaption( images[ imgIndex ] ) : '';

--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -143,10 +143,15 @@
 
 						// If the src is lazy loaded, use the data-src attribute.
 						// Compatibility with A3 Lazy Load plugin and maybe others.
-						if ( img.attributes.src.value?.includes( 'lazy-load' ) ) {
-							imagePreloader[ `img-${ imgIndex }` ].src = img.attributes[ 'data-src' ].value;
+						if (
+							img.attributes.src.value?.includes( 'lazy-load' ) &&
+							'undefined' !== typeof img.attributes?.[ 'data-src' ]?.value
+						) {
+							imagePreloader[ `img-${ imgIndex }` ].src =
+								img.attributes[ 'data-src' ].value;
 						} else {
-							imagePreloader[ `img-${ imgIndex }` ].src = img.attributes.src.value;
+							imagePreloader[ `img-${ imgIndex }` ].src =
+								img.attributes.src.value;
 						}
 
 						imagePreloader[ `img-${ imgIndex }` ][ 'data-caption' ] =


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Fixes #2582 

Enhance the Lightbox script logic to allow for Lightbox with A3 Lazy Load plugin. 
Source the image from `data-src` attribute if the `src` contains 'lazy-load'.

### Screenshots
<!-- if applicable -->
![LightBoxLazyLoad](https://github.com/godaddy-wordpress/coblocks/assets/30462574/08480c6c-8c30-42ff-b564-c82f8d6d5042)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Lightbox JavaScript changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually. 

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should allow Lightbox to function when A3 Lazy Load is enabled.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
