### PR TITLE
Refactor/update deprecated function

### DIFF
--- a/src/blocks/post-carousel/post-item.js
+++ b/src/blocks/post-carousel/post-item.js
@@ -15,9 +15,7 @@ import { PlainText } from '@wordpress/block-editor';
 import { RawHTML } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { withSelect } from '@wordpress/data';
-// Disable reason: We choose to use unsafe APIs in our codebase.
-// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { __experimentalGetSettings, dateI18n, format } from '@wordpress/date';
+import { dateI18n, format, getSettings } from '@wordpress/date';
 
 const PostItem = ( {
 	post,
@@ -45,7 +43,7 @@ const PostItem = ( {
 	excerptElement.innerHTML = excerpt;
 	excerpt = excerptElement.textContent || excerptElement.innerText || '';
 
-	const dateFormat = __experimentalGetSettings().formats.date; // eslint-disable-line no-restricted-syntax
+	const dateFormat = getSettings().formats.date;
 
 	return (
 		<div className="wp-block-coblocks-post-carousel__item">

--- a/src/blocks/posts/edit.js
+++ b/src/blocks/posts/edit.js
@@ -15,9 +15,7 @@ import { compose, usePrevious } from '@wordpress/compose';
 import { lazy, RawHTML, useState, useEffect, useRef } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { addQueryArgs } from '@wordpress/url';
-// Disable reason: We choose to use unsafe APIs in our codebase.
-// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { dateI18n, format, __experimentalGetSettings } from '@wordpress/date';
+import { dateI18n, format, getSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 import { BlockControls, RichText } from '@wordpress/block-editor';
 import {
@@ -224,7 +222,7 @@ const PostsEdit = ( props ) => {
 		onClick: () => setAttributes( { listPosition: 'right' } ),
 	} ];
 
-	const dateFormat = __experimentalGetSettings().formats.date; // eslint-disable-line no-restricted-syntax
+	const dateFormat = getSettings().formats.date;
 
 	const updateStyle = ( style ) => {
 		const newActiveStyle = getActiveStyle( styleOptions, className );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->

From WP 6.1 __experimentalGetSettings settings is deprecated, therefore update it with getSettings because Coblocks min WP is 6.3, which is safe to replace experimental function.

https://github.com/WordPress/gutenberg/blob/v20.2.0/packages/date/src/index.js#L211-L227


### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix: Replaced deprecated function with standard one.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Yarn start and tested the plugin's blocks.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->


### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
