### PR TITLE
Update E2E and PHP tests to test against WP 6.8

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         wp: # Test against Prev-Prev Major, Prev-Major, and current Major release versions.
-          - "6.5"
           - "6.6"
           - "6.7"
+          - "6.8"
         theme:
           - "https://downloads.wordpress.org/theme/go.zip"
           - "" # Default theme is TwentyTwentyThree

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: ['7.4','8.3']
-        wp: ['6.7']
+        wp: ['6.8']
     name: PHP Unit ${{ matrix.php }} | WP Version ${{ matrix.wp }}
     uses: ./.github/workflows/test-php-unit.yml
     with:


### PR DESCRIPTION
### Description
- [x] Update E2E tests to test against WordPress 6.8.
- [x] Update PHP tests to test against WordPress 6.8. 