### PR TITLE
fix spec duplication and failure video path

### DIFF
--- a/.github/workflows/test-e2e-cypress.yml
+++ b/.github/workflows/test-e2e-cypress.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           changed_files=$(git diff --name-only --diff-filter=ADMR ${{ github.event.before }} origin/master)
           spec_list=()
+          declare -A spec_seen
 
           for line in $changed_files; do
             if [[ "$line" =~ src/(blocks|extensions|components|block-styles).* ]]; then # If changed file is within our tested paths.
@@ -59,7 +60,10 @@ jobs:
                   spec=$(echo $spec | sed 's:.*/::')
 
                   # Build spec list for cypress run.
-                  spec_list+="'${spec}',"
+                  if [[ -z "${spec_seen[$spec]}" ]]; then
+                    spec_list+="'${spec}',"
+                    spec_seen[$spec]=1
+                  fi
 
                 fi
               done
@@ -177,10 +181,9 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.spec }}-fail.mp4
+          name: ${{ matrix.spec }}-wp${{ env.WP_CORE_VERSION }}-php${{ inputs.phpVersion }}-fail.mp4
           path: ./.dev/tests/cypress/videos/${{ matrix.spec }}.mp4
           retention-days: 1
-
 
   test_cypress_e2e_full:
     if: github.event_name == 'push'
@@ -326,7 +329,8 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.spec }}-fail.mp4
+          name: ${{ matrix.spec }}-wp${{ env.WP_CORE_VERSION }}-php${{ inputs.phpVersion }}-fail.mp4
           path: ./.dev/tests/cypress/videos/${{ matrix.spec }}.mp4
           retention-days: 1
+          
 


### PR DESCRIPTION
### Description
I deduplicated the Cypress spec matrix to avoid redundant runs and updated failure artifact names to include the WordPress and PHP versions. This makes artifacts unique per environment and preserves multiple failures when they happen across versions.

### Screenshots
Before:
<img width="297" height="133" alt="Screenshot 2025-08-12 at 2 12 16 PM" src="https://github.com/user-attachments/assets/0a5c6b31-6a63-4036-8cb9-02b383b2e02d" />

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
I ran the workflow on a PR with changed files, confirmed the printed matrix lists each spec once, and verified failure artifacts are saved with `wp<version>` and `php<version>` in their names.

### Acceptance criteria
- Unique spec list without duplicates for changed-file runs
- Failure artifacts named `<spec>-wp<WP>-php<PHP>-fail.mp4`
- Multiple failures across matrix combos produce separate artifacts
- No change to behavior when tests pass

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [x] I've included any necessary tests
- [x] I've included developer documentation
- [x] I've added proper labels to this pull request


