### PR TITLE
Bump tested up to 6.8

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -7,7 +7,7 @@
  * Version: 3.1.15
  * Text Domain: coblocks
  * Domain Path: /languages
- * Tested up to: 6.7
+ * Tested up to: 6.8
  * Requires at least: 6.3
  *
  * CoBlocks is free software: you can redistribute it and/or modify

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "CoBlocks",
 	"description": "CoBlocks is a suite of professional page building blocks for the WordPress Gutenberg block editor.",
 	"version": "3.1.15",
-	"tested_up_to": "6.7",
+	"tested_up_to": "6.8",
 	"requires_at_least": "6.3",
 	"author": "GoDaddy",
 	"license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Author URI: https://www.godaddy.com
 Contributors: godaddy, richtabor, eherman24, jonathanbardo, jrtashjian, paranoia1906, fjarrett, olivierlafleur, jasonlemay, snovosel
 Tags: page builder, Gutenberg blocks, WordPress blocks, gutenberg, blocks
 Requires at least: 6.3
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 3.1.15
 License: GPL-2.0


### PR DESCRIPTION
### Description
Tested CoBlocks with WordPress 6.8 release, found no issues. Bump the tested up to value to 6.8.
