### PR TITLE
Escape the icon href attribute

### DIFF
--- a/src/blocks/icon/index.php
+++ b/src/blocks/icon/index.php
@@ -88,7 +88,7 @@ function coblocks_render_coblocks_icon_block( $attrs ) {
 	if ( ! empty( $attrs['href'] ) ) {
 		$icon = sprintf(
 			'<a href="%1$s" rel="%2$s" target="%3$s" style="%4$s">%5$s</a>',
-			$attrs['href'],
+			esc_url( $attrs['href'] ),
 			! empty( $attrs['rel'] ) ? esc_attr( $attrs['rel'] ) : '',
 			! empty( $attrs['linkTarget'] ) ? esc_attr( $attrs['linkTarget'] ) : '_self',
 			esc_attr( $color_styles ), // To make sure the color gets to the svg when there is an anchor.


### PR DESCRIPTION
### Description
Escape icon block `href` attribute.

### Types of changes
 Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
