### PR TITLE
Fix lightbox showing 'Placeholder' instead of image ALT text

### DIFF
--- a/src/js/coblocks-lightbox.js
+++ b/src/js/coblocks-lightbox.js
@@ -154,6 +154,8 @@
 								img.attributes.src.value;
 						}
 
+						imagePreloader[ `img-${ imgIndex }` ][ 'data-alt' ] = img.attributes.alt?.value || '';
+
 						imagePreloader[ `img-${ imgIndex }` ][ 'data-caption' ] =
 								( images[ imgIndex ] && images[ imgIndex ].nextElementSibling )
 									? getImageCaption( images[ imgIndex ] ) : '';
@@ -177,6 +179,7 @@
 			openLightbox();
 			wrapperBackground.style.backgroundImage = `url(${ imagePreloader[ `img-${ index }` ].src })`;
 			image.src = imagePreloader[ `img-${ index }` ].src;
+			image.alt = imagePreloader[ `img-${ index }` ][ 'data-alt' ];
 			caption.innerHTML = imagePreloader[ `img-${ index }` ][ 'data-caption' ];
 			counter.textContent = `${ ( index + 1 ) } / ${ images.length }`;
 		}


### PR DESCRIPTION
### Description
Fixed an issue where the lightbox was displaying “Placeholder” as the ALT text instead of the actual image ALT text.
Issue: https://github.com/godaddy-wordpress/coblocks/issues/2628


### Screenshots

Before
<img width="1512" alt="Screenshot 2025-02-18 at 1 17 40 AM" src="https://github.com/user-attachments/assets/ff45d7f2-c6ec-47bb-a49c-4918ed010f52" />

After
<img width="1512" alt="Screenshot 2025-02-18 at 1 18 07 AM" src="https://github.com/user-attachments/assets/a5503a6f-0fce-4098-b024-af5dfcdc7975" />

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

- Inserted the images having alt text into a Gallery block and enabled Lightbox.
- Opened images in the Lightbox and confirmed that the correct ALT text appeared.
- Tested with different browsers and themes to ensure consistency.

### Acceptance criteria
"Placeholder" should never appear as ALT text.


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
