### PR TITLE
enable the lightbox script to load for all CoBlocks galleries

### DIFF
--- a/src/blocks/gallery-carousel/block.json
+++ b/src/blocks/gallery-carousel/block.json
@@ -111,6 +111,7 @@
 	"title": "Carousel",
 	"textdomain": "coblocks",
 	"editorScript": ["coblocks-1"],
+	"viewScript": ["coblocks-lightbox"],
 	"script": [ "coblocks-tiny-swiper", "coblocks-tinyswiper-initializer" ],
 	"description": "Display multiple images in a beautiful carousel gallery.",
 	"supports": {

--- a/src/blocks/gallery-collage/block.json
+++ b/src/blocks/gallery-collage/block.json
@@ -65,5 +65,6 @@
 	"title": "Collage",
 	"textdomain": "coblocks",
 	"editorScript": ["coblocks-4"],
+	"viewScript": ["coblocks-lightbox"],
 	"description": "Assemble images into a beautiful collage gallery."
 }

--- a/src/blocks/gallery-offset/block.json
+++ b/src/blocks/gallery-offset/block.json
@@ -10,5 +10,6 @@
 	"title": "Offset",
 	"textdomain": "coblocks",
 	"editorScript": ["coblocks-7"],
+	"viewScript": ["coblocks-lightbox"],
 	"description": "Display images in an offset brick pattern gallery."
 }

--- a/src/blocks/gallery-stacked/block.json
+++ b/src/blocks/gallery-stacked/block.json
@@ -93,5 +93,6 @@
 	"textdomain": "coblocks",
 	"title": "Stacked",
 	"editorScript": ["coblocks-10"],
+	"viewScript": ["coblocks-lightbox"],
 	"description": "Display multiple images in a single column stacked gallery."
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Fixes #2571 
Not all galleries properly listed the 'Lightbox' script to load under the 'viewScript' block.json property. Adding the script allows the Lightbox to function as expected with all CoBlocks galleries. 

### Screenshots
<!-- if applicable -->
![LightBoxAllGalleries](https://github.com/godaddy-wordpress/coblocks/assets/30462574/3a407231-7add-48a4-a3ef-71aff3a45f95)


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Change here to block.json to allow for proper loading of the 'lightbox-script'.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should allow the Lightbox on all CoBlocks galleries if only that single gallery is present on the page or all of them. Each block now ensures the script is loaded. 

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
