### PR TITLE
Refactors for layout selector and WP 6.8 compatibility

### DIFF
--- a/src/extensions/layout-selector/index.php
+++ b/src/extensions/layout-selector/index.php
@@ -62,8 +62,8 @@ function coblocks_layout_selector_layouts() {
  * Localize layout and category definitions for the Layout Selector component.
  */
 function coblocks_localize_layout_selector() {
-	$current_screen   = get_current_screen();
-	$screen_post_type = $current_screen->post_type;
+	$current_screen   = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	$screen_post_type = ( $current_screen && isset( $current_screen->post_type ) ) ? $current_screen->post_type : null;
 
 	$allowed_post_types = array(
 		'page',
@@ -73,7 +73,7 @@ function coblocks_localize_layout_selector() {
 		'coblocks-editor',
 		'coblocksLayoutSelector',
 		array(
-			'postTypeEnabled' => in_array( $screen_post_type, $allowed_post_types, true ),
+			'postTypeEnabled' => $screen_post_type ? in_array( $screen_post_type, $allowed_post_types, true ) : false,
 			'layouts'         => coblocks_layout_selector_layouts(),
 			'categories'      => coblocks_layout_selector_categories(),
 		)

--- a/src/extensions/layout-selector/store.js
+++ b/src/extensions/layout-selector/store.js
@@ -9,7 +9,8 @@ import { kebabCase } from 'lodash';
  */
 import { controls } from '@wordpress/data-controls';
 import memoize from 'memize';
-import { createReduxStore, select } from '@wordpress/data';
+import { createReduxStore, select as dataSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 const DEFAULT_STATE = {
 	categories: coblocksLayoutSelector.categories || [],
@@ -110,8 +111,14 @@ const store = createReduxStore( 'coblocks/template-selector', {
 
 	resolvers: {
 		* isTemplateSelectorActive() {
-			const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
-			const isEditedPostEmpty = select( 'core/editor' ).isEditedPostEmpty();
+			// Ensure the editor store is available in environments where it isn't auto-enqueued.
+			const editorSelect = dataSelect( editorStore );
+			const isCleanNewPost = editorSelect && typeof editorSelect.isCleanNewPost === 'function'
+				? editorSelect.isCleanNewPost()
+				: false;
+			const isEditedPostEmpty = editorSelect && typeof editorSelect.isEditedPostEmpty === 'function'
+				? editorSelect.isEditedPostEmpty()
+				: false;
 			const shouldShowTemplateSelector = isCleanNewPost || isEditedPostEmpty;
 
 			return shouldShowTemplateSelector && actions.openTemplateSelector();


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
<!-- Search for original issue and link below -->
Changes here refactor the layout selector to properly use hooks and prevent the plugin from attempting to render until all conditions are met. 


### Screenshots
<!-- if applicable -->
**Before:**
<img width="1116" height="355" alt="Screenshot 2025-08-12 at 1 21 19 PM" src="https://github.com/user-attachments/assets/e7c794ac-df50-4a4a-a85d-d04108ef367e" />

**After:**
<img width="1126" height="785" alt="Screenshot 2025-08-12 at 1 22 27 PM" src="https://github.com/user-attachments/assets/4ae290b8-12c6-40c4-a1ad-a261a53fde28" />


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Only code changes exist.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested manually in WordPress 6.8 and 6.7. Layout selector renders in all cases.

### Acceptance criteria
<!-- Does this PR have a clearly defined acceptance criteria? -->
<!-- If there is a clear criteria it should be included within this PR. -->
<!-- If no criteria explain reason for PR -->
Should allow the Layout Selector to render in WP 6.8.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
