### PR TITLE
advanced-controls: removed "handleMargins" functionality

### DIFF
--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -91,52 +91,6 @@ const useAdvancedControls = ( props ) => {
 	const hasStackedControl = hasBlockSupport( name, 'stackedOnMobile' );
 	const withBlockSpacing = hasBlockSupport( name, 'coBlocksSpacing' );
 
-	const handleMargins = ( target ) => {
-		if ( ! target.querySelector ) {
-			return;
-		}
-
-		const innerAlignmentBlock = target.querySelector( '.wp-block[data-align]' );
-		const setInnerAlignmentBlock = ( margin, val ) => {
-			if ( !! innerAlignmentBlock ) {
-				innerAlignmentBlock.style[ margin ] = val;
-			}
-		};
-		switch ( target.outerHTML.includes( 'data-coblocks-bottom-spacing' ) ) {
-			case true:
-				target.style.marginBottom = 0;
-				setInnerAlignmentBlock( 'marginBottom', 0 );
-				break;
-			case false:
-				target.style.marginBottom = null;
-				setInnerAlignmentBlock( 'marginBottom', null );
-				break;
-		}
-		switch ( target.outerHTML.includes( 'data-coblocks-top-spacing' ) ) {
-			case true:
-				target.style.marginTop = 0;
-				setInnerAlignmentBlock( 'marginTop', 0 );
-				break;
-			case false:
-				target.style.marginTop = null;
-				setInnerAlignmentBlock( 'marginTop', null );
-
-				break;
-		}
-	};
-
-	useEffect( ( ) => {
-		// Check if alignment wrapper has been applied - Gutenberg 8.2.1
-		if ( !! document.getElementsByClassName( 'block-editor-block-list__layout is-root-container' ).length ) {
-			const targetElems = document.querySelectorAll( '.block-editor-block-list__layout' );
-			targetElems.forEach( ( elem ) => {
-				elem.childNodes.forEach( ( child ) => {
-					handleMargins( child );
-				} );
-			} );
-		}
-	}, [ noBottomMargin, noTopMargin ] );
-
 	const hasAdvancedControl = !! hasStackedControl || !! withBlockSpacing;
 
 	return isSelected && hasAdvancedControl ? (


### PR DESCRIPTION
### Description
In this update, I addressed a significant performance issue in the block editor, particularly noticeable when interacting with a large number of blocks. The "handleMargins" functionality within the "advanced-controls" component was identified as a primary contributor to these performance bottlenecks. Upon thorough investigation, I concluded that this piece of code was not essential, and its removal did not impact the editor's functionality. This change is aimed at enhancing the user experience by reducing lags and improving the overall responsiveness of the editor.

### Types of changes
This change is primarily a Bug fix. By removing an unnecessary piece of code that was causing performance issues, I have enhanced the efficiency of the block editor without (hopefully) affecting its existing capabilities.

### How has this been tested?
- The changes were tested in a local development environment with various scenarios to ensure that removing the "handleMargins" functionality did not affect the editor's behavior.
- Performance metrics were compared before and after the change, highlighting a noticeable improvement in the editor's responsiveness, especially with a high number of blocks.

### Acceptance criteria
- The editor should maintain all current functionalities without "handleMargins" code.
- Performance improvements should be observed, specifically in scenarios with a large number of blocks present in the editor.
- No adverse effects on the layout and visual appearance due to the removal of "handleMargins".

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
