### PR TITLE
Sanitize the iCal URL before initializing

### DIFF
--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -19,6 +19,11 @@ function coblocks_render_coblocks_events_block( $attributes, $content ) {
 		return $content;
 	}
 
+	// If externalCalendarUrl contains a localhost URL, return an error message.
+	if ( strpos( $attributes['externalCalendarUrl'], 'localhost' ) !== false || strpos( $attributes['externalCalendarUrl'], '127.0' ) !== false ) {
+		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'An error has occurred, localhost URLs are not permitted.', 'coblocks' ) . '</div></div>';
+	}
+
 	try {
 		$ical = new \CoBlocks_ICal(
 			false,

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -34,7 +34,7 @@ function coblocks_render_coblocks_events_block( $attributes, $content ) {
 				'use_timezone_with_r_rules'     => false,
 			)
 		);
-		$ical->init_url( sanitize_url( $attributes['externalCalendarUrl'] ) );
+		$ical->init_url( esc_url( $attributes['externalCalendarUrl'] ) );
 
 		if ( 'all' === $attributes['eventsRange'] ) {
 			$events = $ical->events_from_range();

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -34,7 +34,7 @@ function coblocks_render_coblocks_events_block( $attributes, $content ) {
 				'use_timezone_with_r_rules'     => false,
 			)
 		);
-		$ical->init_url( $attributes['externalCalendarUrl'] );
+		$ical->init_url( sanitize_url( $attributes['externalCalendarUrl'] ) );
 
 		if ( 'all' === $attributes['eventsRange'] ) {
 			$events = $ical->events_from_range();

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -39,7 +39,7 @@ function coblocks_render_coblocks_events_block( $attributes, $content ) {
 				'use_timezone_with_r_rules'     => false,
 			)
 		);
-		$ical->init_url( esc_url( $attributes['externalCalendarUrl'] ) );
+		$ical->init_url( sanitize_url( $attributes['externalCalendarUrl'] ) );
 
 		if ( 'all' === $attributes['eventsRange'] ) {
 			$events = $ical->events_from_range();

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -39,7 +39,7 @@ function coblocks_render_coblocks_events_block( $attributes, $content ) {
 				'use_timezone_with_r_rules'     => false,
 			)
 		);
-		$ical->init_url( sanitize_url( $attributes['externalCalendarUrl'] ) );
+		$ical->init_url( esc_url_raw( $attributes['externalCalendarUrl'] ) );
 
 		if ( 'all' === $attributes['eventsRange'] ) {
 			$events = $ical->events_from_range();

--- a/src/blocks/events/index.php
+++ b/src/blocks/events/index.php
@@ -21,7 +21,7 @@ function coblocks_render_coblocks_events_block( $attributes, $content ) {
 
 	// If externalCalendarUrl contains a localhost URL, return an error message.
 	if ( strpos( $attributes['externalCalendarUrl'], 'localhost' ) !== false || strpos( $attributes['externalCalendarUrl'], '127.0' ) !== false ) {
-		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'An error has occurred, localhost URLs are not permitted.', 'coblocks' ) . '</div></div>';
+		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'An error has occurred. localhost URLs are not permitted.', 'coblocks' ) . '</div></div>';
 	}
 
 	try {


### PR DESCRIPTION
### Description
- [x] Escape the iCal URL before initializing the events calendar.
- [x] Prevent `localhost` or `127.0x` URLs from being used for external calendar URLs.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tested by running `nc -l 127.0.0.1 9000`. Adding a `Events` block to the page, ticking off `Link a calendar` and adding the URL `http://127.0.0.1:9000` to the calendar URL and ensuring an error is returned.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
