### PR TITLE
Update matrix wp68

### DIFF
--- a/.github/workflows/test-e2e-cypress.yml
+++ b/.github/workflows/test-e2e-cypress.yml
@@ -17,7 +17,7 @@ on:
       phpVersion:
         required: false
         type: string
-        default: "8.3"
+        default: "8.4"
       installPath:
           required: false
           type: string

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,15 +22,15 @@ jobs:
       fail-fast: false
       matrix:
         wp: # Test against Prev-Prev Major, Prev-Major, and current Major release versions.
-          - "6.5"
           - "6.6"
           - "6.7"
+          - "6.8"
         theme:
           - "https://downloads.wordpress.org/theme/go.zip"
           - "" # Default theme is TwentyTwentyThree
         php: # Test against minimum and latest PHP versions.
           - "7.4"
-          - "8.3"
+          - "8.4"
     with:
       wpVersion: "WordPress/WordPress#${{matrix.wp}}"
       theme: ${{matrix.theme}}

--- a/.github/workflows/test-php-unit.yml
+++ b/.github/workflows/test-php-unit.yml
@@ -6,7 +6,7 @@ on:
       phpVersion:
         required: false
         type: string
-        default: '8.3'
+        default: '8.4'
       wpVersion:
         required: false
         type: string

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -11,8 +11,8 @@ jobs:
   php_unit_versions_matrix:
     strategy:
       matrix:
-        php: ['7.4','8.3']
-        wp: ['6.7']
+        php: ['7.4','8.4']
+        wp: ['6.8']
     name: PHP Unit ${{ matrix.php }} | WP Version ${{ matrix.wp }}
     uses: ./.github/workflows/test-php-unit.yml
     with:

--- a/.github/workflows/test-wp-next.yml
+++ b/.github/workflows/test-wp-next.yml
@@ -47,7 +47,7 @@ jobs:
     name: PHP ${{ matrix.php }} WP Next Version
     strategy:
       matrix:
-        php: ['7.4','8.3']
+        php: ['7.4','8.4']
     uses: ./.github/workflows/test-php-unit.yml
     with:
       phpVersion: ${{ matrix.php }}


### PR DESCRIPTION
### Description
- Update CI test matrices to reflect current supported versions
- Drop WordPress 6.5; add WordPress 6.8
- Add PHP 8.4 (and set as default where applicable)
<!-- No existing issue — maintenance/CI update -->

### Screenshots
N/A

### Types of changes
- CI/configuration (non-breaking)

### How has this been tested?
- Verified matrices and defaults in updated workflow files
- Ensured E2E matrix now targets WP 6.6, 6.7, 6.8 and PHP 7.4, 8.4
- Ensured PHP Unit matrix now targets WP 6.8 and PHP 7.4, 8.4
- Ensured default phpVersion in reusable workflows is 8.4
- Rely on GitHub Actions runs to validate across the new matrix

### Acceptance criteria
- E2E workflow runs against WP 6.6, 6.7, 6.8 and PHP 7.4, 8.4 without CI errors
- PHP Unit workflow runs against WP 6.8 and PHP 7.4, 8.4 without CI errors
- No references to WP 6.5 remain
- Default PHP is 8.4 in reusable workflows

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [x] I've included any necessary tests
- [x] I've included developer documentation
- [x] I've added proper labels to this pull request