### PR TITLE
Update workflows and readme with 6.7 changes

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         wp: # Test against Prev-Prev Major, Prev-Major, and current Major release versions.
-          - "6.4"
           - "6.5"
           - "6.6"
+          - "6.7"
         theme:
           - "https://downloads.wordpress.org/theme/go.zip"
           - "" # Default theme is TwentyTwentyThree

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: ['7.4','8.3']
-        wp: ['6.6']
+        wp: ['6.7']
     name: PHP Unit ${{ matrix.php }} | WP Version ${{ matrix.wp }}
     uses: ./.github/workflows/test-php-unit.yml
     with:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "CoBlocks",
 	"description": "CoBlocks is a suite of professional page building blocks for the WordPress Gutenberg block editor.",
 	"version": "3.1.13",
-	"tested_up_to": "6.6",
+	"tested_up_to": "6.7",
 	"requires_at_least": "6.3",
 	"author": "GoDaddy",
 	"license": "GPL-2.0",


### PR DESCRIPTION
### Description
Update the readme and workflows to test against WordPress 6.7.

**Note:** This should not be merged until on or after November 12th, 2024.

### Types of changes
non-breaking change
