### PR TITLE
Fix: Ensure Carousel thumbnails are now responsive.

### DIFF
--- a/src/components/block-gallery/gallery-thumbnail.js
+++ b/src/components/block-gallery/gallery-thumbnail.js
@@ -7,7 +7,7 @@ const GalleryCarouselThumbnail = ( { changeStep, item, index } ) => {
 			'is-active': false,
 			'wp-block-coblocks-gallery-carousel-thumbnail': true,
 		} ) } onClick={ () => changeStep( index ) } style={ { height: '80px', width: '100px' } } >
-			<img alt={ item.alt } data-id={ item.id } data-link={ item.link } src={ item.url } style={ { height: '100%', width: '100%' } } />
+			<img className={ `wp-image-${ item.id || 'id' }` } alt={ item.alt } data-id={ item.id } data-link={ item.link } src={ item.url } style={ { height: '100%', width: '100%' } } />
 		</button>
 	);
 };


### PR DESCRIPTION
### Description

This PR addresses the following ticket: #2605. It adds the missing class to enable Carousel thumbnails become responsive.

### Screenshots

<img width="696" alt="Screenshot 2025-06-05 at 21 49 18" src="https://github.com/user-attachments/assets/85e2e0e9-26c3-4e03-bd59-68ba24e9be9d" />

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

- Insert Gallery Carousel block.
- Observe that images are now responsive.
- Tested with different browsers and themes to ensure consistency.

### Acceptance criteria

Images should now have class with value `wp-image-{id}`

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards
- [ ] My code has proper inline documentation
- [ ] I've included any necessary tests
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->