### PR TITLE
Only load the coblocks-site-content plugin on post-new.php

### DIFF
--- a/includes/class-coblocks-site-content.php
+++ b/includes/class-coblocks-site-content.php
@@ -20,6 +20,15 @@ class CoBlocks_Site_Content {
 	 */
 	public function __construct() {
 
+		global $pagenow;
+
+		// Ensure Site Content only loads if within the post editor.
+		if (
+			! isset( $pagenow ) || strpos( $pagenow, 'post-new.php' ) === false
+		) {
+			return;
+		}
+
 		add_action( 'init', array( $this, 'register_settings' ), 11 );
 		add_filter( 'wp_insert_post_empty_content', array( $this, 'allow_empty_post_content' ), 10, 2 );
 

--- a/includes/class-coblocks-site-content.php
+++ b/includes/class-coblocks-site-content.php
@@ -20,15 +20,6 @@ class CoBlocks_Site_Content {
 	 */
 	public function __construct() {
 
-		global $pagenow;
-
-		// Ensure Site Content only loads if within the post editor.
-		if (
-			! isset( $pagenow ) || strpos( $pagenow, 'post-new.php' ) === false
-		) {
-			return;
-		}
-
 		add_action( 'init', array( $this, 'register_settings' ), 11 );
 		add_filter( 'wp_insert_post_empty_content', array( $this, 'allow_empty_post_content' ), 10, 2 );
 

--- a/src/extensions/site-content/index.js
+++ b/src/extensions/site-content/index.js
@@ -45,6 +45,10 @@ export const CoBlocksSiteContent = ( props ) => {
 
 	const { postTypes } = props;
 
+	if ( ! window.location.pathname.includes( 'post-new.php' ) ) {
+		return;
+	}
+
 	return (
 		<span data-test="site-content__container">
 			<PluginSidebar

--- a/src/extensions/site-content/index.js
+++ b/src/extensions/site-content/index.js
@@ -45,11 +45,6 @@ export const CoBlocksSiteContent = ( props ) => {
 
 	const { postTypes } = props;
 
-	// Prevent Site Content from loading outside of post-new.php pages.
-	if ( ! window.location.pathname.includes( 'post-new.php' ) ) {
-		return;
-	}
-
 	return (
 		<span data-test="site-content__container">
 			<PluginSidebar
@@ -79,10 +74,12 @@ registerPlugin( PLUGIN_NAME, {
 	icon,
 	render: compose( [
 		ifCondition( () => {
+			// Prevent Site Content from loading outside of post-new.php pages.
+			const isPostEditor = window.location.pathname.includes( 'post-new.php' )
 			const [ siteContentEnabled ] = useEntityProp( 'root', 'site', SITE_CONTENT_FEATURE_ENABLED_KEY );
 			// In the context of `widgets.php` site content is incompatible due to missing dependencies.
 			const isCompatible = !! selectWithoutHooks( 'core/editor' );
-			return siteContentEnabled && isCompatible;
+			return isPostEditor && siteContentEnabled && isCompatible;
 		} ),
 		withSelect( ( select ) => {
 			const {

--- a/src/extensions/site-content/index.js
+++ b/src/extensions/site-content/index.js
@@ -75,7 +75,7 @@ registerPlugin( PLUGIN_NAME, {
 	render: compose( [
 		ifCondition( () => {
 			// Prevent Site Content from loading outside of post-new.php pages.
-			const isPostEditor = window.location.pathname.includes( 'post-new.php' )
+			const isPostEditor = window.location.pathname.includes( 'post-new.php' );
 			const [ siteContentEnabled ] = useEntityProp( 'root', 'site', SITE_CONTENT_FEATURE_ENABLED_KEY );
 			// In the context of `widgets.php` site content is incompatible due to missing dependencies.
 			const isCompatible = !! selectWithoutHooks( 'core/editor' );

--- a/src/extensions/site-content/index.js
+++ b/src/extensions/site-content/index.js
@@ -45,6 +45,7 @@ export const CoBlocksSiteContent = ( props ) => {
 
 	const { postTypes } = props;
 
+	// Prevent Site Content from loading outside of post-new.php pages.
 	if ( ! window.location.pathname.includes( 'post-new.php' ) ) {
 		return;
 	}


### PR DESCRIPTION
### Description
Prevent the `coblocks-site-content` plugin from loading outside of `post-new.php` pages.


### Screenshots

#### Bug
<img width="1266" alt="image" src="https://github.com/godaddy-wordpress/coblocks/assets/5321364/a5c1bc5a-1031-4ed5-9bcb-677a5086912f">

#### With Fix
<img width="1243" alt="image" src="https://github.com/godaddy-wordpress/coblocks/assets/5321364/4beed8d7-9d2c-43f9-8d9b-94f6d92c6433">

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
