### PR TITLE
Fix: Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/includes/Dependencies/GoDaddy/Styles/StylesLoader.php
+++ b/includes/Dependencies/GoDaddy/Styles/StylesLoader.php
@@ -62,10 +62,10 @@ class StylesLoader {
     /**
      * Set the instance.
      *
-     * @param  StylesLoader|null  $instance
+     * @param  StylesLoader  $instance
      * @return StylesLoader|static
      */
-    public static function setInstance( StylesLoader $instance = null ) {
+    public static function setInstance( StylesLoader $instance ) {
         return static::$instance = $instance;
     }
 

--- a/includes/block-migrate/class-coblocks-block-migration.php
+++ b/includes/block-migrate/class-coblocks-block-migration.php
@@ -195,11 +195,11 @@ abstract class CoBlocks_Block_Migration {
 	 * Evaluates the given XPath expression and returns the full DOMNodeList.
 	 *
 	 * @param string  $expression The XPath expression to execute.
-	 * @param DOMNode $context_node The optional context_node can be specified for doing relative XPath queries.
+	 * @param DOMNode|null $context_node The optional context_node can be specified for doing relative XPath queries.
 	 *
 	 * @return DOMNodeList|false all nodes matching the given XPath expression.
 	 */
-	protected function query_selector_all( $expression, DOMNode $context_node = null ) {
+	protected function query_selector_all( $expression, ?DOMNode $context_node = null ) {
 		return empty( $this->xpath ) ? new DOMNodeList() : $this->xpath->query( $expression, $context_node );
 	}
 
@@ -207,11 +207,11 @@ abstract class CoBlocks_Block_Migration {
 	 * Evaluates the given XPath expression and returns the node at the first position in the DOMNodeList.
 	 *
 	 * @param string  $expression The XPath expression to execute.
-	 * @param DOMNode $context_node The optional context_node can be specified for doing relative XPath queries.
+	 * @param DOMNode|null $context_node The optional context_node can be specified for doing relative XPath queries.
 	 *
 	 * @return DOMNode|null The node at the first position in the DOMNodeList, or null if that is not a valid index.
 	 */
-	protected function query_selector( $expression, DOMNode $context_node = null ) {
+	protected function query_selector( $expression, ?DOMNode $context_node = null ) {
 		return $this->query_selector_all( $expression, $context_node )->item( 0 );
 	}
 

--- a/includes/class-coblocks-site-design.php
+++ b/includes/class-coblocks-site-design.php
@@ -77,7 +77,7 @@ class CoBlocks_Site_Design {
 
 		// short-circuit.
 		if ( $this->short_circuit_check() ) {
-			return array();
+			return;
 		}
 
 		add_action( 'wp_ajax_site_design_update_design_style', array( $this, 'design_endpoint_ajax' ) );


### PR DESCRIPTION
### Description
Fixes #2652 

### Types of changes
Adds explicit nullable types.

### How has this been tested?

### Acceptance criteria


### Checklist:
- [ ] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
